### PR TITLE
Update reef table to use Material UI table

### DIFF
--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -15,7 +15,7 @@ exports[`renders as expected 1`] = `
         <mock-hidden
           xsdown="true"
         >
-          Featured - 
+          Featured Reef
         </mock-hidden>
         <mock-hidden
           smup="true"
@@ -36,7 +36,7 @@ exports[`renders as expected 1`] = `
             position="relative"
           >
             <div
-              class="MuiCardMedia-root SelectedReefCard-cardImage-1"
+              class="MuiCardMedia-root Component-cardImage-3"
               style="background-image: url(reef-image.jpg);"
             />
             <mock-hidden
@@ -74,7 +74,6 @@ exports[`renders as expected 1`] = `
         </div>
         <div
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8 MuiGrid-grid-lg-6"
-          style="margin-bottom: 1rem; max-height: 14rem;"
         >
           <mock-box
             fontweight="400"
@@ -95,7 +94,7 @@ exports[`renders as expected 1`] = `
           style="display: flex;"
         >
           <div
-            class="SelectedReefCard-metricsContainer-2"
+            class="Component-metricsContainer-4"
           >
             <div>
               <mock-typography
@@ -183,7 +182,7 @@ exports[`renders loading as expected 1`] = `
         <mock-hidden
           xsdown="true"
         >
-          Featured - 
+          Featured Reef
         </mock-hidden>
         <mock-hidden
           smup="true"

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.test.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.test.tsx
@@ -1,6 +1,8 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
+import configureStore from "redux-mock-store";
+import { Provider } from "react-redux";
 
 import SelectedReefCard from ".";
 import { Reef } from "../../../../store/Reefs/types";
@@ -14,96 +16,70 @@ jest.mock("react-chartjs-2", () => ({
   },
 }));
 
+const mockStore = configureStore([]);
+
+const store = mockStore({
+  selectedReef: {
+    details: {
+      id: 2,
+      name: "",
+      polygon: {
+        coordinates: [0, 0],
+        type: "Point",
+      },
+      maxMonthlyMean: 0,
+      depth: 0,
+      status: 0,
+      videoStream: null,
+      region: "",
+      admin: null,
+      stream: null,
+      dailyData: [
+        {
+          id: 171,
+          date: "2020-07-01T16:40:19.842Z",
+          minBottomTemperature: 37,
+          maxBottomTemperature: 39,
+          avgBottomTemperature: 38,
+          degreeHeatingDays: 34,
+          surfaceTemperature: 29,
+          satelliteTemperature: 23,
+          minWaveHeight: 2,
+          maxWaveHeight: 4,
+          avgWaveHeight: 3,
+          waveDirection: 205,
+          wavePeriod: 28,
+          minWindSpeed: 3,
+          maxWindSpeed: 5,
+          avgWindSpeed: 4,
+          windDirection: 229,
+        },
+      ],
+    },
+  },
+});
+
 test("renders as expected", () => {
   process.env.REACT_APP_FEATURED_REEF_ID = "2";
-  const reef: Reef = {
-    id: 2,
-    name: "",
-    polygon: {
-      coordinates: [0, 0],
-      type: "Point",
-    },
-    maxMonthlyMean: 0,
-    depth: 0,
-    status: 0,
-    videoStream: null,
-    region: "",
-    admin: null,
-    stream: null,
-    dailyData: [
-      {
-        id: 171,
-        date: "2020-07-01T16:40:19.842Z",
-        minBottomTemperature: 37,
-        maxBottomTemperature: 39,
-        avgBottomTemperature: 38,
-        degreeHeatingDays: 34,
-        surfaceTemperature: 29,
-        satelliteTemperature: 23,
-        minWaveHeight: 2,
-        maxWaveHeight: 4,
-        avgWaveHeight: 3,
-        waveDirection: 205,
-        wavePeriod: 28,
-        minWindSpeed: 3,
-        maxWindSpeed: 5,
-        avgWindSpeed: 4,
-        windDirection: 229,
-      },
-    ],
-  };
 
   const { container } = render(
-    <Router>
-      <SelectedReefCard reef={reef} />
-    </Router>
+    <Provider store={store}>
+      <Router>
+        <SelectedReefCard />
+      </Router>
+    </Provider>
   );
   expect(container).toMatchSnapshot();
 });
 
 test("renders loading as expected", () => {
   process.env.REACT_APP_FEATURED_REEF_ID = "4";
-  const reef: Reef = {
-    id: 2,
-    name: "",
-    polygon: {
-      coordinates: [0, 0],
-      type: "Point",
-    },
-    maxMonthlyMean: 0,
-    depth: 0,
-    status: 0,
-    videoStream: null,
-    region: "",
-    admin: null,
-    stream: null,
-    dailyData: [
-      {
-        id: 171,
-        date: "2020-07-01T16:40:19.842Z",
-        minBottomTemperature: 37,
-        maxBottomTemperature: 39,
-        avgBottomTemperature: 38,
-        degreeHeatingDays: 34,
-        surfaceTemperature: 29,
-        satelliteTemperature: 23,
-        minWaveHeight: 2,
-        maxWaveHeight: 4,
-        avgWaveHeight: 3,
-        waveDirection: 205,
-        wavePeriod: 28,
-        minWindSpeed: 3,
-        maxWindSpeed: 5,
-        avgWindSpeed: 4,
-        windDirection: 229,
-      },
-    ],
-  };
-
   const { container } = render(
-    <Router>
-      <SelectedReefCard reef={reef} />
-    </Router>
+    <Provider store={store}>
+      <Router>
+        <SelectedReefCard />
+      </Router>
+    </Provider>
   );
   expect(container).toMatchSnapshot();
 });

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -15,15 +15,22 @@ import {
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
 
+import { useSelector } from "react-redux";
 import CardChart from "./cardChart";
-import { Reef } from "../../../../store/Reefs/types";
 import { sortDailyData } from "../../../../helpers/sortDailyData";
 import { formatNumber } from "../../../../helpers/numberUtils";
 
 import reefImage from "../../../../assets/reef-image.jpg";
 import { degreeHeatingWeeksCalculator } from "../../../../helpers/degreeHeatingWeeks";
+import { reefDetailsSelector } from "../../../../store/Reefs/selectedReefSlice";
 
-const SelectedReefCard = ({ classes, reef }: SelectedReefCardProps) => {
+const SelectedReefCard = ({ classes }: SelectedReefCardProps) => {
+  const reef = useSelector(reefDetailsSelector);
+
+  if (!reef) {
+    return null;
+  }
+
   const sortByDate = sortDailyData(reef.dailyData);
   const dailyDataLen = sortByDate.length;
   const {
@@ -185,11 +192,6 @@ const styles = (theme: Theme) =>
     },
   });
 
-interface selectedReefCardIncomingProps {
-  reef: Reef;
-}
-
-type SelectedReefCardProps = selectedReefCardIncomingProps &
-  WithStyles<typeof styles>;
+type SelectedReefCardProps = WithStyles<typeof styles>;
 
 export default withStyles(styles)(SelectedReefCard);

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -23,145 +23,7 @@ import { formatNumber } from "../../../../helpers/numberUtils";
 import reefImage from "../../../../assets/reef-image.jpg";
 import { degreeHeatingWeeksCalculator } from "../../../../helpers/degreeHeatingWeeks";
 import { reefDetailsSelector } from "../../../../store/Reefs/selectedReefSlice";
-
-const SelectedReefCard = ({ classes }: SelectedReefCardProps) => {
-  const reef = useSelector(reefDetailsSelector);
-
-  if (!reef) {
-    return null;
-  }
-
-  const sortByDate = sortDailyData(reef.dailyData);
-  const dailyDataLen = sortByDate.length;
-  const {
-    maxBottomTemperature,
-    surfaceTemperature,
-    satelliteTemperature,
-    degreeHeatingDays,
-  } = sortByDate[dailyDataLen - 1];
-
-  const surfTemp = surfaceTemperature || satelliteTemperature;
-
-  const featuredReefId = process.env.REACT_APP_FEATURED_REEF_ID || "";
-
-  if (!featuredReefId) {
-    return null;
-  }
-
-  const metrics = [
-    {
-      label: "SURFACE TEMP",
-      value: `${formatNumber(surfTemp, 1)}`,
-      unit: "\u2103",
-    },
-    {
-      label: `TEMP AT ${reef.depth}M`,
-      value: `${formatNumber(maxBottomTemperature, 1)}`,
-      unit: "\u2103",
-    },
-    {
-      label: "HEAT STRESS",
-      value: `${formatNumber(
-        degreeHeatingWeeksCalculator(degreeHeatingDays),
-        1
-      )}`,
-      unit: "DHW",
-    },
-  ];
-
-  return (
-    <Box p={1}>
-      <Box mb={2}>
-        <Typography variant="h5" color="textSecondary">
-          <Hidden xsDown>{`Featured ${
-            reef.name ? `- ${reef.name}` : "Reef"
-          }`}</Hidden>
-          <Hidden smUp>Featured Reef</Hidden>
-        </Typography>
-      </Box>
-
-      <Card>
-        {`${reef.id}` === featuredReefId ? (
-          <Grid container spacing={1}>
-            <Grid item xs={12} sm={4} lg={3}>
-              <Box position="relative" height="100%">
-                <CardMedia className={classes.cardImage} image={reefImage} />
-
-                <Hidden smUp>
-                  <Box position="absolute" top={16} left={16}>
-                    <Typography variant="h5">{reef.name}</Typography>
-
-                    {reef.region?.name && (
-                      <Typography variant="h6" style={{ fontWeight: 400 }}>
-                        {reef.region.name}
-                      </Typography>
-                    )}
-                  </Box>
-                </Hidden>
-
-                <Box position="absolute" bottom={16} right={16}>
-                  <Link
-                    style={{ color: "inherit", textDecoration: "none" }}
-                    to={`/reefs/${reef.id}`}
-                  >
-                    <Button size="small" variant="contained" color="primary">
-                      EXPLORE
-                    </Button>
-                  </Link>
-                </Box>
-              </Box>
-            </Grid>
-
-            <Grid item xs={12} sm={8} lg={6}>
-              <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
-                <Typography color="textSecondary" variant="subtitle1">
-                  MEAN DAILY SURFACE TEMP. (C&deg;)
-                </Typography>
-              </Box>
-              <CardChart
-                dailyData={reef.dailyData}
-                temperatureThreshold={
-                  reef.maxMonthlyMean ? reef.maxMonthlyMean + 1 : null
-                }
-                maxMonthlyMean={reef.maxMonthlyMean || null}
-              />
-            </Grid>
-
-            <Grid
-              item
-              xs={12}
-              lg={3}
-              style={{
-                display: "flex",
-              }}
-            >
-              <div className={classes.metricsContainer}>
-                {metrics.map(({ label, value, unit }) => (
-                  <div key={label}>
-                    <Typography variant="caption" color="textSecondary">
-                      {label}
-                    </Typography>
-                    <Typography variant="h4" color="primary">
-                      {value}
-                      &nbsp;
-                      <Typography variant="h6" component="span">
-                        {unit}
-                      </Typography>
-                    </Typography>
-                  </div>
-                ))}
-              </div>
-            </Grid>
-          </Grid>
-        ) : (
-          <Box textAlign="center" p={4}>
-            <CircularProgress size="6rem" thickness={1} />
-          </Box>
-        )}
-      </Card>
-    </Box>
-  );
-};
+import { Reef } from "../../../../store/Reefs/types";
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -188,6 +50,145 @@ const styles = (theme: Theme) =>
     },
   });
 
-type SelectedReefCardProps = WithStyles<typeof styles>;
+type SelectedReefContentProps = WithStyles<typeof styles> & { reef: Reef };
+
+const SelectedReefContent = withStyles(styles)(
+  ({ classes, reef }: SelectedReefContentProps) => {
+    const sortByDate = sortDailyData(reef.dailyData);
+    const dailyDataLen = sortByDate.length;
+    const {
+      maxBottomTemperature,
+      surfaceTemperature,
+      satelliteTemperature,
+      degreeHeatingDays,
+    } = sortByDate[dailyDataLen - 1];
+
+    const surfTemp = surfaceTemperature || satelliteTemperature;
+
+    const metrics = [
+      {
+        label: "SURFACE TEMP",
+        value: `${formatNumber(surfTemp, 1)}`,
+        unit: "\u2103",
+      },
+      {
+        label: `TEMP AT ${reef.depth}M`,
+        value: `${formatNumber(maxBottomTemperature, 1)}`,
+        unit: "\u2103",
+      },
+      {
+        label: "HEAT STRESS",
+        value: `${formatNumber(
+          degreeHeatingWeeksCalculator(degreeHeatingDays),
+          1
+        )}`,
+        unit: "DHW",
+      },
+    ];
+
+    return (
+      <Grid container spacing={1}>
+        <Grid item xs={12} sm={4} lg={3}>
+          <Box position="relative" height="100%">
+            <CardMedia className={classes.cardImage} image={reefImage} />
+
+            <Hidden smUp>
+              <Box position="absolute" top={16} left={16}>
+                <Typography variant="h5">{reef.name}</Typography>
+
+                {reef.region?.name && (
+                  <Typography variant="h6" style={{ fontWeight: 400 }}>
+                    {reef.region.name}
+                  </Typography>
+                )}
+              </Box>
+            </Hidden>
+
+            <Box position="absolute" bottom={16} right={16}>
+              <Link
+                style={{ color: "inherit", textDecoration: "none" }}
+                to={`/reefs/${reef.id}`}
+              >
+                <Button size="small" variant="contained" color="primary">
+                  EXPLORE
+                </Button>
+              </Link>
+            </Box>
+          </Box>
+        </Grid>
+
+        <Grid item xs={12} sm={8} lg={6}>
+          <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
+            <Typography color="textSecondary" variant="subtitle1">
+              MEAN DAILY SURFACE TEMP. (C&deg;)
+            </Typography>
+          </Box>
+          <CardChart
+            dailyData={reef.dailyData}
+            temperatureThreshold={
+              reef.maxMonthlyMean ? reef.maxMonthlyMean + 1 : null
+            }
+            maxMonthlyMean={reef.maxMonthlyMean || null}
+          />
+        </Grid>
+
+        <Grid
+          item
+          xs={12}
+          lg={3}
+          style={{
+            display: "flex",
+          }}
+        >
+          <div className={classes.metricsContainer}>
+            {metrics.map(({ label, value, unit }) => (
+              <div key={label}>
+                <Typography variant="caption" color="textSecondary">
+                  {label}
+                </Typography>
+                <Typography variant="h4" color="primary">
+                  {value}
+                  &nbsp;
+                  <Typography variant="h6" component="span">
+                    {unit}
+                  </Typography>
+                </Typography>
+              </div>
+            ))}
+          </div>
+        </Grid>
+      </Grid>
+    );
+  }
+);
+
+const SelectedReefCard = () => {
+  const reef = useSelector(reefDetailsSelector);
+
+  const featuredReefId = process.env.REACT_APP_FEATURED_REEF_ID || "";
+
+  return featuredReefId ? (
+    <Box p={1}>
+      <Box mb={2}>
+        <Typography variant="h5" color="textSecondary">
+          <Hidden xsDown>{`Featured ${
+            reef?.name ? `- ${reef.name}` : "Reef"
+          }`}</Hidden>
+          <Hidden smUp>Featured Reef</Hidden>
+        </Typography>
+      </Box>
+
+      <Card>
+        {reef && `${reef?.id}` === featuredReefId ? (
+          <SelectedReefContent reef={reef} />
+        ) : (
+          <Box textAlign="center" p={4}>
+            <CircularProgress size="6rem" thickness={1} />
+          </Box>
+        )}
+      </Card>
+    </Box>
+  ) : null;
+};
 
 export default withStyles(styles)(SelectedReefCard);

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -73,7 +73,9 @@ const SelectedReefCard = ({ classes }: SelectedReefCardProps) => {
     <Box p={1}>
       <Box mb={2}>
         <Typography variant="h5" color="textSecondary">
-          <Hidden xsDown>{`Featured - ${reef.name}`}</Hidden>
+          <Hidden xsDown>{`Featured ${
+            reef.name ? `- ${reef.name}` : "Reef"
+          }`}</Hidden>
           <Hidden smUp>Featured Reef</Hidden>
         </Typography>
       </Box>
@@ -110,13 +112,7 @@ const SelectedReefCard = ({ classes }: SelectedReefCardProps) => {
               </Box>
             </Grid>
 
-            <Grid
-              item
-              xs={12}
-              sm={8}
-              lg={6}
-              style={{ marginBottom: "1rem", maxHeight: "14rem" }}
-            >
+            <Grid item xs={12} sm={8} lg={6}>
               <Box pb="0.5rem" pl="0.5rem" fontWeight={400}>
                 <Typography color="textSecondary" variant="subtitle1">
                   MEAN DAILY SURFACE TEMP. (C&deg;)

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -34,8 +34,11 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
       All Reefs
     </mock-typography>
   </mock-hidden>
-  <div
-    class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+  <mock-selectedreefcard />
+  <mock-box
+    display="flex"
+    flex="1"
+    flexdirection="column"
   >
     <mock-tablecontainer>
       <mock-table>
@@ -46,9 +49,11 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             <mock-tablecell
               align="center"
               padding="none"
+              sortdirection="asc"
             >
               <mock-tablesortlabel
                 active="true"
+                direction="asc"
               >
                 <mock-typography
                   style="color: black;"
@@ -135,17 +140,12 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               padding="default"
               sortdirection="false"
             >
-              <mock-tablesortlabel
-                active="false"
-                direction="asc"
+              <mock-typography
+                style="color: black;"
+                variant="h6"
               >
-                <mock-typography
-                  style="color: black;"
-                  variant="h6"
-                >
-                  ALERT
-                </mock-typography>
-              </mock-tablesortlabel>
+                ALERT
+              </mock-typography>
             </mock-tablecell>
           </mock-tablerow>
         </mock-tablehead>
@@ -214,6 +214,6 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
         </mock-tablebody>
       </mock-table>
     </mock-tablecontainer>
-  </div>
+  </mock-box>
 </div>
 `;

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -160,7 +160,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
           >
             <mock-tablecell>
               <mock-typography
