### PR TITLE
Augment get-reefs endpoint to include latest daily data

### DIFF
--- a/packages/api/src/reefs/daily-data.entity.ts
+++ b/packages/api/src/reefs/daily-data.entity.ts
@@ -3,10 +3,10 @@ import {
   PrimaryGeneratedColumn,
   Column,
   ManyToOne,
-  JoinColumn,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
+// eslint-disable-next-line import/no-cycle
 import { Reef } from './reefs.entity';
 
 @Entity()
@@ -63,7 +63,6 @@ export class DailyData {
   windDirection: number;
 
   @ManyToOne(() => Reef, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'reef_id' })
   reef: Reef;
 
   @CreateDateColumn()

--- a/packages/api/src/reefs/reefs.entity.ts
+++ b/packages/api/src/reefs/reefs.entity.ts
@@ -7,7 +7,7 @@ import {
   ManyToOne,
   CreateDateColumn,
   UpdateDateColumn,
-  OneToMany,
+  OneToOne,
 } from 'typeorm';
 import { Region } from '../regions/regions.entity';
 import { User } from '../users/users.entity';
@@ -58,6 +58,6 @@ export class Reef {
   @ManyToOne(() => VideoStream, { onDelete: 'CASCADE', nullable: true })
   stream?: VideoStream;
 
-  @OneToMany(() => DailyData, (dailyData) => dailyData.reef)
-  dailyData?: DailyData[];
+  @OneToOne(() => DailyData, (latestDailyData) => latestDailyData.reef)
+  latestDailyData?: DailyData;
 }

--- a/packages/api/src/reefs/reefs.entity.ts
+++ b/packages/api/src/reefs/reefs.entity.ts
@@ -7,9 +7,12 @@ import {
   ManyToOne,
   CreateDateColumn,
   UpdateDateColumn,
+  OneToMany,
 } from 'typeorm';
 import { Region } from '../regions/regions.entity';
 import { User } from '../users/users.entity';
+// eslint-disable-next-line import/no-cycle
+import { DailyData } from './daily-data.entity';
 import { VideoStream } from './video-streams.entity';
 
 @Entity()
@@ -54,4 +57,7 @@ export class Reef {
 
   @ManyToOne(() => VideoStream, { onDelete: 'CASCADE', nullable: true })
   stream?: VideoStream;
+
+  @OneToMany(() => DailyData, (dailyData) => dailyData.reef)
+  dailyData?: DailyData[];
 }

--- a/packages/api/src/reefs/reefs.service.ts
+++ b/packages/api/src/reefs/reefs.service.ts
@@ -21,6 +21,14 @@ export class ReefsService {
     private dailyDataRepository: Repository<DailyData>,
   ) {}
 
+  latestDailyDataSubquery(): string {
+    const query = this.dailyDataRepository.createQueryBuilder('dailyData');
+    query.select('MAX(date)', 'date');
+    query.addSelect('reef_id');
+    query.groupBy('reef_id');
+    return query.getQuery();
+  }
+
   async create(createReefDto: CreateReefDto): Promise<Reef> {
     return this.reefsRepository.save(createReefDto);
   }
@@ -48,6 +56,11 @@ export class ReefsService {
     query.leftJoinAndSelect('reef.region', 'region');
     query.leftJoinAndSelect('reef.admin', 'admin');
     query.leftJoinAndSelect('reef.stream', 'stream');
+    query.leftJoinAndSelect(
+      'reef.dailyData',
+      'dailyData',
+      `(dailyData.date, dailyData.reef_id) IN (${this.latestDailyDataSubquery()})`,
+    );
     return query.getMany();
   }
 

--- a/packages/api/src/reefs/reefs.service.ts
+++ b/packages/api/src/reefs/reefs.service.ts
@@ -57,9 +57,9 @@ export class ReefsService {
     query.leftJoinAndSelect('reef.admin', 'admin');
     query.leftJoinAndSelect('reef.stream', 'stream');
     query.leftJoinAndSelect(
-      'reef.dailyData',
-      'dailyData',
-      `(dailyData.date, dailyData.reef_id) IN (${this.latestDailyDataSubquery()})`,
+      'reef.latestDailyData',
+      'latestDailyData',
+      `(latestDailyData.date, latestDailyData.reef_id) IN (${this.latestDailyDataSubquery()})`,
     );
     return query.getMany();
   }


### PR DESCRIPTION
This PR augments the `[GET] /reefs` endpoint to include the latest available daily data.