### PR TITLE
Seed Reef Point Of Interest

### DIFF
--- a/packages/api/src/seeds/create-reefs.seeds.ts
+++ b/packages/api/src/seeds/create-reefs.seeds.ts
@@ -1,6 +1,7 @@
 import { Factory, Seeder } from 'typeorm-seeding';
 import { Reef } from '../reefs/reefs.entity';
 import { DailyData } from '../reefs/daily-data.entity';
+import { ReefPointOfInterest } from '../reef-pois/reef-pois.entity';
 
 export class CreateReef implements Seeder {
   public async run(factory: Factory) {
@@ -20,6 +21,17 @@ export class CreateReef implements Seeder {
             dailyData.date = date;
             dailyData.reef = reef;
             return dailyData;
+          })
+          .create();
+      }),
+    );
+
+    await Promise.all(
+      [...Array(4).keys()].map(() => {
+        return factory(ReefPointOfInterest)()
+          .map(async (poi) => {
+            poi.reef = reef;
+            return poi;
           })
           .create();
       }),

--- a/packages/api/src/seeds/reefs-point-of-interest.factory.ts
+++ b/packages/api/src/seeds/reefs-point-of-interest.factory.ts
@@ -1,0 +1,11 @@
+import Faker from 'faker';
+import { define } from 'typeorm-seeding';
+import { ReefPointOfInterest } from '../reef-pois/reef-pois.entity';
+
+define(ReefPointOfInterest, (faker: typeof Faker) => {
+  const reefPointOfInterest = new ReefPointOfInterest();
+
+  reefPointOfInterest.name = `Mock Reef Point Of Interest ${faker.name.lastName()}`;
+
+  return reefPointOfInterest;
+});


### PR DESCRIPTION
Add Reef Point Of Interest factory.
- 4 ReefPointOfInterest entities are created and related to the previously created reef
- Name of reef is in format 'Mock Reef Point Of Interest {FameName}'
- No custom image is added