-                align="center"
+                align="left"
                 color="textSecondary"
                 variant="subtitle1"
               >

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -37,243 +37,184 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
   <div
     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
   >
-    <div
-      class="MuiPaper-root MuiPaper-elevation0 MuiPaper-rounded"
-      style="position: relative;"
-    >
-      <div
-        class="Component-horizontalScrollContainer-5"
-        style="overflow-x: auto; position: relative;"
-      >
-        <div>
-          <div
-            style="overflow-y: auto;"
-          >
-            <div>
-              <mock-table
-                style="table-layout: auto;"
+    <mock-tablecontainer>
+      <mock-table>
+        <mock-tablehead>
+          <mock-tablerow>
+            <mock-tablecell
+              align="left"
+              padding="none"
+            >
+              <mock-tablesortlabel
+                active="true"
               >
-                <mock-tablehead>
-                  <mock-tablerow>
-                    <mock-tablecell
-                      align="left"
-                      classname="MTableHeader-header-6"
-                      size="medium"
-                      style="background-color: rgb(202, 203, 209); color: black; text-align: left; box-sizing: border-box;"
-                    >
-                      <mock-tablesortlabel
-                        active="false"
-                        direction="asc"
-                        iconcomponent="[object Object]"
-                      >
-                        <div
-                          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                          data-rbd-drag-handle-context-id="0"
-                          data-rbd-drag-handle-draggable-id="0"
-                          data-rbd-draggable-context-id="0"
-                          data-rbd-draggable-id="0"
-                          draggable="false"
-                          role="button"
-                          tabindex="0"
-                        >
-                          REEF
-                        </div>
-                      </mock-tablesortlabel>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      classname="MTableHeader-header-6"
-                      size="medium"
-                      style="background-color: rgb(202, 203, 209); color: black; text-align: left; box-sizing: border-box;"
-                    >
-                      <mock-tablesortlabel
-                        active="false"
-                        direction="asc"
-                        iconcomponent="[object Object]"
-                      >
-                        <div
-                          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                          data-rbd-drag-handle-context-id="0"
-                          data-rbd-drag-handle-draggable-id="1"
-                          data-rbd-draggable-context-id="0"
-                          data-rbd-draggable-id="1"
-                          draggable="false"
-                          role="button"
-                          tabindex="0"
-                        >
-                          TEMP
-                        </div>
-                      </mock-tablesortlabel>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      classname="MTableHeader-header-6"
-                      size="medium"
-                      style="background-color: rgb(202, 203, 209); color: black; text-align: left; box-sizing: border-box;"
-                    >
-                      <mock-tablesortlabel
-                        active="false"
-                        direction="asc"
-                        iconcomponent="[object Object]"
-                      >
-                        <div
-                          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                          data-rbd-drag-handle-context-id="0"
-                          data-rbd-drag-handle-draggable-id="2"
-                          data-rbd-draggable-context-id="0"
-                          data-rbd-draggable-id="2"
-                          draggable="false"
-                          role="button"
-                          tabindex="0"
-                        >
-                          DEPTH
-                        </div>
-                      </mock-tablesortlabel>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      classname="MTableHeader-header-6"
-                      size="medium"
-                      style="background-color: rgb(202, 203, 209); color: black; text-align: left; box-sizing: border-box;"
-                    >
-                      <mock-tablesortlabel
-                        active="false"
-                        direction="asc"
-                        iconcomponent="[object Object]"
-                      >
-                        <div
-                          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                          data-rbd-drag-handle-context-id="0"
-                          data-rbd-drag-handle-draggable-id="3"
-                          data-rbd-draggable-context-id="0"
-                          data-rbd-draggable-id="3"
-                          draggable="false"
-                          role="button"
-                          tabindex="0"
-                        >
-                          DHW
-                        </div>
-                      </mock-tablesortlabel>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="left"
-                      classname="MTableHeader-header-6"
-                      size="medium"
-                      style="background-color: rgb(202, 203, 209); color: black; text-align: left; box-sizing: border-box;"
-                    >
-                      <mock-tablesortlabel
-                        active="false"
-                        direction="asc"
-                        iconcomponent="[object Object]"
-                      >
-                        <div
-                          aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                          data-rbd-drag-handle-context-id="0"
-                          data-rbd-drag-handle-draggable-id="4"
-                          data-rbd-draggable-context-id="0"
-                          data-rbd-draggable-id="4"
-                          draggable="false"
-                          role="button"
-                          tabindex="0"
-                        >
-                          ALERT
-                        </div>
-                      </mock-tablesortlabel>
-                    </mock-tablecell>
-                  </mock-tablerow>
-                </mock-tablehead>
-                <mock-tablebody>
-                  <mock-tablerow
-                    hover="true"
-                    index="0"
-                    level="0"
-                    path="0"
-                    selected="false"
-                    style="transition: all ease 300ms; cursor: pointer;"
+                <mock-typography
+                  style="color: black;"
+                  variant="h6"
+                >
+                  REEF
+                </mock-typography>
+                <span>
+                  sorted ascending
+                </span>
+              </mock-tablesortlabel>
+            </mock-tablecell>
+            <mock-tablecell
+              align="left"
+              padding="default"
+              sortdirection="false"
+            >
+              <mock-tablesortlabel
+                active="false"
+                direction="asc"
+              >
+                <mock-typography
+                  style="color: black;"
+                  variant="h6"
+                >
+                  TEMP
+                  <mock-typography
+                    component="span"
+                    style="color: black;"
+                    variant="subtitle2"
                   >
