### PR TITLE
Added mobile responsive design to SelectedReefCard

### DIFF
--- a/packages/website/src/common/NavBar/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/NavBar/__snapshots__/index.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`NavBar should render with given state from Redux store 1`] = `
           </h4>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -13,6 +13,7 @@ import {
   WithStyles,
   createStyles,
   Theme,
+  Hidden,
 } from "@material-ui/core";
 import MenuIcon from "@material-ui/icons/Menu";
 import NotificationsIcon from "@material-ui/icons/Notifications";
@@ -66,7 +67,11 @@ const NavBar = ({ searchLocation, classes }: NavBarProps) => {
               item
               xs={6}
             >
-              {searchLocation && <Search />}
+              {searchLocation && (
+                <Hidden xsDown>
+                  <Search />
+                </Hidden>
+              )}
               {user ? (
                 <Grid container justify="flex-end" item xs={6}>
                   <IconButton>

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -63,7 +63,7 @@ const NavBar = ({ searchLocation, classes }: NavBarProps) => {
             <Grid
               container
               alignItems="flex-start"
-              justify="flex-start"
+              justify="flex-end"
               item
               xs={6}
             >

--- a/packages/website/src/routes/Homepage/Map/Popup/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/Map/Popup/__snapshots__/index.test.tsx.snap
@@ -58,18 +58,26 @@ exports[`renders as expected 1`] = `
             <span
               class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
             >
-              D. H. WEEKS
+              HEAT STRESS
             </span>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
           >
             <h5
               class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
               style="color: rgb(8, 91, 163);"
             >
               1.4
+               
             </h5>
+            <h6
+              class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
+              style="color: rgb(8, 91, 163); position: relative; bottom: 0px;"
+              title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
+            >
+              DHW
+            </h6>
           </div>
         </div>
       </div>

