### PR TITLE
Hacky fix to get user data on sign-in

### DIFF
--- a/packages/website/src/store/User/userSlice.ts
+++ b/packages/website/src/store/User/userSlice.ts
@@ -38,6 +38,7 @@ export const createUser = createAsyncThunk<
       return {
         email: data.email,
         fullName: data.fullName,
+        adminLevel: data.adminLevel,
         firebaseUid: data.firebaseUid,
         administeredReefs: reefs,
         token: await user?.getIdToken(),
@@ -59,10 +60,16 @@ export const signInUser = createAsyncThunk<
   async ({ email, password }: UserSignInParams, { rejectWithValue }) => {
     try {
       const { user } = await userServices.signInUser(email, password);
+      const token = await user?.getIdToken();
+      const { data: userData } = await userServices.getSelf(token);
+      const { data: reefs } = await userServices.getAdministeredReefs(token);
       return {
-        email: user?.email,
-        firebaseUid: user?.uid,
-        token: await user?.getIdToken(),
+        email: userData.email,
+        fullName: userData.fullName,
+        adminLevel: userData.adminLevel,
+        firebaseUid: userData.firebaseUid,
+        administeredReefs: reefs,
+        token,
       };
     } catch (err) {
       return rejectWithValue(err.message);


### PR DESCRIPTION
The problem we have is that getSelf is called on `auth` change. But during sign-in, the auth change happens at the very beginning, and getSelf finishes before the signIn is over and the data from the signIn chunck ends up overriding the data we just got.

So as a hacky way to fix #222 I fetch all the data during the signIn chunck, similar to what we do during the create chunck.

There is probably a better way to handle this, so I am open to suggestions.