### PR TITLE
Make marker pop-up open on table reef click

### DIFF
--- a/packages/website/src/routes/Homepage/Map/Markers/index.tsx
+++ b/packages/website/src/routes/Homepage/Map/Markers/index.tsx
@@ -40,7 +40,11 @@ const ActiveReefListener = ({ reef }: { reef: Reef }) => {
         [reefOnMap.polygon.coordinates[1], reefOnMap.polygon.coordinates[0]],
         6
       );
-      popupContainer.openPopup();
+      const openPopup = () => {
+        popupContainer.openPopup();
+        map.off("moveend", openPopup);
+      };
+      map.on("moveend", openPopup);
     }
   }, [reefOnMap, reef.id, map, popupContainer]);
   return null;


### PR DESCRIPTION
This PR fixes #180 by making sure that reef cards open on table click even if clustered.