--- a/packages/website/src/routes/Homepage/Map/Popup/index.tsx
+++ b/packages/website/src/routes/Homepage/Map/Popup/index.tsx
@@ -10,6 +10,7 @@ import {
   Grid,
   Typography,
   Button,
+  Tooltip,
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 
@@ -52,10 +53,16 @@ const Popup = ({ reef, classes }: PopupProps) => {
           <Grid item xs={6}>
             <Grid container justify="flex-end" item xs={12}>
               <Typography variant="caption" color="textSecondary">
-                D. H. WEEKS
+                HEAT STRESS
               </Typography>
             </Grid>
-            <Grid container justify="flex-end" item xs={12}>
+            <Grid
+              container
+              alignItems="flex-end"
+              justify="flex-end"
+              item
+              xs={12}
+            >
               <Typography
                 style={{
                   color: `${colorFinder(
@@ -69,7 +76,23 @@ const Popup = ({ reef, classes }: PopupProps) => {
                   degreeHeatingWeeksCalculator(degreeHeatingDays),
                   1
                 )}
+                &nbsp;
               </Typography>
+              <Tooltip title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures">
+                <Typography
+                  style={{
+                    color: `${colorFinder(
+                      degreeHeatingWeeksCalculator(degreeHeatingDays)
+                    )}`,
+                    position: "relative",
+                    bottom: 0,
+                  }}
+                  variant="h6"
+                  color="textSecondary"
+                >
+                  DHW
+                </Typography>
+              </Tooltip>
             </Grid>
           </Grid>
         </Grid>

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`renders as expected 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+          style="max-height: 14rem;"
         >
           <div
             class="MuiBox-root MuiBox-root-7"

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -5,124 +5,155 @@ exports[`renders as expected 1`] = `
   <div
     class="SelectedReefCard-root-1"
   >
-    <h5
-      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-      style="margin: 0px 0px 0.5rem 1.5rem;"
-    >
-      Featured Reef
-    </h5>
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
     >
       <div
-        class="MuiPaper-root SelectedReefCard-selectedReef-2 MuiPaper-elevation3 MuiPaper-rounded"
+        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+      >
+        <h5
+          class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+        >
+          Featured Reef
+        </h5>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
       >
         <div
-          class="MuiGrid-root SelectedReefCard-card-4 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+          class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
         >
           <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-4"
+            class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
           >
             <div
-              class="MuiCardMedia-root SelectedReefCard-cardImage-5"
-              style="background-image: url(reef-image.jpg);"
-            />
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-6"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-item MuiGrid-grid-xs-12"
             >
-              <h5
-                class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-                style="padding: 0.5rem 0px 0px 0.5rem;"
-              />
-              <h6
-                class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
-                style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
-              />
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-            >
-              <h6
-                class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
-                style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
+              <div
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+                style="position: relative;"
               >
-                MEAN DAILY SURFACE TEMPERATURE (C°)
-              </h6>
-              Mock-Line
-            </div>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-2"
-            style="padding-left: 2rem;"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                <div
+                  class="MuiCardMedia-root SelectedReefCard-cardImage-3"
+                  style="background-image: url(reef-image.jpg);"
+                />
+                <mock-hidden
+                  smup="true"
+                >
+                  <div
+                    class="MuiGrid-root SelectedReefCard-mobileTitle-5 MuiGrid-item MuiGrid-grid-xs-12"
+                  >
+                    <h5
+                      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextPrimary"
+                      style="padding: 0.5rem 0px 0px 0.5rem;"
+                    />
+                    <h6
+                      class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary"
+                      style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
+                    />
+                  </div>
+                </mock-hidden>
+                <div
+                  class="MuiGrid-root SelectedReefCard-exploreButton-4 MuiGrid-item"
+                >
+                  <a
+                    href="/reefs/2"
+                    style="text-decoration: none;"
+                  >
+                    <button
+                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+                      tabindex="0"
+                      type="button"
+                    >
+                      <span
+                        class="MuiButton-label"
+                      >
+                        EXPLORE
+                      </span>
+                      <span
+                        class="MuiTouchRipple-root"
+                      />
+                    </button>
+                  </a>
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6"
               >
-                TEMP AT 0M
-              </span>
-              <h4
-                class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
+                <mock-hidden
+                  xsdown="true"
+                >
+                  <div
+                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+                  >
+                    <h5
+                      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+                      style="padding: 0.5rem 0px 0px 0.5rem;"
+                    />
+                    <h6
+                      class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
+                      style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
+                    />
+                  </div>
+                </mock-hidden>
+                <div
+                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+                >
+                  <h6
+                    class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
+                    style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
+                  >
+                    MEAN DAILY SURFACE TEMPERATURE (C°)
+                  </h6>
+                  Mock-Line
+                </div>
+              </div>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12 MuiGrid-grid-sm-2"
               >
-                39.0 ℃
-              </h4>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-              >
-                SURFACE TEMP
-              </span>
-              <h4
-                class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
-              >
-                29.0 ℃
-              </h4>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-            >
-              <span
-                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-              >
-                D. H. WEEKS
-              </span>
-              <h4
-                class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
-              >
-                4.9
-              </h4>
-            </div>
-            <div
-              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-            >
-              <a
-                href="/reefs/2"
-                style="text-decoration: none;"
-              >
-                <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
-                  tabindex="0"
-                  type="button"
+                <div
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
                 >
                   <span
-                    class="MuiButton-label"
+                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
                   >
-                    EXPLORE
+                    TEMP AT 0M
                   </span>
+                  <h4
+                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
+                  >
+                    39.0 ℃
+                  </h4>
+                </div>
+                <div
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
+                >
                   <span
-                    class="MuiTouchRipple-root"
-                  />
-                </button>
-              </a>
+                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                  >
+                    SURFACE TEMP
+                  </span>
+                  <h4
+                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
+                  >
+                    29.0 ℃
+                  </h4>
+                </div>
+                <div
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
+                >
+                  <span
+                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+                  >
+                    D. H. WEEKS
+                  </span>
+                  <h4
+                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
+                  >
+                    4.9
+                  </h4>
+                </div>
+              </div>
             </div>
           </div>
         </div>
@@ -135,41 +166,52 @@ exports[`renders as expected 1`] = `
 exports[`renders loading as expected 1`] = `
 <div>
   <div
-    class="SelectedReefCard-root-7"
+    class="SelectedReefCard-root-8"
   >
-    <h5
-      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-      style="margin: 0px 0px 0.5rem 1.5rem;"
-    >
-      Featured Reef
-    </h5>
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
+      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
     >
       <div
-        class="MuiPaper-root SelectedReefCard-selectedReef-8 MuiPaper-elevation3 MuiPaper-rounded"
+        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+      >
+        <h5
+          class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+        >
+          Featured Reef
+        </h5>
+      </div>
+      <div
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
       >
         <div
-          class="SelectedReefCard-loading-9"
+          class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
         >
           <div
-            class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
-            role="progressbar"
-            style="width: 6rem; height: 6rem;"
+            class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
           >
-            <svg
-              class="MuiCircularProgress-svg"
-              viewBox="22 22 44 44"
+            <div
+              class="SelectedReefCard-loading-9"
             >
-              <circle
-                class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
-                cx="44"
-                cy="44"
-                fill="none"
-                r="21.5"
-                stroke-width="1"
-              />
-            </svg>
+              <div
+                class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
+                role="progressbar"
+                style="width: 6rem; height: 6rem;"
+              >
+                <svg
+                  class="MuiCircularProgress-svg"
+                  viewBox="22 22 44 44"
+                >
+                  <circle
+                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+                    cx="44"
+                    cy="44"
+                    fill="none"
+                    r="21.5"
+                    stroke-width="1"
+                  />
+                </svg>
+              </div>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -125,12 +125,12 @@ exports[`renders as expected 1`] = `
               <span
                 class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
               >
-                D. H. WEEKS
+                HEAT STRESS
               </span>
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
               >
-                4.9
+                4.9 DHW
               </h4>
             </div>
           </div>

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -3,155 +3,134 @@
 exports[`renders as expected 1`] = `
 <div>
   <div
-    class="SelectedReefCard-root-1"
+    class="MuiBox-root MuiBox-root-2"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+      class="MuiBox-root MuiBox-root-3"
     >
-      <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+      <h5
+        class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
       >
         <mock-hidden
           xsdown="true"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-          >
-            Featured - 
-          </h5>
+          Featured - 
         </mock-hidden>
         <mock-hidden
           smup="true"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-          >
-            Featured Reef
-          </h5>
+          Featured Reef
         </mock-hidden>
-      </div>
+      </h5>
+    </div>
+    <div
+      class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+    >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
       >
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
         >
           <div
-            class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+            class="MuiBox-root MuiBox-root-4"
           >
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-item MuiGrid-grid-xs-12"
+              class="MuiCardMedia-root SelectedReefCard-cardImage-1"
+              style="background-image: url(reef-image.jpg);"
+            />
+            <mock-hidden
+              smup="true"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
-                style="height: 8rem; position: relative;"
+                class="MuiBox-root MuiBox-root-5"
               >
-                <div
-                  class="MuiCardMedia-root SelectedReefCard-cardImage-3"
-                  style="background-image: url(reef-image.jpg);"
+                <h5
+                  class="MuiTypography-root MuiTypography-h5"
                 />
-                <mock-hidden
-                  smup="true"
-                >
-                  <div
-                    class="MuiGrid-root SelectedReefCard-mobileTitle-5 MuiGrid-item MuiGrid-grid-xs-12"
-                  >
-                    <h5
-                      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextPrimary"
-                      style="padding: 0.5rem 0px 0px 0.5rem;"
-                    />
-                    <h6
-                      class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextPrimary"
-                      style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
-                    />
-                  </div>
-                </mock-hidden>
-                <div
-                  class="MuiGrid-root SelectedReefCard-exploreButton-4 MuiGrid-item"
-                >
-                  <a
-                    href="/reefs/2"
-                    style="text-decoration: none;"
-                  >
-                    <button
-                      class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
-                      tabindex="0"
-                      type="button"
-                    >
-                      <span
-                        class="MuiButton-label"
-                      >
-                        EXPLORE
-                      </span>
-                      <span
-                        class="MuiTouchRipple-root"
-                      />
-                    </button>
-                  </a>
-                </div>
+                
               </div>
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+            </mock-hidden>
+            <div
+              class="MuiBox-root MuiBox-root-6"
+            >
+              <a
+                href="/reefs/2"
+                style="text-decoration: none;"
               >
-                <div
-                  class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-                  style="height: 8rem;"
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-containedSizeSmall MuiButton-sizeSmall"
+                  tabindex="0"
+                  type="button"
                 >
-                  <h6
-                    class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
-                    style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
+                  <span
+                    class="MuiButton-label"
                   >
-                    MEAN DAILY SURFACE TEMP. (C°)
-                  </h6>
-                  Mock-Line
-                </div>
-              </div>
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+                    EXPLORE
+                  </span>
+                  <span
+                    class="MuiTouchRipple-root"
+                  />
+                </button>
+              </a>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        >
+          <div
+            class="MuiBox-root MuiBox-root-7"
+          >
+            <h6
+              class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
+            >
+              MEAN DAILY SURFACE TEMP. (C°)
+            </h6>
+          </div>
+          Mock-Line
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        >
+          <div
+            class="MuiBox-root MuiBox-root-8"
+          >
+            <div>
+              <span
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
               >
-                <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                  >
-                    TEMP AT 0M
-                  </span>
-                  <h4
-                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
-                  >
-                    39.0 ℃
-                  </h4>
-                </div>
-                <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                  >
-                    SURFACE TEMP
-                  </span>
-                  <h4
-                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
-                  >
-                    29.0 ℃
-                  </h4>
-                </div>
-                <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
-                >
-                  <span
-                    class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-                  >
-                    D. H. WEEKS
-                  </span>
-                  <h4
-                    class="MuiTypography-root SelectedReefCard-cardMetrics-6 MuiTypography-h4 MuiTypography-colorTextSecondary"
-                  >
-                    4.9
-                  </h4>
-                </div>
-              </div>
+                TEMP AT 0M
+              </span>
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
+              >
+                39.0 ℃
+              </h4>
+            </div>
+            <div>
+              <span
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                SURFACE TEMP
+              </span>
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
+              >
+                29.0 ℃
+              </h4>
+            </div>
+            <div>
+              <span
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                D. H. WEEKS
+              </span>
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
+              >
+                4.9
+              </h4>
             </div>
           </div>
         </div>
@@ -164,66 +143,50 @@ exports[`renders as expected 1`] = `
 exports[`renders loading as expected 1`] = `
 <div>
   <div
-    class="SelectedReefCard-root-8"
+    class="MuiBox-root MuiBox-root-10"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2"
+      class="MuiBox-root MuiBox-root-11"
     >
-      <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+      <h5
+        class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
       >
         <mock-hidden
           xsdown="true"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-          >
-            Featured - 
-          </h5>
+          Featured - 
         </mock-hidden>
         <mock-hidden
           smup="true"
         >
-          <h5
-            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-          >
-            Featured Reef
-          </h5>
+          Featured Reef
         </mock-hidden>
-      </div>
+      </h5>
+    </div>
+    <div
+      class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+    >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+        class="MuiBox-root MuiBox-root-12"
       >
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-justify-xs-center"
+          class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
+          role="progressbar"
+          style="width: 6rem; height: 6rem;"
         >
-          <div
-            class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+          <svg
+            class="MuiCircularProgress-svg"
+            viewBox="22 22 44 44"
           >
-            <div
-              class="SelectedReefCard-loading-9"
-            >
-              <div
-                class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"
-                role="progressbar"
-                style="width: 6rem; height: 6rem;"
-              >
-                <svg
-                  class="MuiCircularProgress-svg"
-                  viewBox="22 22 44 44"
-                >
-                  <circle
-                    class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
-                    cx="44"
-                    cy="44"
-                    fill="none"
-                    r="21.5"
-                    stroke-width="1"
-                  />
-                </svg>
-              </div>
-            </div>
-          </div>
+            <circle
+              class="MuiCircularProgress-circle MuiCircularProgress-circleIndeterminate"
+              cx="44"
+              cy="44"
+              fill="none"
+              r="21.5"
+              stroke-width="1"
+            />
+          </svg>
         </div>
       </div>
     </div>

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -78,7 +78,7 @@ exports[`renders as expected 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 MuiGrid-grid-lg-6"
-          style="max-height: 14rem;"
+          style="margin-bottom: 1rem; max-height: 14rem;"
         >
           <div
             class="MuiBox-root MuiBox-root-8"

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`renders as expected 1`] = `
 <div>
   <div
-    class="MuiBox-root MuiBox-root-2"
+    class="MuiBox-root MuiBox-root-3"
   >
     <div
-      class="MuiBox-root MuiBox-root-3"
+      class="MuiBox-root MuiBox-root-4"
     >
       <h5
         class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -30,10 +30,10 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4 MuiGrid-grid-lg-3"
         >
           <div
-            class="MuiBox-root MuiBox-root-4"
+            class="MuiBox-root MuiBox-root-5"
           >
             <div
               class="MuiCardMedia-root SelectedReefCard-cardImage-1"
@@ -43,7 +43,7 @@ exports[`renders as expected 1`] = `
               smup="true"
             >
               <div
-                class="MuiBox-root MuiBox-root-5"
+                class="MuiBox-root MuiBox-root-6"
               >
                 <h5
                   class="MuiTypography-root MuiTypography-h5"
@@ -52,7 +52,7 @@ exports[`renders as expected 1`] = `
               </div>
             </mock-hidden>
             <div
-              class="MuiBox-root MuiBox-root-6"
+              class="MuiBox-root MuiBox-root-7"
             >
               <a
                 href="/reefs/2"
@@ -77,11 +77,10 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
-          style="max-height: 14rem;"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 MuiGrid-grid-lg-6"
         >
           <div
-            class="MuiBox-root MuiBox-root-7"
+            class="MuiBox-root MuiBox-root-8"
           >
             <h6
               class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
@@ -92,10 +91,11 @@ exports[`renders as expected 1`] = `
           Mock-Line
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-3"
+          style="display: flex;"
         >
           <div
-            class="MuiBox-root MuiBox-root-8"
+            class="SelectedReefCard-metricsContainer-2"
           >
             <div>
               <span
@@ -144,10 +144,10 @@ exports[`renders as expected 1`] = `
 exports[`renders loading as expected 1`] = `
 <div>
   <div
-    class="MuiBox-root MuiBox-root-10"
+    class="MuiBox-root MuiBox-root-11"
   >
     <div
-      class="MuiBox-root MuiBox-root-11"
+      class="MuiBox-root MuiBox-root-12"
     >
       <h5
         class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
@@ -168,7 +168,7 @@ exports[`renders loading as expected 1`] = `
       class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiBox-root MuiBox-root-12"
+        class="MuiBox-root MuiBox-root-13"
       >
         <div
           class="MuiCircularProgress-root MuiCircularProgress-colorPrimary MuiCircularProgress-indeterminate"

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -11,11 +11,24 @@ exports[`renders as expected 1`] = `
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
       >
-        <h5
-          class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+        <mock-hidden
+          xsdown="true"
         >
-          Featured Reef
-        </h5>
+          <h5
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+          >
+            Featured - 
+          </h5>
+        </mock-hidden>
+        <mock-hidden
+          smup="true"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+          >
+            Featured Reef
+          </h5>
+        </mock-hidden>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
@@ -31,7 +44,7 @@ exports[`renders as expected 1`] = `
             >
               <div
                 class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
-                style="position: relative;"
+                style="height: 8rem; position: relative;"
               >
                 <div
                   class="MuiCardMedia-root SelectedReefCard-cardImage-3"
@@ -78,41 +91,26 @@ exports[`renders as expected 1`] = `
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6"
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
               >
-                <mock-hidden
-                  xsdown="true"
-                >
-                  <div
-                    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
-                  >
-                    <h5
-                      class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-                      style="padding: 0.5rem 0px 0px 0.5rem;"
-                    />
-                    <h6
-                      class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
-                      style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
-                    />
-                  </div>
-                </mock-hidden>
                 <div
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+                  style="height: 8rem;"
                 >
                   <h6
                     class="MuiTypography-root MuiTypography-subtitle1 MuiTypography-colorTextSecondary"
                     style="padding: 0px 0px 0.5rem 0.5rem; font-weight: 400;"
                   >
-                    MEAN DAILY SURFACE TEMPERATURE (C°)
+                    MEAN DAILY SURFACE TEMP. (C°)
                   </h6>
                   Mock-Line
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12 MuiGrid-grid-sm-2"
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
               >
                 <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
@@ -126,7 +124,7 @@ exports[`renders as expected 1`] = `
                   </h4>
                 </div>
                 <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
@@ -140,7 +138,7 @@ exports[`renders as expected 1`] = `
                   </h4>
                 </div>
                 <div
-                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-12"
+                  class="MuiGrid-root SelectedReefCard-metricsContainer-7 MuiGrid-item MuiGrid-grid-xs-4 MuiGrid-grid-sm-4"
                 >
                   <span
                     class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
@@ -174,11 +172,24 @@ exports[`renders loading as expected 1`] = `
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
       >
-        <h5
-          class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+        <mock-hidden
+          xsdown="true"
         >
-          Featured Reef
-        </h5>
+          <h5
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+          >
+            Featured - 
+          </h5>
+        </mock-hidden>
+        <mock-hidden
+          smup="true"
+        >
+          <h5
+            class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+          >
+            Featured Reef
+          </h5>
+        </mock-hidden>
       </div>
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -78,6 +78,7 @@ exports[`renders as expected 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 MuiGrid-grid-lg-6"
+          style="max-height: 14rem;"
         >
           <div
             class="MuiBox-root MuiBox-root-8"
@@ -101,24 +102,24 @@ exports[`renders as expected 1`] = `
               <span
                 class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
               >
-                TEMP AT 0M
-              </span>
-              <h4
-                class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
-              >
-                39.0 ℃
-              </h4>
-            </div>
-            <div>
-              <span
-                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-              >
                 SURFACE TEMP
               </span>
               <h4
                 class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
               >
                 29.0 ℃
+              </h4>
+            </div>
+            <div>
+              <span
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                TEMP AT 0M
+              </span>
+              <h4
+                class="MuiTypography-root MuiTypography-h4 MuiTypography-colorPrimary"
+              >
+                39.0 ℃
               </h4>
             </div>
             <div>

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/cardChart.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/cardChart.tsx
@@ -58,6 +58,7 @@ const CardChart = ({ dailyData, temperatureThreshold }: CardChartProps) => {
     <Line
       ref={chartRef}
       options={{
+        maintainAspectRatio: false,
         plugins: {
           chartJsPluginBarchartBackground: {
             color: "rgb(158, 166, 170, 0.07)",

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -44,9 +44,16 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
     <div className={classes.root}>
       <Grid container spacing={2}>
         <Grid container item xs={12}>
-          <Typography variant="h5" color="textSecondary">
-            {`Featured - ${reef.name}`}
-          </Typography>
+          <Hidden xsDown>
+            <Typography variant="h5" color="textSecondary">
+              {`Featured - ${reef.name}`}
+            </Typography>
+          </Hidden>
+          <Hidden smUp>
+            <Typography variant="h5" color="textSecondary">
+              Featured Reef
+            </Typography>
+          </Hidden>
         </Grid>
         <Grid item xs={12}>
           <Grid container justify="center">
@@ -63,6 +70,27 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                       className={classes.cardImage}
                       image={reefImage}
                     />
+                    <Hidden smUp>
+                      <Grid item xs={12} className={classes.mobileTitle}>
+                        <Typography
+                          style={{ padding: "0.5rem 0 0 0.5rem" }}
+                          color="textPrimary"
+                          variant="h5"
+                        >
+                          {reef.name}
+                        </Typography>
+                        <Typography
+                          style={{
+                            padding: "0 0 0.5rem 0.5rem",
+                            fontWeight: 400,
+                          }}
+                          color="textPrimary"
+                          variant="h6"
+                        >
+                          {reef.region}
+                        </Typography>
+                      </Grid>
+                    </Hidden>
                     <Grid item className={classes.exploreButton}>
                       <Link
                         style={{ color: "inherit", textDecoration: "none" }}

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -209,6 +209,7 @@ const styles = (theme: Theme) =>
       [theme.breakpoints.down("xs")]: {
         textAlign: "center",
       },
+      marginTop: "1rem",
     },
   });
 

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -43,12 +43,12 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
 
   const metrics = [
     {
-      label: `TEMP AT ${reef.depth}M`,
-      value: `${formatNumber(maxBottomTemperature, 1)} \u2103`,
-    },
-    {
       label: "SURFACE TEMP",
       value: `${formatNumber(surfTemp, 1)} \u2103`,
+    },
+    {
+      label: `TEMP AT ${reef.depth}M`,
+      value: `${formatNumber(maxBottomTemperature, 1)} \u2103`,
     },
     {
       label: "HEAT STRESS",
@@ -100,7 +100,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               </Box>
             </Grid>
 
-            <Grid item xs={12} sm={8} lg={6}>
+            <Grid item xs={12} sm={8} lg={6} style={{ maxHeight: "14rem" }}>
               <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
                 <Typography color="textSecondary" variant="subtitle1">
                   MEAN DAILY SURFACE TEMP. (C&deg;)
@@ -112,7 +112,14 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               />
             </Grid>
 
-            <Grid item xs={12} lg={3} style={{ display: "flex" }}>
+            <Grid
+              item
+              xs={12}
+              lg={3}
+              style={{
+                display: "flex",
+              }}
+            >
               <div className={classes.metricsContainer}>
                 {metrics.map(({ label, value }) => (
                   <div key={label}>
@@ -152,11 +159,12 @@ const styles = (theme: Theme) =>
       justifyContent: "space-around",
       alignItems: "center",
       flexDirection: "row",
-      margin: theme.spacing(1),
+      margin: theme.spacing(2),
       width: "100%",
 
       [theme.breakpoints.up("lg")]: {
         flexDirection: "column",
+        alignItems: "start",
       },
     },
   });

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -71,7 +71,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
       <Card>
         {`${reef.id}` === featuredReefId ? (
           <Grid container spacing={1}>
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} sm={4} lg={3}>
               <Box position="relative" height="100%">
                 <CardMedia className={classes.cardImage} image={reefImage} />
 
@@ -100,7 +100,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               </Box>
             </Grid>
 
-            <Grid item xs={12} sm={8} style={{ maxHeight: "14rem" }}>
+            <Grid item xs={12} sm={8} lg={6}>
               <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
                 <Typography color="textSecondary" variant="subtitle1">
                   MEAN DAILY SURFACE TEMP. (C&deg;)
@@ -112,8 +112,8 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               />
             </Grid>
 
-            <Grid item xs={12}>
-              <Box display="flex" justifyContent="space-around" my={1}>
+            <Grid item xs={12} lg={3} style={{ display: "flex" }}>
+              <div className={classes.metricsContainer}>
                 {metrics.map(({ label, value }) => (
                   <div key={label}>
                     <Typography variant="caption" color="textSecondary">
@@ -124,7 +124,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                     </Typography>
                   </div>
                 ))}
-              </Box>
+              </div>
             </Grid>
           </Grid>
         ) : (
@@ -143,8 +143,20 @@ const styles = (theme: Theme) =>
       borderRadius: "4px 0 0 4px",
       height: "100%",
 
-      [theme.breakpoints.down("sm")]: {
+      [theme.breakpoints.down("xs")]: {
         height: 300,
+      },
+    },
+    metricsContainer: {
+      display: "flex",
+      justifyContent: "space-around",
+      alignItems: "center",
+      flexDirection: "row",
+      margin: theme.spacing(1),
+      width: "100%",
+
+      [theme.breakpoints.up("lg")]: {
+        flexDirection: "column",
       },
     },
   });

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -11,6 +11,7 @@ import {
   CircularProgress,
   Card,
   Hidden,
+  Box,
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 
@@ -40,204 +41,108 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
     return null;
   }
 
+  const metrics = [
+    {
+      label: `TEMP AT ${reef.depth}M`,
+      value: `${formatNumber(maxBottomTemperature, 1)} \u2103`,
+    },
+    {
+      label: "SURFACE TEMP",
+      value: `${formatNumber(surfTemp, 1)} \u2103`,
+    },
+    {
+      label: "D. H. WEEKS",
+      value: formatNumber(degreeHeatingWeeksCalculator(degreeHeatingDays), 1),
+    },
+  ];
+
   return (
-    <div className={classes.root}>
-      <Grid container spacing={2}>
-        <Grid container item xs={12}>
-          <Hidden xsDown>
-            <Typography variant="h5" color="textSecondary">
-              {`Featured - ${reef.name}`}
-            </Typography>
-          </Hidden>
-          <Hidden smUp>
-            <Typography variant="h5" color="textSecondary">
-              Featured Reef
-            </Typography>
-          </Hidden>
-        </Grid>
-        <Grid item xs={12}>
-          <Grid container justify="center">
-            <Card>
-              {`${reef.id}` === featuredReefId ? (
-                <Grid container item xs={12} spacing={1}>
-                  <Grid
-                    item
-                    xs={12}
-                    sm={4}
-                    style={{ height: "8rem", position: "relative" }}
+    <Box p={1}>
+      <Box mb={2}>
+        <Typography variant="h5" color="textSecondary">
+          <Hidden xsDown>{`Featured - ${reef.name}`}</Hidden>
+          <Hidden smUp>Featured Reef</Hidden>
+        </Typography>
+      </Box>
+
+      <Card>
+        {`${reef.id}` === featuredReefId ? (
+          <Grid container spacing={1}>
+            <Grid item xs={12} sm={4}>
+              <Box position="relative" height="100%">
+                <CardMedia className={classes.cardImage} image={reefImage} />
+
+                <Hidden smUp>
+                  <Box position="absolute" top={16} left={16}>
+                    <Typography variant="h5">{reef.name}</Typography>
+
+                    {reef.region && (
+                      <Typography variant="h6" style={{ fontWeight: 400 }}>
+                        {reef.region}
+                      </Typography>
+                    )}
+                  </Box>
+                </Hidden>
+
+                <Box position="absolute" bottom={16} right={16}>
+                  <Link
+                    style={{ color: "inherit", textDecoration: "none" }}
+                    to={`/reefs/${reef.id}`}
                   >
-                    <CardMedia
-                      className={classes.cardImage}
-                      image={reefImage}
-                    />
-                    <Hidden smUp>
-                      <Grid item xs={12} className={classes.mobileTitle}>
-                        <Typography
-                          style={{ padding: "0.5rem 0 0 0.5rem" }}
-                          color="textPrimary"
-                          variant="h5"
-                        >
-                          {reef.name}
-                        </Typography>
-                        <Typography
-                          style={{
-                            padding: "0 0 0.5rem 0.5rem",
-                            fontWeight: 400,
-                          }}
-                          color="textPrimary"
-                          variant="h6"
-                        >
-                          {reef.region}
-                        </Typography>
-                      </Grid>
-                    </Hidden>
-                    <Grid item className={classes.exploreButton}>
-                      <Link
-                        style={{ color: "inherit", textDecoration: "none" }}
-                        to={`/reefs/${reef.id}`}
-                      >
-                        <Button
-                          size="small"
-                          variant="contained"
-                          color="primary"
-                        >
-                          EXPLORE
-                        </Button>
-                      </Link>
-                    </Grid>
-                  </Grid>
-                  <Grid container item xs={12} sm={8}>
-                    <Grid item xs={12} style={{ height: "8rem" }}>
-                      <Typography
-                        style={{
-                          padding: "0 0 0.5rem 0.5rem",
-                          fontWeight: 400,
-                        }}
-                        color="textSecondary"
-                        variant="subtitle1"
-                      >
-                        MEAN DAILY SURFACE TEMP. (C&deg;)
-                      </Typography>
-                      <CardChart
-                        dailyData={reef.dailyData}
-                        temperatureThreshold={(reef.maxMonthlyMean || 22) + 1}
-                      />
-                    </Grid>
-                  </Grid>
-                  <Grid
-                    container
-                    direction="row"
-                    alignItems="center"
-                    item
-                    xs={12}
-                    sm={8}
-                  >
-                    <Grid
-                      item
-                      xs={4}
-                      sm={4}
-                      className={classes.metricsContainer}
-                    >
-                      <Typography variant="caption" color="textSecondary">
-                        {`TEMP AT ${reef.depth}M`}
-                      </Typography>
-                      <Typography
-                        className={classes.cardMetrics}
-                        variant="h4"
-                        color="textSecondary"
-                      >
-                        {`${formatNumber(maxBottomTemperature, 1)} \u2103`}
-                      </Typography>
-                    </Grid>
-                    <Grid
-                      item
-                      xs={4}
-                      sm={4}
-                      className={classes.metricsContainer}
-                    >
-                      <Typography variant="caption" color="textSecondary">
-                        SURFACE TEMP
-                      </Typography>
-                      <Typography
-                        className={classes.cardMetrics}
-                        variant="h4"
-                        color="textSecondary"
-                      >
-                        {`${formatNumber(surfTemp, 1)} \u2103`}
-                      </Typography>
-                    </Grid>
-                    <Grid
-                      item
-                      xs={4}
-                      sm={4}
-                      className={classes.metricsContainer}
-                    >
-                      <Typography variant="caption" color="textSecondary">
-                        D. H. WEEKS
-                      </Typography>
-                      <Typography
-                        className={classes.cardMetrics}
-                        variant="h4"
-                        color="textSecondary"
-                      >
-                        {formatNumber(
-                          degreeHeatingWeeksCalculator(degreeHeatingDays),
-                          1
-                        )}
-                      </Typography>
-                    </Grid>
-                  </Grid>
-                </Grid>
-              ) : (
-                <div className={classes.loading}>
-                  <CircularProgress size="6rem" thickness={1} />
-                </div>
-              )}
-            </Card>
+                    <Button size="small" variant="contained" color="primary">
+                      EXPLORE
+                    </Button>
+                  </Link>
+                </Box>
+              </Box>
+            </Grid>
+
+            <Grid item xs={12} sm={8}>
+              <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
+                <Typography color="textSecondary" variant="subtitle1">
+                  MEAN DAILY SURFACE TEMP. (C&deg;)
+                </Typography>
+              </Box>
+              <CardChart
+                dailyData={reef.dailyData}
+                temperatureThreshold={(reef.maxMonthlyMean || 22) + 1}
+              />
+            </Grid>
+
+            <Grid item xs={12}>
+              <Box display="flex" justifyContent="space-around" my={1}>
+                {metrics.map(({ label, value }) => (
+                  <div key={label}>
+                    <Typography variant="caption" color="textSecondary">
+                      {label}
+                    </Typography>
+                    <Typography variant="h4" color="primary">
+                      {value}
+                    </Typography>
+                  </div>
+                ))}
+              </Box>
+            </Grid>
           </Grid>
-        </Grid>
-      </Grid>
-    </div>
+        ) : (
+          <Box textAlign="center" p={4}>
+            <CircularProgress size="6rem" thickness={1} />
+          </Box>
+        )}
+      </Card>
+    </Box>
   );
 };
 
 const styles = (theme: Theme) =>
   createStyles({
-    root: {
-      padding: "8px",
-    },
-    loading: {
-      height: "100%",
-      width: "100%",
-      display: "flex",
-      justifyContent: "center",
-      alignItems: "center",
-    },
     cardImage: {
       borderRadius: "4px 0 0 4px",
-      minHeight: "200px",
-    },
-    exploreButton: {
-      position: "absolute",
-      bottom: "16px",
-      right: "16px",
-    },
-    mobileTitle: {
-      position: "absolute",
-      top: "8px",
-      left: "8px",
-    },
-    cardMetrics: {
-      color: theme.palette.primary.main,
-      [theme.breakpoints.down("xs")]: {
-        textAlign: "center",
+      height: "100%",
+
+      [theme.breakpoints.down("sm")]: {
+        height: 300,
       },
-    },
-    metricsContainer: {
-      [theme.breakpoints.down("xs")]: {
-        textAlign: "center",
-      },
-      marginTop: "1rem",
     },
   });
 

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -51,8 +51,11 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
       value: `${formatNumber(surfTemp, 1)} \u2103`,
     },
     {
-      label: "D. H. WEEKS",
-      value: formatNumber(degreeHeatingWeeksCalculator(degreeHeatingDays), 1),
+      label: "HEAT STRESS",
+      value: `${formatNumber(
+        degreeHeatingWeeksCalculator(degreeHeatingDays),
+        1
+      )} DHW`,
     },
   ];
 

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -97,7 +97,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               </Box>
             </Grid>
 
-            <Grid item xs={12} sm={8}>
+            <Grid item xs={12} sm={8} style={{ maxHeight: "14rem" }}>
               <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
                 <Typography color="textSecondary" variant="subtitle1">
                   MEAN DAILY SURFACE TEMP. (C&deg;)

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import {
   Typography,
-  Paper,
   Grid,
   Button,
   CardMedia,
@@ -10,6 +9,8 @@ import {
   createStyles,
   Theme,
   CircularProgress,
+  Card,
+  Hidden,
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 
@@ -41,116 +42,169 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
 
   return (
     <div className={classes.root}>
-      <Typography
-        style={{ margin: "0 0 0.5rem 1.5rem" }}
-        variant="h5"
-        color="textSecondary"
-      >
-        Featured Reef
-      </Typography>
-      <Grid container justify="center">
-        <Paper elevation={3} className={classes.selectedReef}>
-          {`${reef.id}` === featuredReefId ? (
-            <Grid className={classes.card} container item xs={12}>
-              <Grid item xs={4}>
-                <CardMedia className={classes.cardImage} image={reefImage} />
-              </Grid>
-              <Grid container item xs={6}>
-                <Grid item xs={12}>
-                  <Typography
-                    style={{ padding: "0.5rem 0 0 0.5rem" }}
-                    color="textSecondary"
-                    variant="h5"
+      <Grid container spacing={2}>
+        <Grid container item xs={12}>
+          <Typography variant="h5" color="textSecondary">
+            Featured Reef
+          </Typography>
+        </Grid>
+        <Grid item xs={12}>
+          <Grid container justify="center">
+            <Card>
+              {`${reef.id}` === featuredReefId ? (
+                <Grid container item xs={12} spacing={1}>
+                  <Grid item xs={12} sm={4} style={{ position: "relative" }}>
+                    <CardMedia
+                      className={classes.cardImage}
+                      image={reefImage}
+                    />
+                    <Hidden smUp>
+                      <Grid item xs={12} className={classes.mobileTitle}>
+                        <Typography
+                          style={{ padding: "0.5rem 0 0 0.5rem" }}
+                          color="textPrimary"
+                          variant="h5"
+                        >
+                          {reef.name}
+                        </Typography>
+                        <Typography
+                          style={{
+                            padding: "0 0 0.5rem 0.5rem",
+                            fontWeight: 400,
+                          }}
+                          color="textPrimary"
+                          variant="h6"
+                        >
+                          {reef.region}
+                        </Typography>
+                      </Grid>
+                    </Hidden>
+                    <Grid item className={classes.exploreButton}>
+                      <Link
+                        style={{ color: "inherit", textDecoration: "none" }}
+                        to={`/reefs/${reef.id}`}
+                      >
+                        <Button
+                          size="small"
+                          variant="contained"
+                          color="primary"
+                        >
+                          EXPLORE
+                        </Button>
+                      </Link>
+                    </Grid>
+                  </Grid>
+                  <Grid container item xs={12} sm={6}>
+                    <Hidden xsDown>
+                      <Grid item xs={12}>
+                        <Typography
+                          style={{ padding: "0.5rem 0 0 0.5rem" }}
+                          color="textSecondary"
+                          variant="h5"
+                        >
+                          {reef.name}
+                        </Typography>
+                        <Typography
+                          style={{
+                            padding: "0 0 0.5rem 0.5rem",
+                            fontWeight: 400,
+                          }}
+                          color="textSecondary"
+                          variant="h6"
+                        >
+                          {reef.region}
+                        </Typography>
+                      </Grid>
+                    </Hidden>
+                    <Grid item xs={12}>
+                      <Typography
+                        style={{
+                          padding: "0 0 0.5rem 0.5rem",
+                          fontWeight: 400,
+                        }}
+                        color="textSecondary"
+                        variant="subtitle1"
+                      >
+                        MEAN DAILY SURFACE TEMPERATURE (C&deg;)
+                      </Typography>
+                      <CardChart
+                        dailyData={reef.dailyData}
+                        temperatureThreshold={(reef.maxMonthlyMean || 22) + 1}
+                      />
+                    </Grid>
+                  </Grid>
+                  <Grid
+                    container
+                    direction="row"
+                    alignItems="center"
+                    item
+                    xs={12}
+                    sm={2}
                   >
-                    {reef.name}
-                  </Typography>
-                  <Typography
-                    style={{ padding: "0 0 0.5rem 0.5rem", fontWeight: 400 }}
-                    color="textSecondary"
-                    variant="h6"
-                  >
-                    {reef.region}
-                  </Typography>
+                    <Grid
+                      item
+                      xs={4}
+                      sm={12}
+                      className={classes.metricsContainer}
+                    >
+                      <Typography variant="caption" color="textSecondary">
+                        {`TEMP AT ${reef.depth}M`}
+                      </Typography>
+                      <Typography
+                        className={classes.cardMetrics}
+                        variant="h4"
+                        color="textSecondary"
+                      >
+                        {`${formatNumber(maxBottomTemperature, 1)} \u2103`}
+                      </Typography>
+                    </Grid>
+                    <Grid
+                      item
+                      xs={4}
+                      sm={12}
+                      className={classes.metricsContainer}
+                    >
+                      <Typography variant="caption" color="textSecondary">
+                        SURFACE TEMP
+                      </Typography>
+                      <Typography
+                        className={classes.cardMetrics}
+                        variant="h4"
+                        color="textSecondary"
+                      >
+                        {`${formatNumber(surfTemp, 1)} \u2103`}
+                      </Typography>
+                    </Grid>
+                    <Grid
+                      item
+                      xs={4}
+                      sm={12}
+                      className={classes.metricsContainer}
+                    >
+                      <Typography variant="caption" color="textSecondary">
+                        D. H. WEEKS
+                      </Typography>
+                      <Typography
+                        className={classes.cardMetrics}
+                        variant="h4"
+                        color="textSecondary"
+                      >
+                        {formatNumber(
+                          degreeHeatingWeeksCalculator(degreeHeatingDays),
+                          1
+                        )}
+                      </Typography>
+                    </Grid>
+                  </Grid>
                 </Grid>
-                <Grid item xs={12}>
-                  <Typography
-                    style={{ padding: "0 0 0.5rem 0.5rem", fontWeight: 400 }}
-                    color="textSecondary"
-                    variant="subtitle1"
-                  >
-                    MEAN DAILY SURFACE TEMPERATURE (C&deg;)
-                  </Typography>
-                  <CardChart
-                    dailyData={reef.dailyData}
-                    temperatureThreshold={(reef.maxMonthlyMean || 22) + 1}
-                  />
-                </Grid>
-              </Grid>
-              <Grid
-                style={{ paddingLeft: "2rem" }}
-                container
-                direction="row"
-                alignItems="center"
-                item
-                xs={2}
-              >
-                <Grid item xs={12}>
-                  <Typography variant="caption" color="textSecondary">
-                    {`TEMP AT ${reef.depth}M`}
-                  </Typography>
-                  <Typography
-                    className={classes.cardMetrics}
-                    variant="h4"
-                    color="textSecondary"
-                  >
-                    {`${formatNumber(maxBottomTemperature, 1)} \u2103`}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                  <Typography variant="caption" color="textSecondary">
-                    SURFACE TEMP
-                  </Typography>
-                  <Typography
-                    className={classes.cardMetrics}
-                    variant="h4"
-                    color="textSecondary"
-                  >
-                    {`${formatNumber(surfTemp, 1)} \u2103`}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                  <Typography variant="caption" color="textSecondary">
-                    D. H. WEEKS
-                  </Typography>
-                  <Typography
-                    className={classes.cardMetrics}
-                    variant="h4"
-                    color="textSecondary"
-                  >
-                    {formatNumber(
-                      degreeHeatingWeeksCalculator(degreeHeatingDays),
-                      1
-                    )}
-                  </Typography>
-                </Grid>
-                <Grid item xs={12}>
-                  <Link
-                    style={{ color: "inherit", textDecoration: "none" }}
-                    to={`/reefs/${reef.id}`}
-                  >
-                    <Button size="small" variant="contained" color="primary">
-                      EXPLORE
-                    </Button>
-                  </Link>
-                </Grid>
-              </Grid>
-            </Grid>
-          ) : (
-            <div className={classes.loading}>
-              <CircularProgress size="6rem" thickness={1} />
-            </div>
-          )}
-        </Paper>
+              ) : (
+                <div className={classes.loading}>
+                  <CircularProgress size="6rem" thickness={1} />
+                </div>
+              )}
+            </Card>
+          </Grid>
+        </Grid>
       </Grid>
     </div>
   );
@@ -159,12 +213,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
 const styles = (theme: Theme) =>
   createStyles({
     root: {
-      marginTop: "1rem",
-      marginBottom: "2rem",
-    },
-    selectedReef: {
-      width: "48vw",
-      height: "28vh",
+      padding: "8px",
     },
     loading: {
       height: "100%",
@@ -173,15 +222,30 @@ const styles = (theme: Theme) =>
       justifyContent: "center",
       alignItems: "center",
     },
-    card: {
-      height: "100%",
-    },
     cardImage: {
       borderRadius: "4px 0 0 4px",
-      height: "100%",
+      minHeight: "200px",
+    },
+    exploreButton: {
+      position: "absolute",
+      bottom: "16px",
+      right: "16px",
+    },
+    mobileTitle: {
+      position: "absolute",
+      top: "8px",
+      left: "8px",
     },
     cardMetrics: {
       color: theme.palette.primary.main,
+      [theme.breakpoints.down("xs")]: {
+        textAlign: "center",
+      },
+    },
+    metricsContainer: {
+      [theme.breakpoints.down("xs")]: {
+        textAlign: "center",
+      },
     },
   });
 

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -100,7 +100,13 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
               </Box>
             </Grid>
 
-            <Grid item xs={12} sm={8} lg={6} style={{ maxHeight: "14rem" }}>
+            <Grid
+              item
+              xs={12}
+              sm={8}
+              lg={6}
+              style={{ marginBottom: "1rem", maxHeight: "14rem" }}
+            >
               <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
                 <Typography color="textSecondary" variant="subtitle1">
                   MEAN DAILY SURFACE TEMP. (C&deg;)

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -45,7 +45,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
       <Grid container spacing={2}>
         <Grid container item xs={12}>
           <Typography variant="h5" color="textSecondary">
-            Featured Reef
+            {`Featured - ${reef.name}`}
           </Typography>
         </Grid>
         <Grid item xs={12}>
@@ -53,32 +53,16 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
             <Card>
               {`${reef.id}` === featuredReefId ? (
                 <Grid container item xs={12} spacing={1}>
-                  <Grid item xs={12} sm={4} style={{ position: "relative" }}>
+                  <Grid
+                    item
+                    xs={12}
+                    sm={4}
+                    style={{ height: "8rem", position: "relative" }}
+                  >
                     <CardMedia
                       className={classes.cardImage}
                       image={reefImage}
                     />
-                    <Hidden smUp>
-                      <Grid item xs={12} className={classes.mobileTitle}>
-                        <Typography
-                          style={{ padding: "0.5rem 0 0 0.5rem" }}
-                          color="textPrimary"
-                          variant="h5"
-                        >
-                          {reef.name}
-                        </Typography>
-                        <Typography
-                          style={{
-                            padding: "0 0 0.5rem 0.5rem",
-                            fontWeight: 400,
-                          }}
-                          color="textPrimary"
-                          variant="h6"
-                        >
-                          {reef.region}
-                        </Typography>
-                      </Grid>
-                    </Hidden>
                     <Grid item className={classes.exploreButton}>
                       <Link
                         style={{ color: "inherit", textDecoration: "none" }}
@@ -94,29 +78,8 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                       </Link>
                     </Grid>
                   </Grid>
-                  <Grid container item xs={12} sm={6}>
-                    <Hidden xsDown>
-                      <Grid item xs={12}>
-                        <Typography
-                          style={{ padding: "0.5rem 0 0 0.5rem" }}
-                          color="textSecondary"
-                          variant="h5"
-                        >
-                          {reef.name}
-                        </Typography>
-                        <Typography
-                          style={{
-                            padding: "0 0 0.5rem 0.5rem",
-                            fontWeight: 400,
-                          }}
-                          color="textSecondary"
-                          variant="h6"
-                        >
-                          {reef.region}
-                        </Typography>
-                      </Grid>
-                    </Hidden>
-                    <Grid item xs={12}>
+                  <Grid container item xs={12} sm={8}>
+                    <Grid item xs={12} style={{ height: "8rem" }}>
                       <Typography
                         style={{
                           padding: "0 0 0.5rem 0.5rem",
@@ -125,7 +88,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                         color="textSecondary"
                         variant="subtitle1"
                       >
-                        MEAN DAILY SURFACE TEMPERATURE (C&deg;)
+                        MEAN DAILY SURFACE TEMP. (C&deg;)
                       </Typography>
                       <CardChart
                         dailyData={reef.dailyData}
@@ -139,12 +102,12 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                     alignItems="center"
                     item
                     xs={12}
-                    sm={2}
+                    sm={8}
                   >
                     <Grid
                       item
                       xs={4}
-                      sm={12}
+                      sm={4}
                       className={classes.metricsContainer}
                     >
                       <Typography variant="caption" color="textSecondary">
@@ -161,7 +124,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                     <Grid
                       item
                       xs={4}
-                      sm={12}
+                      sm={4}
                       className={classes.metricsContainer}
                     >
                       <Typography variant="caption" color="textSecondary">
@@ -178,7 +141,7 @@ const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
                     <Grid
                       item
                       xs={4}
-                      sm={12}
+                      sm={4}
                       className={classes.metricsContainer}
                     >
                       <Typography variant="caption" color="textSecondary">

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -276,10 +276,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
                     >
                       <h6
                         class="MuiTypography-root MuiTypography-h6"
-                        style="color: rgb(22, 141, 189); padding-left: 1.5rem;"
+                        style="color: rgb(22, 141, 189); padding-left: 1rem;"
                       >
                         - -
-                         ℃
+                        ℃
                       </h6>
                     </td>
                     <td

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -91,7 +91,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
                           role="button"
                           tabindex="0"
                         >
-                          REEF NAME
+                          REEF
                         </div>
                         <svg
                           aria-hidden="true"
@@ -276,7 +276,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
                     >
                       <h6
                         class="MuiTypography-root MuiTypography-h6"
-                        style="color: rgb(22, 141, 189); padding-left: 2rem;"
+                        style="color: rgb(22, 141, 189); padding-left: 1.5rem;"
                       >
                         - -
                          ℃

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -47,7 +47,7 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
 
   const tableColumns: Array<Column<Row>> = [
     {
-      title: "REEF NAME",
+      title: "REEF",
       field: "locationName",
       cellStyle,
       render: (rowData) => (
@@ -68,10 +68,10 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
       cellStyle,
       render: (rowData) => (
         <Typography
-          style={{ color: colors.lightBlue, paddingLeft: "2rem" }}
+          style={{ color: colors.lightBlue, paddingLeft: "1rem" }}
           variant="h6"
         >
-          {rowData.temp} &#8451;
+          {rowData.temp}&#8451;
         </Typography>
       ),
     },

--- a/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
               </h4>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
             >
               <mock-hidden
                 xsdown="true"
@@ -301,7 +301,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
             </h4>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
           >
             <mock-hidden
               xsdown="true"

--- a/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
@@ -62,6 +62,250 @@ exports[`Homepage should render with given state from Redux store 1`] = `
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
             >
+              <mock-hidden
+                xsdown="true"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-6"
+                >
+                  <div
+                    class="MuiGrid-root Search-searchBar-12 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-8"
+                  >
+                    <div
+                      class="MuiGrid-root Search-searchBarIcon-13 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-center MuiGrid-grid-xs-2"
+                    >
+                      <button
+                        class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
+                        tabindex="0"
+                        type="button"
+                      >
+                        <span
+                          class="MuiIconButton-label"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            class="MuiSvgIcon-root"
+                            focusable="false"
+                            viewBox="0 0 24 24"
+                          >
+                            <path
+                              d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                            />
+                          </svg>
+                        </span>
+                        <span
+                          class="MuiTouchRipple-root"
+                        />
+                      </button>
+                    </div>
+                    <div
+                      class="MuiGrid-root Search-searchBarText-14 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-10"
+                    >
+                      <div
+                        aria-expanded="false"
+                        class="MuiAutocomplete-root Search-searchBarInput-15 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                        role="combobox"
+                      >
+                        <div
+                          class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
+                          style="height: 100%;"
+                        >
+                          <div
+                            class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
+                          >
+                            <input
+                              aria-autocomplete="list"
+                              aria-invalid="false"
+                              autocapitalize="none"
+                              autocomplete="off"
+                              class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
+                              id="location"
+                              placeholder="Search reef by name"
+                              spellcheck="false"
+                              type="text"
+                              value=""
+                            />
+                            <div
+                              class="MuiAutocomplete-endAdornment"
+                            >
+                              <button
+                                aria-label="Clear"
+                                class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
+                                tabindex="-1"
+                                title="Clear"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                              <button
+                                aria-label="Open"
+                                class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
+                                tabindex="-1"
+                                title="Open"
+                                type="button"
+                              >
+                                <span
+                                  class="MuiIconButton-label"
+                                >
+                                  <svg
+                                    aria-hidden="true"
+                                    class="MuiSvgIcon-root"
+                                    focusable="false"
+                                    viewBox="0 0 24 24"
+                                  >
+                                    <path
+                                      d="M7 10l5 5 5-5z"
+                                    />
+                                  </svg>
+                                </span>
+                                <span
+                                  class="MuiTouchRipple-root"
+                                />
+                              </button>
+                            </div>
+                            <fieldset
+                              aria-hidden="true"
+                              class="PrivateNotchedOutline-root-16 MuiOutlinedInput-notchedOutline"
+                              style="padding-left: 8px;"
+                            >
+                              <legend
+                                class="PrivateNotchedOutline-legend-17"
+                                style="width: 0.01px;"
+                              >
+                                <span>
+                                  ​
+                                </span>
+                              </legend>
+                            </fieldset>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </mock-hidden>
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
+              >
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label"
+                    >
+                      SIGN IN
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+                <div
+                  class="MuiGrid-root MuiGrid-item"
+                >
+                  <button
+                    class="MuiButtonBase-root MuiButton-root MuiButton-text"
+                    tabindex="0"
+                    type="button"
+                  >
+                    <span
+                      class="MuiButton-label"
+                    >
+                      REGISTER
+                    </span>
+                    <span
+                      class="MuiTouchRipple-root"
+                    />
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </header>
+    </div>
+  </mock-hidden>
+  <mock-hidden
+    xsdown="true"
+  >
+    <header
+      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary NavBar-appBar-7 MuiPaper-elevation4"
+    >
+      <div
+        class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
+      >
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
+          >
+            <button
+              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
+              tabindex="0"
+              type="button"
+            >
+              <span
+                class="MuiIconButton-label"
+              >
+                <svg
+                  aria-hidden="true"
+                  class="MuiSvgIcon-root"
+                  focusable="false"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
+                  />
+                </svg>
+              </span>
+              <span
+                class="MuiTouchRipple-root"
+              />
+            </button>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-5"
+          >
+            <h4
+              class="MuiTypography-root MuiTypography-h4"
+            >
+              Aqua
+            </h4>
+            <h4
+              class="MuiTypography-root MuiTypography-h4"
+              style="color: rgb(138, 198, 222);"
+            >
+              link
+            </h4>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+          >
+            <mock-hidden
+              xsdown="true"
+            >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-6"
               >
@@ -196,243 +440,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
                   </div>
                 </div>
               </div>
-              <div
-                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
-              >
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiButton-label"
-                    >
-                      SIGN IN
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-                <div
-                  class="MuiGrid-root MuiGrid-item"
-                >
-                  <button
-                    class="MuiButtonBase-root MuiButton-root MuiButton-text"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiButton-label"
-                    >
-                      REGISTER
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </header>
-    </div>
-  </mock-hidden>
-  <mock-hidden
-    xsdown="true"
-  >
-    <header
-      class="MuiPaper-root MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary NavBar-appBar-7 MuiPaper-elevation4"
-    >
-      <div
-        class="MuiToolbar-root MuiToolbar-regular MuiToolbar-gutters"
-      >
-        <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-12"
-        >
-          <div
-            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-1"
-          >
-            <button
-              class="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit MuiIconButton-edgeStart"
-              tabindex="0"
-              type="button"
-            >
-              <span
-                class="MuiIconButton-label"
-              >
-                <svg
-                  aria-hidden="true"
-                  class="MuiSvgIcon-root"
-                  focusable="false"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6H3z"
-                  />
-                </svg>
-              </span>
-              <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-5"
-          >
-            <h4
-              class="MuiTypography-root MuiTypography-h4"
-            >
-              Aqua
-            </h4>
-            <h4
-              class="MuiTypography-root MuiTypography-h4"
-              style="color: rgb(138, 198, 222);"
-            >
-              link
-            </h4>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
-          >
-            <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-6"
-            >
-              <div
-                class="MuiGrid-root Search-searchBar-12 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-8"
-              >
-                <div
-                  class="MuiGrid-root Search-searchBarIcon-13 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-center MuiGrid-grid-xs-2"
-                >
-                  <button
-                    class="MuiButtonBase-root MuiIconButton-root MuiIconButton-sizeSmall"
-                    tabindex="0"
-                    type="button"
-                  >
-                    <span
-                      class="MuiIconButton-label"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root"
-                        focusable="false"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
-                        />
-                      </svg>
-                    </span>
-                    <span
-                      class="MuiTouchRipple-root"
-                    />
-                  </button>
-                </div>
-                <div
-                  class="MuiGrid-root Search-searchBarText-14 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-grid-xs-10"
-                >
-                  <div
-                    aria-expanded="false"
-                    class="MuiAutocomplete-root Search-searchBarInput-15 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
-                    role="combobox"
-                  >
-                    <div
-                      class="MuiFormControl-root MuiTextField-root MuiFormControl-fullWidth"
-                      style="height: 100%;"
-                    >
-                      <div
-                        class="MuiInputBase-root MuiOutlinedInput-root MuiAutocomplete-inputRoot MuiInputBase-fullWidth MuiInputBase-formControl MuiInputBase-adornedEnd MuiOutlinedInput-adornedEnd"
-                      >
-                        <input
-                          aria-autocomplete="list"
-                          aria-invalid="false"
-                          autocapitalize="none"
-                          autocomplete="off"
-                          class="MuiInputBase-input MuiOutlinedInput-input MuiAutocomplete-input MuiAutocomplete-inputFocused MuiInputBase-inputAdornedEnd MuiOutlinedInput-inputAdornedEnd"
-                          id="location"
-                          placeholder="Search reef by name"
-                          spellcheck="false"
-                          type="text"
-                          value=""
-                        />
-                        <div
-                          class="MuiAutocomplete-endAdornment"
-                        >
-                          <button
-                            aria-label="Clear"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-clearIndicator"
-                            tabindex="-1"
-                            title="Clear"
-                            type="button"
-                          >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
-                          <button
-                            aria-label="Open"
-                            class="MuiButtonBase-root MuiIconButton-root MuiAutocomplete-popupIndicator"
-                            tabindex="-1"
-                            title="Open"
-                            type="button"
-                          >
-                            <span
-                              class="MuiIconButton-label"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                class="MuiSvgIcon-root"
-                                focusable="false"
-                                viewBox="0 0 24 24"
-                              >
-                                <path
-                                  d="M7 10l5 5 5-5z"
-                                />
-                              </svg>
-                            </span>
-                            <span
-                              class="MuiTouchRipple-root"
-                            />
-                          </button>
-                        </div>
-                        <fieldset
-                          aria-hidden="true"
-                          class="PrivateNotchedOutline-root-16 MuiOutlinedInput-notchedOutline"
-                          style="padding-left: 8px;"
-                        >
-                          <legend
-                            class="PrivateNotchedOutline-legend-17"
-                            style="width: 0.01px;"
-                          >
-                            <span>
-                              ​
-                            </span>
-                          </legend>
-                        </fieldset>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
+            </mock-hidden>
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
             >

--- a/packages/website/src/routes/ReefRoutes/Reef/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/Satellite/__snapshots__/index.test.tsx.snap
@@ -72,12 +72,13 @@ exports[`renders as expected 1`] = `
               <h6
                 class="MuiTypography-root Satellite-contentTextTitles-6 MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
               >
-                DEGREE HEATING WEEKS
+                HEAT STRESS
               </h6>
               <h2
                 class="MuiTypography-root Satellite-contentTextValues-7 MuiTypography-h2 MuiTypography-colorTextPrimary"
+                title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
               >
-                4.1
+                4.1 DHW
               </h2>
             </div>
           </div>

--- a/packages/website/src/routes/ReefRoutes/Reef/Satellite/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/Satellite/index.tsx
@@ -9,6 +9,7 @@ import {
   Typography,
   CardHeader,
   Grid,
+  Tooltip,
 } from "@material-ui/core";
 
 import { colorCode } from "../../../../assets/colorCode";
@@ -79,15 +80,17 @@ const Satellite = ({ dailyData, classes }: SatelliteProps) => {
                   color="textPrimary"
                   variant="subtitle2"
                 >
-                  DEGREE HEATING WEEKS
+                  HEAT STRESS
                 </Typography>
-                <Typography
-                  className={classes.contentTextValues}
-                  color="textPrimary"
-                  variant="h2"
-                >
-                  {formatNumber(degreeHeatingWeeks, 1)}
-                </Typography>
+                <Tooltip title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures">
+                  <Typography
+                    className={classes.contentTextValues}
+                    color="textPrimary"
+                    variant="h2"
+                  >
+                    {`${formatNumber(degreeHeatingWeeks, 1)} DHW`}
+                  </Typography>
+                </Tooltip>
               </Grid>
             </Grid>
           </Grid>

--- a/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           </h4>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
@@ -956,7 +956,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           </h4>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-grid-xs-6"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-start MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-6"

--- a/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
@@ -304,12 +304,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       <h6
                         class="MuiTypography-root Satellite-contentTextTitles-99 MuiTypography-subtitle2 MuiTypography-colorTextPrimary"
                       >
-                        DEGREE HEATING WEEKS
+                        HEAT STRESS
                       </h6>
                       <h2
                         class="MuiTypography-root Satellite-contentTextValues-100 MuiTypography-h2 MuiTypography-colorTextPrimary"
+                        title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
                       >
-                        0.1
+                        0.1 DHW
                       </h2>
                     </div>
                   </div>


### PR DESCRIPTION
SelectedReefCard display improvements for web and mobile views.
<img width="320" alt="Screen Shot 2020-08-28 at 11 50 05 AM" src="https://user-images.githubusercontent.com/59093722/91605769-d5e77900-e925-11ea-8476-8c35d53ae30e.png">
<img width="516" alt="Screen Shot 2020-08-28 at 11 50 26 AM" src="https://user-images.githubusercontent.com/59093722/91605778-d97b0000-e925-11ea-8d78-7bb08caa888e.png">
<img width="306" alt="Screen Shot 2020-08-28 at 11 50 56 AM" src="https://user-images.githubusercontent.com/59093722/91605786-dc75f080-e925-11ea-9f07-4ae83b9d6563.png">
The third image is from an iPad-sized screen - in this size range there are definite improvements to make still but all the content is at visible. Could consider using the mobile layout for this screen size?