-                    <mock-tablecell
-                      align="left"
-                      size="medium"
-                      style="color: black; box-sizing: border-box; font-size: inherit; font-family: inherit; font-weight: inherit; align-items: center; text-align: left;"
-                      value="Mock Reef Hartmann"
-                    >
-                      <mock-typography
-                        align="left"
-                        color="textSecondary"
-                        style="padding-right: 1.5rem;"
-                        variant="subtitle1"
-                      >
-                        Mock Reef Hartmann
-                      </mock-typography>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      size="medium"
-                      style="color: black; box-sizing: border-box; font-size: inherit; font-family: inherit; font-weight: inherit; align-items: center; text-align: left;"
-                      value="- -"
-                    >
-                      <mock-typography
-                        style="color: rgb(22, 141, 189); padding-left: 1rem;"
-                        variant="h6"
-                      >
-                        - -
-                        ℃
-                      </mock-typography>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      size="medium"
-                      style="color: black; box-sizing: border-box; font-size: inherit; font-family: inherit; font-weight: inherit; align-items: center; text-align: left;"
-                      value="19"
-                    >
-                      <mock-typography
-                        color="textSecondary"
-                        style="padding-left: 2rem;"
-                        variant="subtitle1"
-                      >
-                        19
-                         m
-                      </mock-typography>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="right"
-                      size="medium"
-                      style="color: black; box-sizing: border-box; font-size: inherit; font-family: inherit; font-weight: inherit; align-items: center; text-align: left;"
-                      value="2.857142857142857"
-                    >
-                      <mock-typography
-                        style="padding-left: 2rem; color: rgb(12, 157, 165);"
-                        variant="subtitle1"
-                      >
-                        2.9
-                      </mock-typography>
-                    </mock-tablecell>
-                    <mock-tablecell
-                      align="left"
-                      size="medium"
-                      style="color: black; box-sizing: border-box; font-size: inherit; font-family: inherit; font-weight: inherit; align-items: center; text-align: left;"
-                      value="2.857142857142857"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        class="MuiSvgIcon-root"
-                        focusable="false"
-                        style="color: rgb(12, 157, 165); padding-left: 1rem;"
-                        viewBox="0 0 24 24"
-                      >
-                        <path
-                          d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
-                        />
-                      </svg>
-                    </mock-tablecell>
-                  </mock-tablerow>
-                </mock-tablebody>
-              </mock-table>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+                      (°C)
+                  </mock-typography>
+                </mock-typography>
+              </mock-tablesortlabel>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+              padding="default"
+              sortdirection="false"
+            >
+              <mock-tablesortlabel
+                active="false"
+                direction="asc"
+              >
+                <mock-typography
+                  style="color: black;"
+                  variant="h6"
+                >
+                  DEPTH
+                  <mock-typography
+                    component="span"
+                    style="color: black;"
+                    variant="subtitle2"
+                  >
+                      (m)
+                  </mock-typography>
+                </mock-typography>
+              </mock-tablesortlabel>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+              padding="default"
+              sortdirection="false"
+            >
+              <mock-tablesortlabel
+                active="false"
+                direction="asc"
+              >
+                <mock-typography
+                  style="color: black;"
+                  variant="h6"
+                >
+                  STRESS
+                  <mock-typography
+                    component="span"
+                    style="color: black;"
+                    variant="subtitle2"
+                  >
+                      (DHW)
+                  </mock-typography>
+                </mock-typography>
+              </mock-tablesortlabel>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+              padding="default"
+              sortdirection="false"
+            >
+              <mock-tablesortlabel
+                active="false"
+                direction="asc"
+              >
+                <mock-typography
+                  style="color: black;"
+                  variant="h6"
+                >
+                  ALERT
+                </mock-typography>
+              </mock-tablesortlabel>
+            </mock-tablecell>
+          </mock-tablerow>
+        </mock-tablehead>
+        <mock-tablebody>
+          <mock-tablerow
+            hover="true"
+            role="button"
+            style="background-color: white; cursor: pointer;"
+            tabindex="-1"
+          >
+            <mock-tablecell>
+              <mock-typography
+                align="left"
+                color="textSecondary"
+                variant="subtitle1"
+              >
+                Mock Reef Hartmann
+              </mock-typography>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+            >
+              <mock-typography
+                style="color: rgb(22, 141, 189);"
+                variant="subtitle1"
+              >
+                - -
+              </mock-typography>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+            >
+              <mock-typography
+                color="textSecondary"
+                variant="subtitle1"
+              >
+                19
+              </mock-typography>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+            >
+              <mock-typography
+                style="color: rgb(12, 157, 165);"
+                variant="subtitle1"
+              >
+                2.9
+              </mock-typography>
+            </mock-tablecell>
+            <mock-tablecell
+              align="right"
+            >
+              <svg
+                aria-hidden="true"
+                class="MuiSvgIcon-root"
+                focusable="false"
+                style="color: rgb(12, 157, 165); margin-right: 1rem;"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm1 15h-2v-2h2v2zm0-4h-2V7h2v6z"
+                />
+              </svg>
+            </mock-tablecell>
+          </mock-tablerow>
+        </mock-tablebody>
+      </mock-table>
+    </mock-tablecontainer>
   </div>
 </div>
 `;

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -43,13 +43,14 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
     <mock-tablecontainer>
       <mock-table>
         <mock-tablehead
-          style="background-color: rgb(202, 203, 209);"
+          style="background-color: rgb(244, 244, 244);"
         >
           <mock-tablerow>
             <mock-tablecell
-              align="center"
-              padding="none"
+              align="left"
+              padding="default"
               sortdirection="asc"
+              width="30%"
             >
               <mock-tablesortlabel
                 active="true"
@@ -139,6 +140,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               align="center"
               padding="default"
               sortdirection="false"
+              width="10%"
             >
               <mock-typography
                 style="color: black;"
@@ -202,7 +204,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
                 aria-hidden="true"
                 class="MuiSvgIcon-root"
                 focusable="false"
-                style="color: rgb(12, 157, 165); margin-right: 1rem;"
+                style="color: rgb(12, 157, 165);"
                 viewBox="0 0 24 24"
               >
                 <path

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -39,10 +39,12 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
   >
     <mock-tablecontainer>
       <mock-table>
-        <mock-tablehead>
+        <mock-tablehead
+          style="background-color: rgb(202, 203, 209);"
+        >
           <mock-tablerow>
             <mock-tablecell
-              align="left"
+              align="center"
               padding="none"
             >
               <mock-tablesortlabel
@@ -54,13 +56,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
                 >
                   REEF
                 </mock-typography>
-                <span>
-                  sorted ascending
-                </span>
               </mock-tablesortlabel>
             </mock-tablecell>
             <mock-tablecell
-              align="left"
+              align="center"
               padding="default"
               sortdirection="false"
             >
@@ -84,7 +83,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablesortlabel>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
               padding="default"
               sortdirection="false"
             >
@@ -108,7 +107,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablesortlabel>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
               padding="default"
               sortdirection="false"
             >
@@ -132,7 +131,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablesortlabel>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
               padding="default"
               sortdirection="false"
             >
@@ -159,7 +158,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
           >
             <mock-tablecell>
               <mock-typography
-                align="left"
+                align="center"
                 color="textSecondary"
                 variant="subtitle1"
               >
@@ -167,7 +166,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
             >
               <mock-typography
                 style="color: rgb(22, 141, 189);"
@@ -177,7 +176,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
             >
               <mock-typography
                 color="textSecondary"
@@ -187,7 +186,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
             >
               <mock-typography
                 style="color: rgb(12, 157, 165);"
@@ -197,7 +196,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              align="right"
+              align="center"
             >
               <svg
                 aria-hidden="true"

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -83,7 +83,6 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
               <ErrorIcon
                 style={{
                   color: colorFinder(reef.dhw),
-                  marginRight: "1rem",
                 }}
               />
             </TableCell>

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -31,7 +31,7 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
       {stableSort<Row>(
         constructTableData(reefsList),
         getComparator(order, orderBy)
-      ).map((reef, index) => {
+      ).map((reef) => {
         return (
           <TableRow
             hover

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -49,7 +49,7 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
           >
             <TableCell>
               <Typography
-                align="center"
+                align="left"
                 variant="subtitle1"
                 color="textSecondary"
               >

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -45,8 +45,7 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
             onClick={(event) => handleClick(event, reef)}
             role="button"
             tabIndex={-1}
-            // eslint-disable-next-line react/no-array-index-key
-            key={`${reef.locationName}-${index}`}
+            key={reef.tableData.id}
           >
             <TableCell>
               <Typography

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -1,0 +1,98 @@
+import { TableBody, TableCell, TableRow, Typography } from "@material-ui/core";
+import ErrorIcon from "@material-ui/icons/Error";
+import React, { useState } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { TableRow as Row } from "../../../store/Homepage/types";
+import { constructTableData } from "../../../store/Reefs/helpers";
+import { colors } from "../../../layout/App/theme";
+import { colorFinder } from "../../../helpers/degreeHeatingWeeks";
+import { formatNumber } from "../../../helpers/numberUtils";
+import { reefsListSelector } from "../../../store/Reefs/reefsListSlice";
+import { setReefOnMap } from "../../../store/Homepage/homepageSlice";
+import { getComparator, Order, OrderKeys, stableSort } from "./utils";
+
+type ReefTableBodyProps = {
+  order: Order;
+  orderBy: OrderKeys;
+};
+
+const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
+  const dispatch = useDispatch();
+  const reefsList = useSelector(reefsListSelector);
+  const [selectedRow, setSelectedRow] = useState<number>();
+
+  const handleClick = (event: unknown, reef: Row) => {
+    setSelectedRow(reef.tableData.id);
+    dispatch(setReefOnMap(reefsList[reef.tableData.id]));
+  };
+
+  return (
+    <TableBody>
+      {stableSort<Row>(
+        constructTableData(reefsList),
+        getComparator(order, orderBy)
+      ).map((reef, index) => {
+        return (
+          <TableRow
+            hover
+            style={{
+              backgroundColor:
+                reef.tableData.id === selectedRow
+                  ? colors.lighterBlue
+                  : "white",
+              cursor: "pointer",
+            }}
+            onClick={(event) => handleClick(event, reef)}
+            role="button"
+            tabIndex={-1}
+            // eslint-disable-next-line react/no-array-index-key
+            key={`${reef.locationName}-${index}`}
+          >
+            <TableCell>
+              <Typography
+                align="center"
+                variant="subtitle1"
+                color="textSecondary"
+              >
+                {reef.locationName}
+              </Typography>
+            </TableCell>
+            <TableCell align="center">
+              <Typography
+                style={{ color: colors.lightBlue }}
+                variant="subtitle1"
+              >
+                {formatNumber(reef.temp, 1)}
+              </Typography>
+            </TableCell>
+            <TableCell align="center">
+              <Typography variant="subtitle1" color="textSecondary">
+                {reef.depth}
+              </Typography>
+            </TableCell>
+            <TableCell align="center">
+              <Typography
+                style={{
+                  color: reef.dhw ? `${colorFinder(reef.dhw)}` : "black",
+                }}
+                variant="subtitle1"
+              >
+                {formatNumber(reef.dhw, 1)}
+              </Typography>
+            </TableCell>
+            <TableCell align="center">
+              <ErrorIcon
+                style={{
+                  color: colorFinder(reef.dhw),
+                  marginRight: "1rem",
+                }}
+              />
+            </TableCell>
+          </TableRow>
+        );
+      })}
+    </TableBody>
+  );
+};
+
+export default ReefTableBody;

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -1,30 +1,67 @@
-import React, { CSSProperties, forwardRef, useState } from "react";
+import React, { useState } from "react";
 import { useSelector, useDispatch } from "react-redux";
-import MaterialTable, { Column } from "material-table";
-import { Grid, Paper, Typography, IconButton, Hidden } from "@material-ui/core";
+
+import {
+  Grid,
+  Typography,
+  IconButton,
+  Hidden,
+  TableContainer,
+  Table,
+  TableBody,
+  TableRow,
+  TableCell,
+} from "@material-ui/core";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import ErrorIcon from "@material-ui/icons/Error";
 
 import SelectedReefCard from "./SelectedReefCard";
 import { reefsListSelector } from "../../../store/Reefs/reefsListSlice";
+import { constructTableData } from "../../../store/Reefs/helpers";
+import { colors } from "../../../layout/App/theme";
 import { reefDetailsSelector } from "../../../store/Reefs/selectedReefSlice";
 import { setReefOnMap } from "../../../store/Homepage/homepageSlice";
-import { colors } from "../../../layout/App/theme";
+import type { TableRow as Row } from "../../../store/Homepage/types";
 import { formatNumber } from "../../../helpers/numberUtils";
-import {
-  colorFinder,
-  degreeHeatingWeeksCalculator,
-} from "../../../helpers/degreeHeatingWeeks";
+import { colorFinder } from "../../../helpers/degreeHeatingWeeks";
+import type { Order } from "./types";
+import EnhancedTableHead from "./tableHead";
 
-interface Row {
-  locationName: string | null;
-  temp?: string | 0;
-  depth: number | null;
-  dhw: number | null;
-  tableData: {
-    id: number;
-  };
+function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
+  if (b[orderBy] < a[orderBy]) {
+    return -1;
+  }
+  if (b[orderBy] > a[orderBy]) {
+    return 1;
+  }
+  return 0;
+}
+
+function getComparator(
+  order: Order,
+  orderBy: "locationName" | "temp" | "depth" | "dhw"
+): (
+  a: {
+    [key in "locationName" | "temp" | "depth" | "dhw"]: number | string | null;
+  },
+  b: {
+    [key in "locationName" | "temp" | "depth" | "dhw"]: number | string | null;
+  }
+) => number {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+function stableSort<T>(array: T[], comparator: (a: T, b: T) => number) {
+  const stabilizedThis = array.map((el, index) => [el, index] as [T, number]);
+  stabilizedThis.sort((a, b) => {
+    const order = comparator(a[0], b[0]);
+    if (order !== 0) return order;
+    return a[1] - b[1];
+  });
+  return stabilizedThis.map((el) => el[0]);
 }
 
 const ReefTable = ({ openDrawer }: ReefTableProps) => {
@@ -32,108 +69,28 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
   const selectedReef = useSelector(reefDetailsSelector);
   const dispatch = useDispatch();
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
+  const [order, setOrder] = useState<Order>(undefined);
+  const [orderBy, setOrderBy] = useState<
+    "locationName" | "temp" | "depth" | "dhw"
+  >("locationName");
 
-  const headerStyle: CSSProperties = {
-    backgroundColor: "#cacbd1",
-    color: "black",
-    textAlign: "left",
+  const handleClick = (
+    event: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
+    reef: Row
+  ) => {
+    console.log(reef.tableData.id);
+    setSelectedRow(reef.tableData.id);
+    dispatch(setReefOnMap(reefsList[reef.tableData.id]));
   };
 
-  const cellStyle: CSSProperties = {
-    color: "black",
-    alignItems: "center",
-    textAlign: "left",
+  const handleRequestSort = (
+    event: React.MouseEvent<unknown>,
+    property: "locationName" | "temp" | "depth" | "dhw"
+  ) => {
+    const isAsc = orderBy === property && order === "asc";
+    setOrder(isAsc ? "desc" : "asc");
+    setOrderBy(property);
   };
-
-  const tableColumns: Array<Column<Row>> = [
-    {
-      title: "REEF",
-      field: "locationName",
-      cellStyle,
-      render: (rowData) => (
-        <Typography
-          align="left"
-          style={{ paddingRight: "1.5rem" }}
-          variant="subtitle1"
-          color="textSecondary"
-        >
-          {rowData.locationName}
-        </Typography>
-      ),
-    },
-    {
-      title: "TEMP",
-      field: "temp",
-      type: "numeric",
-      cellStyle,
-      render: (rowData) => (
-        <Typography
-          style={{ color: colors.lightBlue, paddingLeft: "1rem" }}
-          variant="h6"
-        >
-          {rowData.temp}&#8451;
-        </Typography>
-      ),
-    },
-    {
-      title: "DEPTH",
-      field: "depth",
-      type: "numeric",
-      cellStyle,
-      render: (rowData) => (
-        <Typography
-          style={{ paddingLeft: "2rem" }}
-          variant="subtitle1"
-          color="textSecondary"
-        >
-          {rowData.depth} m
-        </Typography>
-      ),
-    },
-    {
-      title: "DHW",
-      field: "dhw",
-      type: "numeric",
-      cellStyle,
-      render: (rowData) => (
-        <Typography
-          style={{
-            paddingLeft: "2rem",
-            color: rowData.dhw ? `${colorFinder(rowData.dhw)}` : "black",
-          }}
-          variant="subtitle1"
-        >
-          {formatNumber(rowData.dhw, 1)}
-        </Typography>
-      ),
-    },
-    {
-      title: "ALERT",
-      field: "dhw",
-      cellStyle,
-      render: (rowData) => {
-        return (
-          <ErrorIcon
-            style={{ color: colorFinder(rowData.dhw), paddingLeft: "1rem" }}
-          />
-        );
-      },
-    },
-  ];
-
-  const tableData: Row[] = Object.entries(reefsList).map(([key, value]) => {
-    const { degreeHeatingDays, satelliteTemperature } =
-      value.latestDailyData || {};
-    return {
-      locationName: value.name,
-      temp: formatNumber(satelliteTemperature, 1),
-      depth: value.depth,
-      dhw: degreeHeatingWeeksCalculator(degreeHeatingDays),
-      tableData: {
-        id: parseFloat(key),
-      },
-    };
-  });
 
   return (
     <>
@@ -165,36 +122,82 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
         )}
       {reefsList && reefsList.length > 0 && (
         <Grid item xs={12}>
-          <MaterialTable
-            icons={{
-              SortArrow: forwardRef((props, ref) => (
-                <ArrowUpwardIcon {...props} ref={ref} />
-              )),
-            }}
-            columns={tableColumns}
-            data={tableData}
-            onRowClick={(event, row) => {
-              if (row && row.tableData) {
-                setSelectedRow(row.tableData.id);
-                dispatch(setReefOnMap(reefsList[row.tableData.id]));
-              }
-            }}
-            options={{
-              rowStyle: (rowData) => ({
-                backgroundColor:
-                  selectedRow === rowData.tableData.id
-                    ? colors.lighterBlue
-                    : "none",
-              }),
-              paging: false,
-              headerStyle,
-            }}
-            components={{
-              Container: (props) => <Paper {...props} elevation={0} />,
-              Toolbar: () => null,
-              Pagination: () => null,
-            }}
-          />
+          <TableContainer>
+            <Table>
+              <EnhancedTableHead
+                order={order}
+                orderBy={orderBy}
+                onRequestSort={handleRequestSort}
+              />
+              <TableBody>
+                {stableSort<Row>(
+                  constructTableData(reefsList),
+                  getComparator(order, orderBy)
+                ).map((reef, index) => {
+                  return (
+                    <TableRow
+                      hover
+                      style={{
+                        backgroundColor:
+                          reef.tableData.id === selectedRow
+                            ? colors.lighterBlue
+                            : "white",
+                        cursor: "pointer",
+                      }}
+                      onClick={(event) => handleClick(event, reef)}
+                      role="button"
+                      tabIndex={-1}
+                      // eslint-disable-next-line react/no-array-index-key
+                      key={`${reef.locationName}-${index}`}
+                    >
+                      <TableCell>
+                        <Typography
+                          align="left"
+                          variant="subtitle1"
+                          color="textSecondary"
+                        >
+                          {reef.locationName}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography
+                          style={{ color: colors.lightBlue }}
+                          variant="subtitle1"
+                        >
+                          {reef.temp}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography variant="subtitle1" color="textSecondary">
+                          {reef.depth}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <Typography
+                          style={{
+                            color: reef.dhw
+                              ? `${colorFinder(reef.dhw)}`
+                              : "black",
+                          }}
+                          variant="subtitle1"
+                        >
+                          {formatNumber(reef.dhw, 1)}
+                        </Typography>
+                      </TableCell>
+                      <TableCell align="right">
+                        <ErrorIcon
+                          style={{
+                            color: colorFinder(reef.dhw),
+                            marginRight: "1rem",
+                          }}
+                        />
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
+          </TableContainer>
         </Grid>
       )}
     </>

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -1,6 +1,4 @@
 import React, { useState } from "react";
-import { useSelector, useDispatch } from "react-redux";
-
 import {
   Grid,
   Typography,
@@ -8,82 +6,25 @@ import {
   Hidden,
   TableContainer,
   Table,
-  TableBody,
-  TableRow,
-  TableCell,
+  CircularProgress,
+  Box,
 } from "@material-ui/core";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
-import ErrorIcon from "@material-ui/icons/Error";
 
+import { useSelector } from "react-redux";
 import SelectedReefCard from "./SelectedReefCard";
-import { reefsListSelector } from "../../../store/Reefs/reefsListSlice";
-import { constructTableData } from "../../../store/Reefs/helpers";
-import { colors } from "../../../layout/App/theme";
-import { reefDetailsSelector } from "../../../store/Reefs/selectedReefSlice";
-import { setReefOnMap } from "../../../store/Homepage/homepageSlice";
-import type { TableRow as Row } from "../../../store/Homepage/types";
-import { formatNumber } from "../../../helpers/numberUtils";
-import { colorFinder } from "../../../helpers/degreeHeatingWeeks";
-import type { Order, OrderKeys } from "./types";
 import EnhancedTableHead from "./tableHead";
-
-function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
-  if (b[orderBy] < a[orderBy]) {
-    return -1;
-  }
-  if (b[orderBy] > a[orderBy]) {
-    return 1;
-  }
-  return 0;
-}
-
-function getComparator(
-  order: Order,
-  orderBy: OrderKeys
-): (
-  a: {
-    [key in OrderKeys]: number | string | null;
-  },
-  b: {
-    [key in OrderKeys]: number | string | null;
-  }
-) => number {
-  return order === "desc"
-    ? (a, b) => descendingComparator(a, b, orderBy)
-    : (a, b) => -descendingComparator(a, b, orderBy);
-}
-
-function stableSort<T>(array: T[], comparator: (a: T, b: T) => number) {
-  const stabilizedThis = array.map((el, index) => [el, index] as [T, number]);
-  stabilizedThis.sort((a, b) => {
-    const order = comparator(a[0], b[0]);
-    if (order !== 0) return order;
-    return a[1] - b[1];
-  });
-  return stabilizedThis.map((el) => el[0]);
-}
+import ReefTableBody from "./body";
+import { Order, OrderKeys } from "./utils";
+import { reefsListLoadingSelector } from "../../../store/Reefs/reefsListSlice";
 
 const ReefTable = ({ openDrawer }: ReefTableProps) => {
-  const reefsList = useSelector(reefsListSelector);
-  const selectedReef = useSelector(reefDetailsSelector);
-  const dispatch = useDispatch();
-  const [selectedRow, setSelectedRow] = useState<number | null>(null);
+  const loading = useSelector(reefsListLoadingSelector);
   const [order, setOrder] = useState<Order>(undefined);
   const [orderBy, setOrderBy] = useState<OrderKeys>("locationName");
 
-  const handleClick = (
-    event: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
-    reef: Row
-  ) => {
-    setSelectedRow(reef.tableData.id);
-    dispatch(setReefOnMap(reefsList[reef.tableData.id]));
-  };
-
-  const handleRequestSort = (
-    event: React.MouseEvent<unknown>,
-    property: OrderKeys
-  ) => {
+  const handleRequestSort = (event: unknown, property: OrderKeys) => {
     const isAsc = orderBy === property && order === "asc";
     setOrder(isAsc ? "desc" : "asc");
     setOrderBy(property);
@@ -112,91 +53,29 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
           </Typography>
         )}
       </Hidden>
-      {selectedReef &&
-        selectedReef.dailyData &&
-        selectedReef.dailyData.length > 0 && (
-          <SelectedReefCard reef={selectedReef} />
+      <SelectedReefCard />
+      <Box display="flex" flexDirection="column" flex={1}>
+        <TableContainer>
+          <Table>
+            <EnhancedTableHead
+              order={order}
+              orderBy={orderBy}
+              onRequestSort={handleRequestSort}
+            />
+            <ReefTableBody order={order} orderBy={orderBy} />
+          </Table>
+        </TableContainer>
+        {loading && (
+          <Box
+            display="flex"
+            flex={1}
+            alignItems="center"
+            justifyContent="center"
+          >
+            <CircularProgress size="10rem" thickness={1} />
+          </Box>
         )}
-      {reefsList && reefsList.length > 0 && (
-        <Grid item xs={12}>
-          <TableContainer>
-            <Table>
-              <EnhancedTableHead
-                order={order}
-                orderBy={orderBy}
-                onRequestSort={handleRequestSort}
-              />
-              <TableBody>
-                {stableSort<Row>(
-                  constructTableData(reefsList),
-                  getComparator(order, orderBy)
-                ).map((reef, index) => {
-                  return (
-                    <TableRow
-                      hover
-                      style={{
-                        backgroundColor:
-                          reef.tableData.id === selectedRow
-                            ? colors.lighterBlue
-                            : "white",
-                        cursor: "pointer",
-                      }}
-                      onClick={(event) => handleClick(event, reef)}
-                      role="button"
-                      tabIndex={-1}
-                      // eslint-disable-next-line react/no-array-index-key
-                      key={`${reef.locationName}-${index}`}
-                    >
-                      <TableCell>
-                        <Typography
-                          align="center"
-                          variant="subtitle1"
-                          color="textSecondary"
-                        >
-                          {reef.locationName}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="center">
-                        <Typography
-                          style={{ color: colors.lightBlue }}
-                          variant="subtitle1"
-                        >
-                          {reef.temp}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="center">
-                        <Typography variant="subtitle1" color="textSecondary">
-                          {reef.depth}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="center">
-                        <Typography
-                          style={{
-                            color: reef.dhw
-                              ? `${colorFinder(reef.dhw)}`
-                              : "black",
-                          }}
-                          variant="subtitle1"
-                        >
-                          {formatNumber(reef.dhw, 1)}
-                        </Typography>
-                      </TableCell>
-                      <TableCell align="center">
-                        <ErrorIcon
-                          style={{
-                            color: colorFinder(reef.dhw),
-                            marginRight: "1rem",
-                          }}
-                        />
-                      </TableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
-          </TableContainer>
-        </Grid>
-      )}
+      </Box>
     </>
   );
 };

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -21,7 +21,7 @@ import { reefsListLoadingSelector } from "../../../store/Reefs/reefsListSlice";
 
 const ReefTable = ({ openDrawer }: ReefTableProps) => {
   const loading = useSelector(reefsListLoadingSelector);
-  const [order, setOrder] = useState<Order>(undefined);
+  const [order, setOrder] = useState<Order>("asc");
   const [orderBy, setOrderBy] = useState<OrderKeys>("locationName");
 
   const handleRequestSort = (event: unknown, property: OrderKeys) => {

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -25,7 +25,7 @@ import { setReefOnMap } from "../../../store/Homepage/homepageSlice";
 import type { TableRow as Row } from "../../../store/Homepage/types";
 import { formatNumber } from "../../../helpers/numberUtils";
 import { colorFinder } from "../../../helpers/degreeHeatingWeeks";
-import type { Order } from "./types";
+import type { Order, OrderKeys } from "./types";
 import EnhancedTableHead from "./tableHead";
 
 function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
@@ -40,13 +40,13 @@ function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
 
 function getComparator(
   order: Order,
-  orderBy: "locationName" | "temp" | "depth" | "dhw"
+  orderBy: OrderKeys
 ): (
   a: {
-    [key in "locationName" | "temp" | "depth" | "dhw"]: number | string | null;
+    [key in OrderKeys]: number | string | null;
   },
   b: {
-    [key in "locationName" | "temp" | "depth" | "dhw"]: number | string | null;
+    [key in OrderKeys]: number | string | null;
   }
 ) => number {
   return order === "desc"
@@ -70,22 +70,19 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
   const dispatch = useDispatch();
   const [selectedRow, setSelectedRow] = useState<number | null>(null);
   const [order, setOrder] = useState<Order>(undefined);
-  const [orderBy, setOrderBy] = useState<
-    "locationName" | "temp" | "depth" | "dhw"
-  >("locationName");
+  const [orderBy, setOrderBy] = useState<OrderKeys>("locationName");
 
   const handleClick = (
     event: React.MouseEvent<HTMLTableRowElement, MouseEvent>,
     reef: Row
   ) => {
-    console.log(reef.tableData.id);
     setSelectedRow(reef.tableData.id);
     dispatch(setReefOnMap(reefsList[reef.tableData.id]));
   };
 
   const handleRequestSort = (
     event: React.MouseEvent<unknown>,
-    property: "locationName" | "temp" | "depth" | "dhw"
+    property: OrderKeys
   ) => {
     const isAsc = orderBy === property && order === "asc";
     setOrder(isAsc ? "desc" : "asc");
@@ -152,14 +149,14 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
                     >
                       <TableCell>
                         <Typography
-                          align="left"
+                          align="center"
                           variant="subtitle1"
                           color="textSecondary"
                         >
                           {reef.locationName}
                         </Typography>
                       </TableCell>
-                      <TableCell align="right">
+                      <TableCell align="center">
                         <Typography
                           style={{ color: colors.lightBlue }}
                           variant="subtitle1"
@@ -167,12 +164,12 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
                           {reef.temp}
                         </Typography>
                       </TableCell>
-                      <TableCell align="right">
+                      <TableCell align="center">
                         <Typography variant="subtitle1" color="textSecondary">
                           {reef.depth}
                         </Typography>
                       </TableCell>
-                      <TableCell align="right">
+                      <TableCell align="center">
                         <Typography
                           style={{
                             color: reef.dhw
@@ -184,7 +181,7 @@ const ReefTable = ({ openDrawer }: ReefTableProps) => {
                           {formatNumber(reef.dhw, 1)}
                         </Typography>
                       </TableCell>
-                      <TableCell align="right">
+                      <TableCell align="center">
                         <ErrorIcon
                           style={{
                             color: colorFinder(reef.dhw),

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -6,7 +6,7 @@ import {
   TableSortLabel,
   Typography,
 } from "@material-ui/core";
-import type { Order, OrderKeys } from "./types";
+import type { Order, OrderKeys } from "./utils";
 
 const columnTitle = (title: string, unit?: string) => (
   <>

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -8,20 +8,22 @@ import {
 } from "@material-ui/core";
 import type { Order, OrderKeys } from "./utils";
 
-const columnTitle = (title: string, unit?: string) => (
-  <>
-    <Typography variant="h6" style={{ color: "black" }}>
-      {title}
-      {unit && (
-        <Typography
-          variant="subtitle2"
-          style={{ color: "black" }}
-          component="span"
-        >{`\u00a0 (${unit})`}</Typography>
-      )}
-    </Typography>
-  </>
+const ColumnTitle = ({ title, unit }: { title: string; unit?: string }) => (
+  <Typography variant="h6" style={{ color: "black" }}>
+    {title}
+    {unit && (
+      <Typography
+        variant="subtitle2"
+        style={{ color: "black" }}
+        component="span"
+      >{`\u00a0 (${unit})`}</Typography>
+    )}
+  </Typography>
 );
+
+ColumnTitle.defaultProps = {
+  unit: undefined,
+};
 
 const EnhancedTableHead = (props: EnhancedTableProps) => {
   const createSortHandler = (property: OrderKeys) => (
@@ -85,7 +87,7 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
                   : () => {}
               }
             >
-              {columnTitle(headCell.label, headCell.unit)}
+              <ColumnTitle title={headCell.label} unit={headCell.unit} />
             </TableSortLabel>
           </TableCell>
         ))}

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -6,7 +6,7 @@ import {
   TableSortLabel,
   Typography,
 } from "@material-ui/core";
-import type { Order } from "./types";
+import type { Order, OrderKeys } from "./types";
 
 const columnTitle = (title: string, unit?: string) => (
   <>
@@ -24,9 +24,9 @@ const columnTitle = (title: string, unit?: string) => (
 );
 
 const EnhancedTableHead = (props: EnhancedTableProps) => {
-  const createSortHandler = (
-    property: "locationName" | "temp" | "depth" | "dhw"
-  ) => (event: React.MouseEvent<unknown>) => {
+  const createSortHandler = (property: OrderKeys) => (
+    event: React.MouseEvent<unknown>
+  ) => {
     props.onRequestSort(event, property);
   };
 
@@ -59,7 +59,7 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
       unit: "DHW",
     },
     {
-      id: "dhw",
+      id: "alert",
       numeric: true,
       disablePadding: false,
       label: "ALERT",
@@ -67,28 +67,25 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
   ];
 
   return (
-    <TableHead>
+    <TableHead style={{ backgroundColor: "#cacbd1" }}>
       <TableRow>
         {headCells.map((headCell) => (
           <TableCell
             key={headCell.id}
-            align={headCell.numeric ? "right" : "left"}
+            align="center"
             padding={headCell.disablePadding ? "none" : "default"}
             sortDirection={props.orderBy === headCell.id ? props.order : false}
           >
             <TableSortLabel
               active={props.orderBy === headCell.id}
               direction={props.orderBy === headCell.id ? props.order : "asc"}
-              onClick={createSortHandler(headCell.id)}
+              onClick={
+                headCell.id !== "alert"
+                  ? createSortHandler(headCell.id)
+                  : () => {}
+              }
             >
               {columnTitle(headCell.label, headCell.unit)}
-              {props.orderBy === headCell.id ? (
-                <span>
-                  {props.order === "desc"
-                    ? "sorted descending"
-                    : "sorted ascending"}
-                </span>
-              ) : null}
             </TableSortLabel>
           </TableCell>
         ))}
@@ -99,7 +96,7 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
 
 interface HeadCell {
   disablePadding: boolean;
-  id: "locationName" | "temp" | "depth" | "dhw";
+  id: OrderKeys | "alert";
   label: string;
   numeric: boolean;
   unit?: string;
@@ -108,7 +105,7 @@ interface HeadCell {
 interface EnhancedTableProps {
   onRequestSort: (
     event: React.MouseEvent<unknown>,
-    property: "locationName" | "temp" | "depth" | "dhw"
+    property: OrderKeys
   ) => void;
   order: Order;
   orderBy: string;

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -36,46 +36,45 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
     {
       id: "locationName",
       numeric: false,
-      disablePadding: true,
       label: "REEF",
+      align: "left",
+      width: "30%",
     },
     {
       id: "temp",
       numeric: false,
-      disablePadding: false,
       label: "TEMP",
       unit: "°C",
     },
     {
       id: "depth",
       numeric: true,
-      disablePadding: false,
       label: "DEPTH",
       unit: "m",
     },
     {
       id: "dhw",
       numeric: true,
-      disablePadding: false,
       label: "STRESS",
       unit: "DHW",
     },
     {
       id: "alert",
       numeric: true,
-      disablePadding: false,
       label: "ALERT",
+      width: "10%",
     },
   ];
 
   return (
-    <TableHead style={{ backgroundColor: "#cacbd1" }}>
+    <TableHead style={{ backgroundColor: "rgb(244, 244, 244)" }}>
       <TableRow>
         {headCells.map((headCell) => (
           <TableCell
             key={headCell.id}
-            align="center"
-            padding={headCell.disablePadding ? "none" : "default"}
+            width={headCell.width}
+            align={headCell.align || "center"}
+            padding="default"
             sortDirection={props.orderBy === headCell.id ? props.order : false}
           >
             {headCell.id !== "alert" ? (
@@ -97,11 +96,12 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
 };
 
 interface HeadCell {
-  disablePadding: boolean;
   id: OrderKeys | "alert";
   label: string;
   numeric: boolean;
   unit?: string;
+  align?: "center" | "left" | "right";
+  width?: string;
 }
 
 interface EnhancedTableProps {

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -78,17 +78,17 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
             padding={headCell.disablePadding ? "none" : "default"}
             sortDirection={props.orderBy === headCell.id ? props.order : false}
           >
-            <TableSortLabel
-              active={props.orderBy === headCell.id}
-              direction={props.orderBy === headCell.id ? props.order : "asc"}
-              onClick={
-                headCell.id !== "alert"
-                  ? createSortHandler(headCell.id)
-                  : () => {}
-              }
-            >
+            {headCell.id !== "alert" ? (
+              <TableSortLabel
+                active={props.orderBy === headCell.id}
+                direction={props.orderBy === headCell.id ? props.order : "asc"}
+                onClick={createSortHandler(headCell.id)}
+              >
+                <ColumnTitle title={headCell.label} unit={headCell.unit} />
+              </TableSortLabel>
+            ) : (
               <ColumnTitle title={headCell.label} unit={headCell.unit} />
-            </TableSortLabel>
+            )}
           </TableCell>
         ))}
       </TableRow>

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -1,0 +1,117 @@
+import React from "react";
+import {
+  TableHead,
+  TableRow,
+  TableCell,
+  TableSortLabel,
+  Typography,
+} from "@material-ui/core";
+import type { Order } from "./types";
+
+const columnTitle = (title: string, unit?: string) => (
+  <>
+    <Typography variant="h6" style={{ color: "black" }}>
+      {title}
+      {unit && (
+        <Typography
+          variant="subtitle2"
+          style={{ color: "black" }}
+          component="span"
+        >{`\u00a0 (${unit})`}</Typography>
+      )}
+    </Typography>
+  </>
+);
+
+const EnhancedTableHead = (props: EnhancedTableProps) => {
+  const createSortHandler = (
+    property: "locationName" | "temp" | "depth" | "dhw"
+  ) => (event: React.MouseEvent<unknown>) => {
+    props.onRequestSort(event, property);
+  };
+
+  const headCells: HeadCell[] = [
+    {
+      id: "locationName",
+      numeric: false,
+      disablePadding: true,
+      label: "REEF",
+    },
+    {
+      id: "temp",
+      numeric: false,
+      disablePadding: false,
+      label: "TEMP",
+      unit: "°C",
+    },
+    {
+      id: "depth",
+      numeric: true,
+      disablePadding: false,
+      label: "DEPTH",
+      unit: "m",
+    },
+    {
+      id: "dhw",
+      numeric: true,
+      disablePadding: false,
+      label: "STRESS",
+      unit: "DHW",
+    },
+    {
+      id: "dhw",
+      numeric: true,
+      disablePadding: false,
+      label: "ALERT",
+    },
+  ];
+
+  return (
+    <TableHead>
+      <TableRow>
+        {headCells.map((headCell) => (
+          <TableCell
+            key={headCell.id}
+            align={headCell.numeric ? "right" : "left"}
+            padding={headCell.disablePadding ? "none" : "default"}
+            sortDirection={props.orderBy === headCell.id ? props.order : false}
+          >
+            <TableSortLabel
+              active={props.orderBy === headCell.id}
+              direction={props.orderBy === headCell.id ? props.order : "asc"}
+              onClick={createSortHandler(headCell.id)}
+            >
+              {columnTitle(headCell.label, headCell.unit)}
+              {props.orderBy === headCell.id ? (
+                <span>
+                  {props.order === "desc"
+                    ? "sorted descending"
+                    : "sorted ascending"}
+                </span>
+              ) : null}
+            </TableSortLabel>
+          </TableCell>
+        ))}
+      </TableRow>
+    </TableHead>
+  );
+};
+
+interface HeadCell {
+  disablePadding: boolean;
+  id: "locationName" | "temp" | "depth" | "dhw";
+  label: string;
+  numeric: boolean;
+  unit?: string;
+}
+
+interface EnhancedTableProps {
+  onRequestSort: (
+    event: React.MouseEvent<unknown>,
+    property: "locationName" | "temp" | "depth" | "dhw"
+  ) => void;
+  order: Order;
+  orderBy: string;
+}
+
+export default EnhancedTableHead;

--- a/packages/website/src/routes/Homepage/ReefTable/types.ts
+++ b/packages/website/src/routes/Homepage/ReefTable/types.ts
@@ -1,1 +1,3 @@
 export type Order = "asc" | "desc" | undefined;
+
+export type OrderKeys = "locationName" | "temp" | "depth" | "dhw";

--- a/packages/website/src/routes/Homepage/ReefTable/types.ts
+++ b/packages/website/src/routes/Homepage/ReefTable/types.ts
@@ -1,0 +1,1 @@
+export type Order = "asc" | "desc" | undefined;

--- a/packages/website/src/routes/Homepage/ReefTable/types.ts
+++ b/packages/website/src/routes/Homepage/ReefTable/types.ts
@@ -1,3 +1,0 @@
-export type Order = "asc" | "desc" | undefined;
-
-export type OrderKeys = "locationName" | "temp" | "depth" | "dhw";

--- a/packages/website/src/routes/Homepage/ReefTable/utils.ts
+++ b/packages/website/src/routes/Homepage/ReefTable/utils.ts
@@ -1,4 +1,4 @@
-export type Order = "asc" | "desc" | undefined;
+export type Order = "asc" | "desc";
 
 export type OrderKeys = "locationName" | "temp" | "depth" | "dhw";
 

--- a/packages/website/src/routes/Homepage/ReefTable/utils.ts
+++ b/packages/website/src/routes/Homepage/ReefTable/utils.ts
@@ -1,0 +1,27 @@
+export type Order = "asc" | "desc" | undefined;
+
+export type OrderKeys = "locationName" | "temp" | "depth" | "dhw";
+
+export function descendingComparator<T>(a: T, b: T, orderBy: keyof T) {
+  return b[orderBy] >= a[orderBy] ? 1 : -1;
+}
+
+export function getComparator(
+  order: Order,
+  orderBy: OrderKeys
+): (
+  a: {
+    [key in OrderKeys]: number | string | null;
+  },
+  b: {
+    [key in OrderKeys]: number | string | null;
+  }
+) => number {
+  return order === "desc"
+    ? (a, b) => descendingComparator(a, b, orderBy)
+    : (a, b) => -descendingComparator(a, b, orderBy);
+}
+
+export function stableSort<T>(array: T[], comparator: (a: T, b: T) => number) {
+  return [...array].sort(comparator);
+}

--- a/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/__snapshots__/index.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
     class="Homepage-root-1"
   >
     <div
-      class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
+      class="MuiGrid-root MuiGrid-container"
     >
       <div
         class="MuiGrid-root Homepage-map-2 MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6"

--- a/packages/website/src/routes/Homepage/index.tsx
+++ b/packages/website/src/routes/Homepage/index.tsx
@@ -38,12 +38,7 @@ const Homepage = ({ classes }: HomepageProps) => {
         <HomepageNavBar searchLocation />
       </div>
       <div className={classes.root}>
-        <Grid
-          container
-          direction="row"
-          justify="flex-start"
-          alignItems="center"
-        >
+        <Grid container direction="row">
           <Grid className={classes.map} item xs={12} sm={6}>
             <HomepageMap />
           </Grid>
@@ -87,12 +82,13 @@ const styles = () =>
       flexGrow: 1,
     },
     map: {
-      height: "100%",
       display: "flex",
     },
     reefTable: {
-      height: "calc(100vh - 64px)",
       overflowY: "auto",
+      display: "flex",
+      flexDirection: "column",
+      height: "calc(100vh - 64px);", // subtract height of the navbar
     },
     drawer: {
       borderTopLeftRadius: "15px",

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -6,7 +6,7 @@ export interface HomePageState {
 
 export interface TableRow {
   locationName: string | null;
-  temp: string | 0;
+  temp: number | 0;
   depth: number | null;
   dhw: number | null;
   tableData: {

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -9,7 +9,6 @@ export interface TableRow {
   temp: string | 0;
   depth: number | null;
   dhw: number | null;
-  alert?: string;
   tableData: {
     id: number;
   };

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -6,7 +6,7 @@ export interface HomePageState {
 
 export interface TableRow {
   locationName: string | null;
-  temp: number | 0;
+  temp: number | null;
   depth: number | null;
   dhw: number | null;
   tableData: {

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -3,3 +3,14 @@ import { Reef } from "../Reefs/types";
 export interface HomePageState {
   reefOnMap: Reef | null;
 }
+
+export interface TableRow {
+  locationName: string | null;
+  temp: string | 0;
+  depth: number | null;
+  dhw: number | null;
+  alert?: string;
+  tableData: {
+    id: number;
+  };
+}

--- a/packages/website/src/store/Reefs/helpers.ts
+++ b/packages/website/src/store/Reefs/helpers.ts
@@ -1,0 +1,22 @@
+/* eslint-disable no-nested-ternary */
+import type { TableRow } from "../Homepage/types";
+import type { Reef } from "./types";
+import { degreeHeatingWeeksCalculator } from "../../helpers/degreeHeatingWeeks";
+import { formatNumber } from "../../helpers/numberUtils";
+
+export const constructTableData = (list: Reef[]): TableRow[] => {
+  return list.map((value, key) => {
+    const { degreeHeatingDays, satelliteTemperature } =
+      value.latestDailyData || {};
+    const locationName = value.name || value.region?.name || null;
+    return {
+      locationName,
+      temp: formatNumber(satelliteTemperature, 1),
+      depth: value.depth,
+      dhw: degreeHeatingWeeksCalculator(degreeHeatingDays),
+      tableData: {
+        id: key,
+      },
+    };
+  });
+};

--- a/packages/website/src/store/Reefs/helpers.ts
+++ b/packages/website/src/store/Reefs/helpers.ts
@@ -2,7 +2,6 @@
 import type { TableRow } from "../Homepage/types";
 import type { Reef } from "./types";
 import { degreeHeatingWeeksCalculator } from "../../helpers/degreeHeatingWeeks";
-import { formatNumber } from "../../helpers/numberUtils";
 
 export const constructTableData = (list: Reef[]): TableRow[] => {
   return list.map((value, key) => {
@@ -11,7 +10,7 @@ export const constructTableData = (list: Reef[]): TableRow[] => {
     const locationName = value.name || value.region?.name || null;
     return {
       locationName,
-      temp: formatNumber(satelliteTemperature, 1),
+      temp: satelliteTemperature,
       depth: value.depth,
       dhw: degreeHeatingWeeksCalculator(degreeHeatingDays),
       tableData: {


### PR DESCRIPTION
This PR switches the reef table to Material UI's built-in table and separates different state dependencies to minimize reloading.

This PR replaces #149. It fixes #114.