### PR TITLE
Improve Homepage Map Performance

### DIFF
--- a/packages/website/src/routes/Homepage/Map/Popup/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/Map/Popup/__snapshots__/index.test.tsx.snap
@@ -2,114 +2,119 @@
 
 exports[`renders as expected 1`] = `
 <div>
-  <div
-    class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
+  <mock-leafletpopup
+    classname="Popup-popup-2"
+    closebutton="false"
   >
     <div
-      class="MuiCardHeader-root Popup-popupHeader-1"
+      class="MuiPaper-root MuiCard-root MuiPaper-elevation1 MuiPaper-rounded"
     >
       <div
-        class="MuiCardHeader-content"
-      >
-        <span
-          class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
-        />
-        <span
-          class="MuiTypography-root MuiCardHeader-subheader MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
-        />
-      </div>
-    </div>
-    <div
-      class="MuiCardContent-root"
-    >
-      <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+        class="MuiCardHeader-root Popup-popupHeader-1"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
+          class="MuiCardHeader-content"
         >
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-            >
-              TEMP AT 0M
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
-          >
-            <h5
-              class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-              style="color: rgb(22, 141, 189);"
-            >
-              10.0
-               ℃
-            </h5>
-          </div>
-        </div>
-        <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
-        >
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
-          >
-            <span
-              class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
-            >
-              HEAT STRESS
-            </span>
-          </div>
-          <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
-          >
-            <h5
-              class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
-              style="color: rgb(8, 91, 163);"
-            >
-              1.4
-               
-            </h5>
-            <h6
-              class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
-              style="color: rgb(8, 91, 163); position: relative; bottom: 0px;"
-              title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
-            >
-              DHW
-            </h6>
-          </div>
+          <span
+            class="MuiTypography-root MuiCardHeader-title MuiTypography-h5 MuiTypography-displayBlock"
+          />
+          <span
+            class="MuiTypography-root MuiCardHeader-subheader MuiTypography-body1 MuiTypography-colorTextSecondary MuiTypography-displayBlock"
+          />
         </div>
       </div>
       <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
-        style="margin: 1rem 0px 1rem 0px;"
+        class="MuiCardContent-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
         >
-          <a
-            href="/reefs/2"
-            style="text-decoration: none;"
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
           >
-            <button
-              class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
-              tabindex="0"
-              type="button"
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
             >
               <span
-                class="MuiButton-label"
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
               >
-                EXPLORE
+                TEMP AT 0M
               </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+                style="color: rgb(22, 141, 189);"
+              >
+                10.0
+                 ℃
+              </h5>
+            </div>
+          </div>
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
+            >
               <span
-                class="MuiTouchRipple-root"
-              />
-            </button>
-          </a>
+                class="MuiTypography-root MuiTypography-caption MuiTypography-colorTextSecondary"
+              >
+                HEAT STRESS
+              </span>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-flex-end MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-12"
+            >
+              <h5
+                class="MuiTypography-root MuiTypography-h5 MuiTypography-colorTextSecondary"
+                style="color: rgb(8, 91, 163);"
+              >
+                1.4
+                 
+              </h5>
+              <h6
+                class="MuiTypography-root MuiTypography-h6 MuiTypography-colorTextSecondary"
+                style="color: rgb(8, 91, 163); position: relative; bottom: 0px;"
+                title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
+              >
+                DHW
+              </h6>
+            </div>
+          </div>
+        </div>
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+          style="margin: 1rem 0px 1rem 0px;"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item"
+          >
+            <a
+              href="/reefs/2"
+              style="text-decoration: none;"
+            >
+              <button
+                class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-outlinedSizeSmall MuiButton-sizeSmall"
+                tabindex="0"
+                type="button"
+              >
+                <span
+                  class="MuiButton-label"
+                >
+                  EXPLORE
+                </span>
+                <span
+                  class="MuiTouchRipple-root"
+                />
+              </button>
+            </a>
+          </div>
         </div>
       </div>
     </div>
-  </div>
+  </mock-leafletpopup>
 </div>
 `;

--- a/packages/website/src/routes/Homepage/Map/Popup/index.test.tsx
+++ b/packages/website/src/routes/Homepage/Map/Popup/index.test.tsx
@@ -1,9 +1,15 @@
 import React from "react";
 import { render } from "@testing-library/react";
-import { BrowserRouter as Router } from "react-router-dom";
 
+import { BrowserRouter as Router } from "react-router-dom";
 import Popup from ".";
 import { Reef } from "../../../../store/Reefs/types";
