### PR TITLE
Add parallelism to Cloud Function Updates

### DIFF
--- a/packages/api/cloud-functions/index.ts
+++ b/packages/api/cloud-functions/index.ts
@@ -58,7 +58,7 @@ exports.dailyUpdate = functions
   });
 
 exports.scheduledDailyUpdate = functions
-  .runWith({ timeoutSeconds: 120 })
+  .runWith({ timeoutSeconds: 540 })
   .pubsub.schedule('every 24 hours')
   .onRun(async () => {
     const dbUrl = functions.config().database.url;

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -51,6 +51,7 @@
     "@nestjs/typeorm": "^7.0.0",
     "axios": "^0.19.2",
     "axios-retry": "^3.1.8",
+    "bluebird": "^3.7.2",
     "class-transformer": "^0.3.1",
     "class-validator": "^0.12.2",
     "firebase-admin": "^9.0.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
     "typeorm-seeding": "ts-node $(yarn bin typeorm-seeding)",
     "seed:config": "yarn typeorm-seeding config",
     "seed:run": "yarn typeorm-seeding seed",
-    "daily-worker": "ts-node -r dotenv/config src/workers/dailyData.ts",
+    "daily-worker": "ts-node -r dotenv/config scripts/daily-update.ts",
     "backfill-data": "ts-node -r dotenv/config scripts/backfill-daily-data.ts",
     "augment-reefs": "ts-node -r dotenv/config scripts/augment-reef-data.ts"
   },

--- a/packages/api/scripts/daily-update.ts
+++ b/packages/api/scripts/daily-update.ts
@@ -1,0 +1,19 @@
+import { createConnection } from 'typeorm';
+import { runDailyUpdate } from '../src/workers/dailyData';
+
+const dbConfig = require('../ormconfig');
+
+async function main() {
+  const conn = await createConnection(dbConfig);
+  try {
+    await runDailyUpdate(conn);
+  } catch (err) {
+    console.error(`Daily data update failed:\n${err}`);
+    process.exit(1);
+  } finally {
+    conn.close();
+  }
+  process.exit(0);
+}
+
+main();

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -2,6 +2,7 @@
 import { isNil, omitBy, sum } from 'lodash';
 import { Connection } from 'typeorm';
 import { Point } from 'geojson';
+import Bluebird from 'bluebird';
 import { Reef } from '../reefs/reefs.entity';
 import { DailyData } from '../reefs/daily-data.entity';
 import { getSofarDailyData, getSpotterData } from '../utils/sofar';
@@ -169,34 +170,41 @@ export async function getReefsDailyData(connection: Connection, date: Date) {
   const reefRepository = connection.getRepository(Reef);
   const dailyDataRepository = connection.getRepository(DailyData);
   const allReefs = await reefRepository.find();
-  // eslint-disable-next-line no-restricted-syntax
-  for (const reef of allReefs) {
-    // eslint-disable-next-line no-await-in-loop
-    const dailyDataInput = await getDailyData(reef, date);
-    const entity = dailyDataRepository.create(dailyDataInput);
-    try {
-      // eslint-disable-next-line no-await-in-loop
-      await dailyDataRepository.save(entity);
-    } catch (err) {
-      // Update instead of insert
-      if (err.constraint === 'no_duplicated_date') {
-        const filteredData = omitBy(entity, isNil);
+  const start = new Date();
+  console.log(`Updating ${allReefs.length} reefs.`);
+  await Bluebird.map(
+    allReefs,
+    async (reef) => {
+      const dailyDataInput = await getDailyData(reef, date);
+      const entity = dailyDataRepository.create(dailyDataInput);
+      try {
+        await dailyDataRepository.save(entity);
+      } catch (err) {
+        // Update instead of insert
+        if (err.constraint === 'no_duplicated_date') {
+          const filteredData = omitBy(entity, isNil);
 
-        dailyDataRepository.update(
-          {
-            reef,
-            date: entity.date,
-          },
-          filteredData,
+          await dailyDataRepository.update(
+            {
+              reef,
+              date: entity.date,
+            },
+            filteredData,
+          );
+          return;
+        }
+        console.error(
+          `Error updating data for Reef ${reef.id} & ${date}: ${err}.`,
         );
-        // eslint-disable-next-line no-continue
-        continue;
       }
-      console.error(
-        `Error updating data for Reef ${reef.id} & ${date}: ${err}.`,
-      );
-    }
-  }
+    },
+    { concurrency: 8 },
+  );
+  console.log(
+    `Updated ${allReefs.length} in ${
+      (new Date().valueOf() - start.valueOf()) / 1000
+    } seconds`,
+  );
 }
 
 /* eslint-disable no-console */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5296,7 +5296,7 @@ bl@^4.0.1:
     inherits "^2.0.4"
     readable-stream "^3.4.0"
 
-bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5:
+bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -8506,6 +8506,14 @@ execa@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/execa/-/execa-0.7.0.tgz#944becd34cc41ee32a63a9faf27ad5a65fc59777"
   integrity sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=
+  dependencies:
+    cross-spawn "^5.0.1"
+    get-stream "^3.0.0"
+    is-stream "^1.1.0"
+    npm-run-path "^2.0.0"
+    p-finally "^1.0.0"
+    signal-exit "^3.0.0"
+    strip-eof "^1.0.0"
 
 execa@^1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6838,6 +6838,15 @@ cross-spawn@7.0.1:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
+cross-spawn@^5.0.1:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
+  integrity sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=
+  dependencies:
+    lru-cache "^4.0.1"
+    shebang-command "^1.2.0"
+    which "^1.2.9"
+
 cross-spawn@^6.0.0, cross-spawn@^6.0.5:
   version "6.0.5"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-6.0.5.tgz#4a5ec7c64dfae22c3a14124dbacdee846d80cbc4"
@@ -12821,7 +12830,7 @@ lowercase-keys@^2.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-2.0.0.tgz#2603e78b7b4b0006cbca2fbcc8a3202558ac9479"
   integrity sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
 
-lru-cache@^4.1.3:
+lru-cache@^4.0.1, lru-cache@^4.1.3:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==


### PR DESCRIPTION
Attempts to speed up daily data updates by adding parallelism to the update process.

In local testing I saw 6-7 seconds per reef update with serial execution.

With 8 concurrent updates I was able to run updates on all 364 reefs in the staging DB in ~260 seconds.