### PR TITLE
Catch failed media deletion when deleting a survey

### DIFF
--- a/packages/api/src/surveys/surveys.service.ts
+++ b/packages/api/src/surveys/surveys.service.ts
@@ -2,6 +2,7 @@ import {
   Injectable,
   NotFoundException,
   InternalServerErrorException,
+  Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
@@ -18,6 +19,8 @@ import { Reef } from '../reefs/reefs.entity';
 
 @Injectable()
 export class SurveysService {
+  private logger: Logger = new Logger(SurveysService.name);
+
   constructor(
     @InjectRepository(Survey)
     private surveyRepository: Repository<Survey>,
@@ -271,10 +274,15 @@ export class SurveysService {
 
     await Promise.all(
       surveyMedia.map((media) => {
+        const file = media.url;
         // We need to grab the path/to/file. So we split the url on "{GCS_BUCKET}/"
-        return this.googleCloudService.deleteFile(
-          media.url.split(`${process.env.GCS_BUCKET}/`)[1],
-        );
+        return this.googleCloudService
+          .deleteFile(file.split(`${process.env.GCS_BUCKET}/`)[1])
+          .catch(() => {
+            this.logger.error(
+              `Could not delete media ${file} of survey ${surveyId}.`,
+            );
+          });
       }),
     );
 

--- a/packages/website/src/routes/ReefRoutes/Reef/Surveys/DeleteButton.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/Surveys/DeleteButton.tsx
@@ -84,7 +84,9 @@ const DeleteButton = ({
         onClose={handleClose}
         header={`Are you sure you would like to delete the survey for ${moment(
           diveDate
-        ).format("MM/DD/YYYY")}?`}
+        ).format(
+          "MM/DD/YYYY"
+        )}? It will delete all media assosciated with this survey.`}
         content={
           <>
             {loading && <LinearProgress />}


### PR DESCRIPTION
Proceed without stopping deletion process on survey deletion endpoint
Throw internal server error if failed to delete a survey media on survey media deletion endpoint
Add more logging on both endpoints