### PR TITLE
Update reef endpoints

### DIFF
--- a/packages/api/src/reefs/dto/create-reef.dto.ts
+++ b/packages/api/src/reefs/dto/create-reef.dto.ts
@@ -6,10 +6,10 @@ import {
   MaxLength,
   IsInt,
   IsUrl,
+  IsLatitude,
+  IsLongitude,
 } from 'class-validator';
-import { GeoJSON } from 'geojson';
 import { EntityExists } from '../../validations/entity-exists.constraint';
-import { Region } from '../../regions/regions.entity';
 import { User } from '../../users/users.entity';
 import { VideoStream } from '../video-streams.entity';
 
@@ -19,8 +19,11 @@ export class CreateReefDto {
   @MaxLength(50)
   readonly name: string;
 
-  @IsNotEmpty()
-  readonly polygon: GeoJSON;
+  @IsLatitude()
+  readonly latitude: number;
+
+  @IsLongitude()
+  readonly longitude: number;
 
   @IsInt()
   readonly temperatureThreshold: number;
@@ -36,14 +39,9 @@ export class CreateReefDto {
   readonly videoStream: string;
 
   @IsOptional()
-  @IsInt()
-  @Validate(EntityExists, [Region])
-  readonly region?: Region;
-
-  @IsOptional()
-  @IsInt()
-  @Validate(EntityExists, [User])
-  readonly admin?: User;
+  @IsInt({ each: true })
+  @Validate(EntityExists, [User], { each: true })
+  readonly admins?: User[];
 
   @IsOptional()
   @IsInt()

--- a/packages/api/src/reefs/dto/update-reef.dto.ts
+++ b/packages/api/src/reefs/dto/update-reef.dto.ts
@@ -46,9 +46,9 @@ export class UpdateReefDto {
   readonly region?: Region;
 
   @IsOptional()
-  @IsInt()
-  @Validate(EntityExists, [User])
-  readonly admin?: User;
+  @IsInt({ each: true })
+  @Validate(EntityExists, [User], { each: true })
+  readonly admins?: User[];
 
   @IsOptional()
   @IsInt()

--- a/packages/api/src/reefs/reefs.controller.spec.ts
+++ b/packages/api/src/reefs/reefs.controller.spec.ts
@@ -5,6 +5,7 @@ import { ReefsController } from './reefs.controller';
 import { Reef } from './reefs.entity';
 import { DailyData } from './daily-data.entity';
 import { ReefsService } from './reefs.service';
+import { Region } from '../regions/regions.entity';
 
 describe('Reefs Controller', () => {
   let controller: ReefsController;
@@ -18,6 +19,7 @@ describe('Reefs Controller', () => {
         ReefsService,
         { provide: getRepositoryToken(Reef), useClass: Repository },
         { provide: getRepositoryToken(DailyData), useClass: Repository },
+        { provide: getRepositoryToken(Region), useClass: Repository },
       ],
       // You could also provide it the real ReefRepository, but then you'll also have to take care of providing *its*
       // dependencies too (e.g. with an `imports` block.

--- a/packages/api/src/reefs/reefs.controller.ts
+++ b/packages/api/src/reefs/reefs.controller.ts
@@ -3,7 +3,6 @@ import {
   Body,
   Param,
   Get,
-  Post,
   Put,
   Delete,
   Query,
@@ -11,7 +10,6 @@ import {
 } from '@nestjs/common';
 import { ReefsService } from './reefs.service';
 import { Reef } from './reefs.entity';
-import { CreateReefDto } from './dto/create-reef.dto';
 import { FilterReefDto } from './dto/filter-reef.dto';
 import { UpdateReefDto } from './dto/update-reef.dto';
 import { AdminLevel } from '../users/users.entity';
@@ -22,11 +20,6 @@ import { Public } from '../auth/public.decorator';
 @Controller('reefs')
 export class ReefsController {
   constructor(private reefsService: ReefsService) {}
-
-  @Post()
-  create(@Body() createReefDto: CreateReefDto): Promise<Reef> {
-    return this.reefsService.create(createReefDto);
-  }
 
   @Public()
   @Get()

--- a/packages/api/src/reefs/reefs.controller.ts
+++ b/packages/api/src/reefs/reefs.controller.ts
@@ -2,6 +2,7 @@ import {
   Controller,
   Body,
   Param,
+  Post,
   Get,
   Put,
   Delete,
@@ -15,11 +16,17 @@ import { UpdateReefDto } from './dto/update-reef.dto';
 import { AdminLevel } from '../users/users.entity';
 import { Auth } from '../auth/auth.decorator';
 import { Public } from '../auth/public.decorator';
+import { CreateReefDto } from './dto/create-reef.dto';
 
 @Auth(AdminLevel.ReefManager, AdminLevel.SuperAdmin)
 @Controller('reefs')
 export class ReefsController {
   constructor(private reefsService: ReefsService) {}
+
+  @Post()
+  create(@Body() createReefDto: CreateReefDto): Promise<Reef> {
+    return this.reefsService.create(createReefDto);
+  }
 
   @Public()
   @Get()

--- a/packages/api/src/reefs/reefs.module.ts
+++ b/packages/api/src/reefs/reefs.module.ts
@@ -6,9 +6,10 @@ import { Reef } from './reefs.entity';
 import { DailyData } from './daily-data.entity';
 import { EntityExists } from '../validations/entity-exists.constraint';
 import { AuthModule } from '../auth/auth.module';
+import { Region } from '../regions/regions.entity';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([Reef, DailyData])],
+  imports: [AuthModule, TypeOrmModule.forFeature([Reef, DailyData, Region])],
   controllers: [ReefsController],
   providers: [ReefsService, EntityExists],
 })


### PR DESCRIPTION
Update reef endpoint:
- PUT /reefs/<reef_id> (Update reef)
  Issue: The reefs admins were not updated properly
  Fix: The endpoint accepts a User[] which are the active admins of the reef. If no value is provided no update actions on reefs admins is performed
- POST /reefs (Create reef)
  Issue: The reefs admins were not added properly. Also regions, timezones and MMM were being provided by the client and not fetched via the reefs uits
  Fix: Apply same flow as reef-application creation