+
+jest.mock("react-leaflet", () => ({
+  __esModule: true,
+  Popup: (props: any) =>
+    jest.requireActual("react").createElement("mock-LeafletPopup", props),
+}));
 
 test("renders as expected", () => {
   const reef: Reef = {

--- a/packages/website/src/routes/Homepage/Map/Popup/index.tsx
+++ b/packages/website/src/routes/Homepage/Map/Popup/index.tsx
@@ -13,6 +13,7 @@ import {
   Tooltip,
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
+import { Popup as LeafletPopup } from "react-leaflet";
 
 import { Reef } from "../../../../store/Reefs/types";
 import { colors } from "../../../../layout/App/theme";
@@ -25,97 +26,100 @@ import {
 const Popup = ({ reef, classes }: PopupProps) => {
   const { degreeHeatingDays, maxBottomTemperature } =
     reef.latestDailyData || {};
+
   return (
-    <Card>
-      <CardHeader
-        className={classes.popupHeader}
-        title={reef.name}
-        subheader={reef.region}
-      />
-      <CardContent>
-        <Grid container item xs={12}>
-          <Grid item xs={6}>
-            <Grid container justify="flex-start" item xs={12}>
-              <Typography variant="caption" color="textSecondary">
-                {`TEMP AT ${reef.depth}M`}
-              </Typography>
+    <LeafletPopup closeButton={false} className={classes.popup}>
+      <Card>
+        <CardHeader
+          className={classes.popupHeader}
+          title={reef.name}
+          subheader={reef.region}
+        />
+        <CardContent>
+          <Grid container item xs={12}>
+            <Grid item xs={6}>
+              <Grid container justify="flex-start" item xs={12}>
+                <Typography variant="caption" color="textSecondary">
+                  {`TEMP AT ${reef.depth}M`}
+                </Typography>
+              </Grid>
+              <Grid container justify="flex-start" item xs={12}>
+                <Typography
+                  style={{ color: colors.lightBlue }}
+                  variant="h5"
+                  color="textSecondary"
+                >
+                  {formatNumber(maxBottomTemperature, 1)} &#8451;
+                </Typography>
+              </Grid>
             </Grid>
-            <Grid container justify="flex-start" item xs={12}>
-              <Typography
-                style={{ color: colors.lightBlue }}
-                variant="h5"
-                color="textSecondary"
+            <Grid item xs={6}>
+              <Grid container justify="flex-end" item xs={12}>
+                <Typography variant="caption" color="textSecondary">
+                  HEAT STRESS
+                </Typography>
+              </Grid>
+              <Grid
+                container
+                alignItems="flex-end"
+                justify="flex-end"
+                item
+                xs={12}
               >
-                {formatNumber(maxBottomTemperature, 1)} &#8451;
-              </Typography>
-            </Grid>
-          </Grid>
-          <Grid item xs={6}>
-            <Grid container justify="flex-end" item xs={12}>
-              <Typography variant="caption" color="textSecondary">
-                HEAT STRESS
-              </Typography>
-            </Grid>
-            <Grid
-              container
-              alignItems="flex-end"
-              justify="flex-end"
-              item
-              xs={12}
-            >
-              <Typography
-                style={{
-                  color: `${colorFinder(
-                    degreeHeatingWeeksCalculator(degreeHeatingDays)
-                  )}`,
-                }}
-                variant="h5"
-                color="textSecondary"
-              >
-                {formatNumber(
-                  degreeHeatingWeeksCalculator(degreeHeatingDays),
-                  1
-                )}
-                &nbsp;
-              </Typography>
-              <Tooltip title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures">
                 <Typography
                   style={{
                     color: `${colorFinder(
                       degreeHeatingWeeksCalculator(degreeHeatingDays)
                     )}`,
-                    position: "relative",
-                    bottom: 0,
                   }}
-                  variant="h6"
+                  variant="h5"
                   color="textSecondary"
                 >
-                  DHW
+                  {formatNumber(
+                    degreeHeatingWeeksCalculator(degreeHeatingDays),
+                    1
+                  )}
+                  &nbsp;
                 </Typography>
-              </Tooltip>
+                <Tooltip title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures">
+                  <Typography
+                    style={{
+                      color: `${colorFinder(
+                        degreeHeatingWeeksCalculator(degreeHeatingDays)
+                      )}`,
+                      position: "relative",
+                      bottom: 0,
+                    }}
+                    variant="h6"
+                    color="textSecondary"
+                  >
+                    DHW
+                  </Typography>
+                </Tooltip>
+              </Grid>
             </Grid>
           </Grid>
-        </Grid>
-        <Grid
-          style={{ margin: "1rem 0 1rem 0" }}
-          container
-          justify="flex-start"
-          item
-          xs={12}
-        >
-          <Grid item>
-            <Link
-              style={{ color: "inherit", textDecoration: "none" }}
-              to={`/reefs/${reef.id}`}
-            >
-              <Button size="small" variant="outlined" color="primary">
-                EXPLORE
-              </Button>
-            </Link>
+          <Grid
+            style={{ margin: "1rem 0 1rem 0" }}
+            container
+            justify="flex-start"
+            item
+            xs={12}
+          >
+            <Grid item>
+              <Link
+                style={{ color: "inherit", textDecoration: "none" }}
+                to={`/reefs/${reef.id}`}
+              >
+                <Button size="small" variant="outlined" color="primary">
+                  EXPLORE
+                </Button>
+              </Link>
+            </Grid>
           </Grid>
-        </Grid>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </LeafletPopup>
   );
 };
 
@@ -123,6 +127,10 @@ const styles = (theme: Theme) =>
   createStyles({
     popupHeader: {
       backgroundColor: theme.palette.primary.main,
+    },
+    popup: {
+      width: "12vw",
+      minWidth: 200,
     },
   });
 

--- a/packages/website/src/routes/Homepage/Map/index.tsx
+++ b/packages/website/src/routes/Homepage/Map/index.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef, useEffect } from "react";
-import { useSelector, useDispatch } from "react-redux";
-import { Map, TileLayer, Marker, Popup as LeafletPopup } from "react-leaflet";
-import L from "leaflet";
+import React from "react";
+import { useSelector } from "react-redux";
+import { Map, TileLayer } from "react-leaflet";
+import { LatLng } from "leaflet";
 import {
   createStyles,
   withStyles,
@@ -9,156 +9,32 @@ import {
   CircularProgress,
 } from "@material-ui/core";
 
-import {
-  reefsListSelector,
-  reefsListLoadingSelector,
-} from "../../../store/Reefs/reefsListSlice";
-import {
-  reefOnMapSelector,
-  unsetReefOnMap,
-} from "../../../store/Homepage/homepageSlice";
-import { Reef } from "../../../store/Reefs/types";
-import Popup from "./Popup";
-import { coloredBuoyIcon } from "./utils";
+import { reefsListLoadingSelector } from "../../../store/Reefs/reefsListSlice";
+import { ReefMarkers } from "./markers";
+import { SofarLayers } from "./sofarLayers";
+
+const INITIAL_CENTER = new LatLng(37.9, -75.3);
+const INITIAL_ZOOM = 5;
 
 const HomepageMap = ({ classes }: HomepageMapProps) => {
-  const mapRef = useRef<Map>(null);
-  const markerRef = useRef<Marker>(null);
-  const dispatch = useDispatch();
-  const reefOnMap = useSelector(reefOnMapSelector);
-  const reefsList = useSelector(reefsListSelector);
   const loading = useSelector(reefsListLoadingSelector);
-  const [center, setCenter] = useState<[number, number]>([37.9, -75.3]);
-  const [zoom, setZoom] = useState<number>(5);
 
-  useEffect(() => {
-    const { current } = mapRef;
-    if (current && current.leafletElement) {
-      const map = current.leafletElement;
-      const southWest = L.latLng(-90, -240);
-      const northEast = L.latLng(90, 240);
-      const bounds = L.latLngBounds(southWest, northEast);
-      map.setMaxBounds(bounds);
-      map.flyTo(center, zoom, { duration: 1 });
-    }
-  }, [center, zoom, mapRef]);
-
-  // Add Sofar Tiles
-  useEffect(() => {
-    const { current } = mapRef;
-    if (current && current.leafletElement) {
-      const map = current.leafletElement;
-
-      const layerControl = L.control.layers(undefined).addTo(map);
-      const sofarLayers = [
-        {
-          name: "Sea Surface Temperature",
-          model: "HYCOM",
-          variableID: "seaSurfaceTemperature",
-          cmap: "turbo",
-        },
-        {
-          name: "NOAA Degree Heating Week",
-          model: "NOAACoralReefWatch",
-          variableID: "degreeHeatingWeek",
-          cmap: "noaacoral",
-        },
-      ];
-
-      const sofarUrl = "https://api.sofarocean.com/marine-weather/v1/models/";
-      const { REACT_APP_SOFAR_API_TOKEN: token } = process.env;
-      sofarLayers.forEach((layer) => {
-        layerControl.addOverlay(
-          L.tileLayer(
-            `${sofarUrl}${layer.model}/tile/{z}/{x}/{y}.png?colormap=${layer.cmap}&token=${token}&variableID=${layer.variableID}`,
-            { opacity: 0.5 }
-          ),
-          layer.name
-        );
-      });
-    }
-  }, [loading]);
-
-  useEffect(() => {
-    const markerCurrent = markerRef.current;
-    const mapCurrent = mapRef.current;
-    if (
-      markerCurrent &&
-      markerCurrent.leafletElement &&
-      mapCurrent &&
-      mapCurrent.leafletElement &&
-      reefOnMap?.polygon?.type === "Point"
-    ) {
-      const map = mapCurrent.leafletElement;
-      const marker = markerCurrent.leafletElement;
-      map.flyTo(
-        [reefOnMap.polygon.coordinates[1], reefOnMap.polygon.coordinates[0]],
-        6,
-        { duration: 1 }
-      );
-      marker.openPopup();
-    }
-  }, [reefOnMap, markerRef, mapRef]);
-
-  return (
-    <>
-      {loading ? (
-        <div className={classes.loading}>
-          <CircularProgress size="10rem" thickness={1} />
-        </div>
-      ) : (
-        <Map
-          maxBoundsViscosity={1.0}
-          className={classes.map}
-          ref={mapRef}
-          center={center}
-          zoom={zoom}
-          minZoom={2}
-        >
-          <TileLayer url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}" />
-          {reefOnMap && reefOnMap.polygon.type === "Point" && (
-            <Marker
-              ref={markerRef}
-              icon={coloredBuoyIcon(
-                reefOnMap.latestDailyData.degreeHeatingDays
-              )}
-              position={[
-                reefOnMap.polygon.coordinates[1],
-                reefOnMap.polygon.coordinates[0],
-              ]}
-            >
-              <LeafletPopup closeButton={false} className={classes.popup}>
-                <Popup reef={reefOnMap} />
-              </LeafletPopup>
-            </Marker>
-          )}
-          {reefsList.length > 0 &&
-            reefsList.map((reef: Reef) => {
-              if (reef.polygon.type === "Point") {
-                const [lng, lat] = reef.polygon.coordinates;
-                const { degreeHeatingDays } = reef.latestDailyData || {};
-                return (
-                  <Marker
-                    onClick={() => {
-                      setZoom(6);
-                      setCenter([lat, lng]);
-                      dispatch(unsetReefOnMap());
-                    }}
-                    key={reef.id}
-                    icon={coloredBuoyIcon(degreeHeatingDays)}
-                    position={[lat, lng]}
-                  >
-                    <LeafletPopup closeButton={false} className={classes.popup}>
-                      <Popup reef={reef} />
-                    </LeafletPopup>
-                  </Marker>
-                );
-              }
-              return null;
-            })}
-        </Map>
-      )}
-    </>
+  return loading ? (
+    <div className={classes.loading}>
+      <CircularProgress size="10rem" thickness={1} />
+    </div>
+  ) : (
+    <Map
+      maxBoundsViscosity={1.0}
+      className={classes.map}
+      center={INITIAL_CENTER}
+      zoom={INITIAL_ZOOM}
+      minZoom={2}
+    >
+      <TileLayer url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}" />
+      <SofarLayers />
+      <ReefMarkers />
+    </Map>
   );
 };
 
@@ -166,10 +42,6 @@ const styles = () =>
   createStyles({
     map: {
       flex: 1,
-    },
-    popup: {
-      width: "12vw",
-      minWidth: "200px",
     },
     loading: {
       height: "100%",

--- a/packages/website/src/routes/Homepage/Map/markers.tsx
+++ b/packages/website/src/routes/Homepage/Map/markers.tsx
@@ -1,0 +1,73 @@
+import { useDispatch, useSelector } from "react-redux";
+import { LayerGroup, Marker, useLeaflet } from "react-leaflet";
+import React, { useEffect } from "react";
+import { reefsListSelector } from "../../../store/Reefs/reefsListSlice";
+import { Reef } from "../../../store/Reefs/types";
+import {
+  reefOnMapSelector,
+  unsetReefOnMap,
+} from "../../../store/Homepage/homepageSlice";
+import { coloredBuoyIcon } from "./utils";
+import Popup from "./Popup";
+
+/**
+ * Dummy component to listen for changes in the active reef/reefOnMap state and initiate the popup/fly-to. This is a
+ * separate component to prevent trigger any leaflet element re-rendering.
+ */
+const ActiveReefListener = ({ reef }: { reef: Reef }) => {
+  const { map, popupContainer } = useLeaflet();
+  const reefOnMap = useSelector(reefOnMapSelector);
+
+  useEffect(() => {
+    if (
+      map &&
+      popupContainer &&
+      reefOnMap?.polygon.type === "Point" &&
+      reefOnMap.id === reef.id
+    ) {
+      map.flyTo(
+        [reefOnMap.polygon.coordinates[1], reefOnMap.polygon.coordinates[0]],
+        6
+      );
+      popupContainer.openPopup();
+    }
+  }, [reefOnMap, reef.id, map, popupContainer]);
+  return null;
+};
+
+export const ReefMarkers = () => {
+  const reefsList = useSelector(reefsListSelector);
+  const dispatch = useDispatch();
+  const { map } = useLeaflet();
+
+  const setCenter = (latLng: [number, number], zoom: number) =>
+    map?.flyTo(latLng, zoom, { duration: 1 });
+
+  return (
+    <LayerGroup>
+      {reefsList.map((reef: Reef) => {
+        if (reef.polygon.type === "Point") {
+          const [lng, lat] = reef.polygon.coordinates;
+          const { degreeHeatingDays } = reef.latestDailyData || {};
+          return (
+            <Marker
+              onClick={() => {
+                setCenter([lat, lng], 6);
+                dispatch(unsetReefOnMap());
+              }}
+              key={reef.id}
+              icon={coloredBuoyIcon(degreeHeatingDays)}
+              position={[lat, lng]}
+            >
+              <ActiveReefListener reef={reef} />
+              <Popup reef={reef} />
+            </Marker>
+          );
+        }
+        return null;
+      })}
+    </LayerGroup>
+  );
+};
+
+export default ReefMarkers;

--- a/packages/website/src/routes/Homepage/Map/sofarLayers.tsx
+++ b/packages/website/src/routes/Homepage/Map/sofarLayers.tsx
@@ -1,0 +1,47 @@
+import React from "react";
+import { LayersControl, TileLayer } from "react-leaflet";
+
+type SofarLayerDefinition = {
+  name: string;
+  model: string;
+  variableId: string;
+  cmap: string;
+};
+
+const SOFAR_LAYERS: SofarLayerDefinition[] = [
+  {
+    name: "Sea Surface Temperature",
+    model: "HYCOM",
+    variableId: "seaSurfaceTemperature",
+    cmap: "turbo",
+  },
+  {
+    name: "NOAA Degree Heating Week",
+    model: "NOAACoralReefWatch",
+    variableId: "degreeHeatingWeek",
+    cmap: "noaacoral",
+  },
+];
+
+const { REACT_APP_SOFAR_API_TOKEN: API_TOKEN } = process.env;
+
+const sofarUrlFromDef = ({ model, cmap, variableId }: SofarLayerDefinition) =>
+  `https://api.sofarocean.com/marine-weather/v1/models/${model}/tile/{z}/{x}/{y}.png?colormap=${cmap}&token=${API_TOKEN}&variableID=${variableId}`;
+
+export const SofarLayers = () => {
+  return (
+    <LayersControl position="topright">
+      {SOFAR_LAYERS.map((def) => (
+        <LayersControl.Overlay name={def.name} key={def.name}>
+          <TileLayer
+            url={sofarUrlFromDef(def)}
+            key={def.variableId}
+            opacity={0.5}
+          />
+        </LayersControl.Overlay>
+      ))}
+    </LayersControl>
+  );
+};
+
+export default SofarLayers;


### PR DESCRIPTION
This PR improves the performance of the homepage map by eliminating unnecessary re-renders caused by state changing. This is primarily accomplished by refactoring the dependencies into separate components to ensure that any data changes only affect a small list of components.

The `reefOnMap`/active reef logic also was refactored to avoid rendering duplicate `Marker` components.

In testing this results in fairly smooth "flying" behavior. I see a noticeable difference in lag on my computer with dev tools open vs. dev tools closed, which is interesting. Slow internet can also cause some (likely unavoidable) jerkiness as tiles take a little bit to load. Hopefully this PR should improve the situation to acceptable levels though.