### PR TITLE
Adapt date format for smaller charts

### DIFF
--- a/packages/website/src/common/Chart/ChartWithTooltip.tsx
+++ b/packages/website/src/common/Chart/ChartWithTooltip.tsx
@@ -53,7 +53,7 @@ function ChartWithTooltip({
     const date = tooltipModel.dataPoints?.[0]?.xLabel;
     const index = date && chartLabels.findIndex((item) => item === date);
 
-    if (index > -1 && index !== 0 && index !== chartLabels.length - 1) {
+    if (index > -1 && index !== 0) {
       setTooltipPosition({ top, left });
       setTooltipData({
         date,
@@ -83,7 +83,6 @@ function ChartWithTooltip({
         dailyData={dailyData}
         chartRef={chartDataRef}
         temperatureThreshold={temperatureThreshold}
-        chartHeight={60}
         chartSettings={{
           plugins: {
             sliceDrawPlugin: {

--- a/packages/website/src/common/Chart/index.tsx
+++ b/packages/website/src/common/Chart/index.tsx
@@ -20,7 +20,6 @@ export interface ChartProps {
   temperatureThreshold: number | null;
   maxMonthlyMean?: number | null;
 
-  chartHeight?: number;
   chartSettings?: {};
   chartRef?: MutableRefObject<Line | null>;
 }
@@ -29,7 +28,6 @@ function Chart({
   dailyData,
   temperatureThreshold,
   maxMonthlyMean = temperatureThreshold ? temperatureThreshold - 1 : null,
-  chartHeight = 100,
   chartSettings = {},
   chartRef: forwardRef,
 }: ChartProps) {
@@ -90,6 +88,9 @@ function Chart({
   });
   const settings = mergeWith(
     {
+      layout: {
+        padding: { right: 10 },
+      },
       maintainAspectRatio: false,
       plugins: {
         chartJsPluginBarchartBackground: {
@@ -137,7 +138,8 @@ function Chart({
             type: "time",
             time: {
               displayFormats: {
-                hour: "MMM D h:mm a",
+                week: "MMM D",
+                month: "MMM D",
               },
               unit: "week",
             },
@@ -147,10 +149,6 @@ function Chart({
               min: xAxisMin,
               max: xAxisMax,
               padding: 10,
-              maxRotation: 0,
-              callback: (value: string) => {
-                return value.split(", ")[0].toUpperCase();
-              },
             },
             gridLines: {
               display: false,
@@ -189,7 +187,6 @@ function Chart({
     <Line
       ref={chartRef}
       options={settings}
-      height={chartHeight}
       data={createChartData(chartLabels, surfaceTemperatureData, true)}
     />
   );

--- a/packages/website/src/common/Chart/utils.ts
+++ b/packages/website/src/common/Chart/utils.ts
@@ -9,16 +9,8 @@ export const createDatasets = (dailyData: DailyData[]) => {
     .map((item) => item.satelliteTemperature);
 
   return {
-    bottomTemperatureData: [
-      bottomTemperature[0],
-      ...bottomTemperature,
-      bottomTemperature[bottomTemperature.length - 1],
-    ],
-    surfaceTemperatureData: [
-      surfaceTemperature[0],
-      ...surfaceTemperature,
-      surfaceTemperature[surfaceTemperature.length - 1],
-    ],
+    bottomTemperatureData: [bottomTemperature[0], ...bottomTemperature],
+    surfaceTemperatureData: [surfaceTemperature[0], ...surfaceTemperature],
   };
 };
 
@@ -34,20 +26,14 @@ export const calculateAxisLimits = (
     .map((item) => item.date);
   const dailyDataLen = dates.length;
 
-  const xAxisMax = new Date(
-    new Date(dates[dailyDataLen - 1]).setHours(24, 0, 0, 0)
-  ).toISOString();
+  const xAxisMax = new Date(new Date(dates[dailyDataLen - 1])).toISOString();
 
   const xAxisMin = new Date(
     new Date(dates[0]).setHours(-1, 0, 0, 0)
   ).toISOString();
 
   // Add an extra date one day after the final daily data date
-  const chartLabels = [
-    new Date(new Date(xAxisMin).setHours(3, 0, 0, 0)).toISOString(),
-    ...dates,
-    new Date(new Date(xAxisMax).setHours(3, 0, 0, 0)).toISOString(),
-  ];
+  const chartLabels = [xAxisMin, ...dates];
 
   const { surfaceTemperatureData } = createDatasets(dailyData);
 


### PR DESCRIPTION
Fixes #259 

<img width="807" alt="Screen Shot 2020-09-28 at 8 24 05 PM" src="https://user-images.githubusercontent.com/16843267/94472180-a8af1480-01ca-11eb-9fe5-50a4ec928005.png">
