### PR TITLE
Improve table card alignment and small charts

### DIFF
--- a/packages/website/src/common/Chart/index.tsx
+++ b/packages/website/src/common/Chart/index.tsx
@@ -43,7 +43,7 @@ function Chart({
 
   const [xTickShift, setXTickShift] = useState<number>(0);
 
-  const [xPeriod, setXPeriod] = useState<string>("week");
+  const [xPeriod, setXPeriod] = useState<"week" | "month">("week");
 
   const {
     xAxisMax,

--- a/packages/website/src/common/Chart/index.tsx
+++ b/packages/website/src/common/Chart/index.tsx
@@ -43,6 +43,8 @@ function Chart({
 
   const [xTickShift, setXTickShift] = useState<number>(0);
 
+  const [xPeriod, setXPeriod] = useState<string>("week");
+
   const {
     xAxisMax,
     xAxisMin,
@@ -52,14 +54,20 @@ function Chart({
     chartLabels,
   } = useProcessedChartData(dailyData, temperatureThreshold);
 
-  const changeXTickShift = () => {
+  const changeXTickShiftAndPeriod = () => {
     const { current } = chartRef;
     if (current) {
       const xScale = current.chartInstance.scales["x-axis-0"];
       const ticksPositions = xScale.ticks.map((_: any, index: number) =>
         xScale.getPixelForTick(index)
       );
-      setXTickShift((ticksPositions[2] - ticksPositions[1]) / 2);
+      if (xScale.width > 400) {
+        setXTickShift((ticksPositions[2] - ticksPositions[1]) / 2);
+        setXPeriod("week");
+      } else {
+        setXPeriod("month");
+        setXTickShift(0);
+      }
     }
   };
 
@@ -71,7 +79,7 @@ function Chart({
     setTimeout(() => {
       // Resize has stopped so stop updating the chart
       setUpdateChart(false);
-      changeXTickShift();
+      changeXTickShiftAndPeriod();
     }, 1);
   }, []);
 
@@ -84,7 +92,7 @@ function Chart({
   }, [onResize]);
 
   useEffect(() => {
-    changeXTickShift();
+    changeXTickShiftAndPeriod();
   });
   const settings = mergeWith(
     {
@@ -139,9 +147,9 @@ function Chart({
             time: {
               displayFormats: {
                 week: "MMM D",
-                month: "MMM D",
+                month: "MMM",
               },
-              unit: "week",
+              unit: xPeriod,
             },
             display: true,
             ticks: {

--- a/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/SelectedReefCard/index.tsx
@@ -52,10 +52,10 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   card: {
-    padding: 40,
     [theme.breakpoints.down("xs")]: {
       padding: 10,
     },
+    padding: 20,
   },
   cardImage: {
     borderRadius: "4px 0 0 4px",

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -51,9 +51,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
           <mock-tablerow>
             <mock-tablecell
               align="left"
+              classname="EnhancedTableHead-headCells-2"
               padding="default"
               sortdirection="false"
-              style="width: 40%; padding-right: 0px; padding-left: 10px;"
+              style="width: 40%;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -70,9 +71,9 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             </mock-tablecell>
             <mock-tablecell
               align="left"
+              classname="EnhancedTableHead-headCells-2"
               padding="default"
               sortdirection="false"
-              style="padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -96,9 +97,9 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             </mock-tablecell>
             <mock-tablecell
               align="left"
+              classname="EnhancedTableHead-headCells-2"
               padding="default"
               sortdirection="false"
-              style="padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -122,9 +123,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             </mock-tablecell>
             <mock-tablecell
               align="left"
+              classname="EnhancedTableHead-headCells-2"
               padding="default"
               sortdirection="desc"
-              style="width: 5%; padding-right: 0px; padding-left: 10px;"
+              style="width: 5%;"
             >
               <mock-tablesortlabel
                 active="true"
@@ -150,7 +152,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             tabindex="-1"
           >
             <mock-tablecell
-              style="padding-left: 10px;"
+              classname="ReefTableBody-nameCells-3"
             >
               <mock-typography
                 align="left"

--- a/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Homepage/ReefTable/__snapshots__/index.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               align="left"
               padding="default"
               sortdirection="false"
-              style="width: 40%; padding-right: 0px;"
+              style="width: 40%; padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -72,7 +72,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               align="left"
               padding="default"
               sortdirection="false"
-              style="padding-right: 0px;"
+              style="padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -98,7 +98,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               align="left"
               padding="default"
               sortdirection="false"
-              style="padding-right: 0px;"
+              style="padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="false"
@@ -124,7 +124,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               align="left"
               padding="default"
               sortdirection="desc"
-              style="width: 5%; padding-right: 0px;"
+              style="width: 5%; padding-right: 0px; padding-left: 10px;"
             >
               <mock-tablesortlabel
                 active="true"
@@ -149,7 +149,9 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             style="background-color: white; cursor: pointer;"
             tabindex="-1"
           >
-            <mock-tablecell>
+            <mock-tablecell
+              style="padding-left: 10px;"
+            >
               <mock-typography
                 align="left"
                 color="textSecondary"

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -65,7 +65,7 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
             tabIndex={-1}
             key={reef.tableData.id}
           >
-            <TableCell>
+            <TableCell style={{ paddingLeft: 10 }}>
               <Typography
                 align="left"
                 variant="subtitle1"

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -1,4 +1,12 @@
-import { TableBody, TableCell, TableRow, Typography } from "@material-ui/core";
+import {
+  TableBody,
+  TableCell,
+  TableRow,
+  Typography,
+  createStyles,
+  withStyles,
+  WithStyles,
+} from "@material-ui/core";
 import ErrorIcon from "@material-ui/icons/Error";
 import React, { useEffect, useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
@@ -15,12 +23,11 @@ import {
 } from "../../../store/Homepage/homepageSlice";
 import { getComparator, Order, OrderKeys, stableSort } from "./utils";
 
-type ReefTableBodyProps = {
-  order: Order;
-  orderBy: OrderKeys;
-};
-
-const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
+const ReefTableBody = ({
+  order,
+  orderBy,
+  classes,
+}: ReefTableBodyPropsStyled) => {
   const dispatch = useDispatch();
   const reefsList = useSelector(reefsListSelector);
   const reefOnMap = useSelector(reefOnMapSelector);
@@ -65,7 +72,7 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
             tabIndex={-1}
             key={reef.tableData.id}
           >
-            <TableCell style={{ paddingLeft: 10 }}>
+            <TableCell className={classes.nameCells}>
               <Typography
                 align="left"
                 variant="subtitle1"
@@ -106,4 +113,18 @@ const ReefTableBody = ({ order, orderBy }: ReefTableBodyProps) => {
   );
 };
 
-export default ReefTableBody;
+const styles = () =>
+  createStyles({
+    nameCells: {
+      paddingLeft: 10,
+    },
+  });
+
+type ReefTableBodyProps = {
+  order: Order;
+  orderBy: OrderKeys;
+};
+
+type ReefTableBodyPropsStyled = WithStyles<typeof styles> & ReefTableBodyProps;
+
+export default withStyles(styles)(ReefTableBody);

--- a/packages/website/src/routes/Homepage/ReefTable/body.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/body.tsx
@@ -23,11 +23,7 @@ import {
 } from "../../../store/Homepage/homepageSlice";
 import { getComparator, Order, OrderKeys, stableSort } from "./utils";
 
-const ReefTableBody = ({
-  order,
-  orderBy,
-  classes,
-}: ReefTableBodyPropsStyled) => {
+const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
   const dispatch = useDispatch();
   const reefsList = useSelector(reefsListSelector);
   const reefOnMap = useSelector(reefOnMapSelector);
@@ -120,11 +116,12 @@ const styles = () =>
     },
   });
 
-type ReefTableBodyProps = {
+type ReefTableBodyIncomingProps = {
   order: Order;
   orderBy: OrderKeys;
 };
 
-type ReefTableBodyPropsStyled = WithStyles<typeof styles> & ReefTableBodyProps;
+type ReefTableBodyProps = WithStyles<typeof styles> &
+  ReefTableBodyIncomingProps;
 
 export default withStyles(styles)(ReefTableBody);

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -11,6 +11,7 @@ import {
   Table,
   CircularProgress,
   Box,
+  Theme,
 } from "@material-ui/core";
 import ArrowUpwardIcon from "@material-ui/icons/ArrowUpward";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
@@ -88,12 +89,15 @@ const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
   );
 };
 
-const styles = () =>
+const styles = (theme: Theme) =>
   createStyles({
     table: {
       paddingLeft: 10,
       height: "70%",
       overflowY: "auto",
+      [theme.breakpoints.down("xs")]: {
+        paddingLeft: 0,
+      },
     },
   });
 

--- a/packages/website/src/routes/Homepage/ReefTable/index.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/index.tsx
@@ -91,6 +91,7 @@ const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
 const styles = () =>
   createStyles({
     table: {
+      paddingLeft: 10,
       height: "70%",
       overflowY: "auto",
     },

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -65,7 +65,7 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
         {headCells.map((headCell) => (
           <TableCell
             key={headCell.id}
-            style={{ width: headCell.width, paddingRight: 0 }}
+            style={{ width: headCell.width, paddingRight: 0, paddingLeft: 10 }}
             align="left"
             padding="default"
             sortDirection={props.orderBy === headCell.id ? props.order : false}

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -5,6 +5,9 @@ import {
   TableCell,
   TableSortLabel,
   Typography,
+  createStyles,
+  withStyles,
+  WithStyles,
 } from "@material-ui/core";
 import type { Order, OrderKeys } from "./utils";
 
@@ -25,7 +28,7 @@ ColumnTitle.defaultProps = {
   unit: undefined,
 };
 
-const EnhancedTableHead = (props: EnhancedTableProps) => {
+const EnhancedTableHead = (props: EnhancedTablePropsStyled) => {
   const createSortHandler = (property: OrderKeys) => (
     event: React.MouseEvent<unknown>
   ) => {
@@ -64,8 +67,9 @@ const EnhancedTableHead = (props: EnhancedTableProps) => {
       <TableRow>
         {headCells.map((headCell) => (
           <TableCell
+            className={props.classes.headCells}
             key={headCell.id}
-            style={{ width: headCell.width, paddingRight: 0, paddingLeft: 10 }}
+            style={{ width: headCell.width }}
             align="left"
             padding="default"
             sortDirection={props.orderBy === headCell.id ? props.order : false}
@@ -101,4 +105,14 @@ interface EnhancedTableProps {
   orderBy: string;
 }
 
-export default EnhancedTableHead;
+const styles = () =>
+  createStyles({
+    headCells: {
+      paddingRight: 0,
+      paddingLeft: 10,
+    },
+  });
+
+type EnhancedTablePropsStyled = WithStyles<typeof styles> & EnhancedTableProps;
+
+export default withStyles(styles)(EnhancedTableHead);

--- a/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
+++ b/packages/website/src/routes/Homepage/ReefTable/tableHead.tsx
@@ -28,7 +28,7 @@ ColumnTitle.defaultProps = {
   unit: undefined,
 };
 
-const EnhancedTableHead = (props: EnhancedTablePropsStyled) => {
+const EnhancedTableHead = (props: EnhancedTableProps) => {
   const createSortHandler = (property: OrderKeys) => (
     event: React.MouseEvent<unknown>
   ) => {
@@ -96,7 +96,7 @@ interface HeadCell {
   width?: string;
 }
 
-interface EnhancedTableProps {
+interface EnhancedTableIncomingProps {
   onRequestSort: (
     event: React.MouseEvent<unknown>,
     property: OrderKeys
@@ -113,6 +113,7 @@ const styles = () =>
     },
   });
 
-type EnhancedTablePropsStyled = WithStyles<typeof styles> & EnhancedTableProps;
+type EnhancedTableProps = WithStyles<typeof styles> &
+  EnhancedTableIncomingProps;
 
 export default withStyles(styles)(EnhancedTableHead);


### PR DESCRIPTION
- Add a spacing before the table and align card and text
- Switch to monthly ticks when the charts are smaller (width < 400)

<img width="1679" alt="Screen Shot 2020-10-07 at 12 43 19 PM" src="https://user-images.githubusercontent.com/16843267/95321035-b8012280-089a-11eb-9af5-084404271f78.png">
