### PR TITLE
Card uniform spacing

### DIFF
--- a/packages/website/src/routes/ReefRoutes/Reef/CoralBleaching/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/CoralBleaching/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders as expected 1`] = `
     classname="Bleaching-card-1"
   >
     <div
-      class="MuiCardHeader-root Bleaching-header-2"
+      class="MuiCardHeader-root Bleaching-header-3"
     >
       <div
         class="MuiCardHeader-content"
@@ -35,7 +35,7 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <mock-cardcontent
-      classname="Bleaching-contentWrapper-3"
+      classname="Bleaching-contentWrapper-8"
     >
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-center MuiGrid-grid-xs-12"

--- a/packages/website/src/routes/ReefRoutes/Reef/CoralBleaching/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/CoralBleaching/index.tsx
@@ -13,6 +13,7 @@ import {
 import type { DailyData } from "../../../../store/Reefs/types";
 
 import { findIntervalByLevel } from "../../../../helpers/bleachingAlertIntervals";
+import { styles as incomingStyles } from "../styles";
 
 const Bleaching = ({ dailyData, classes }: BleachingProps) => {
   return (
@@ -50,7 +51,9 @@ const Bleaching = ({ dailyData, classes }: BleachingProps) => {
 
 const styles = () =>
   createStyles({
+    ...incomingStyles,
     card: {
+      ...incomingStyles.card,
       height: "100%",
       width: "100%",
       backgroundColor: "#eff0f0",

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
@@ -109,11 +109,9 @@ const ReefDetails = ({
             <Map polygon={reef.polygon} />
           </div>
         </Grid>
-        <Grid className={classes.mediaWrapper} item xs={12} md={6}>
+        <Grid item xs={12} md={6}>
+          {diveDate && point && <CardTitle values={featuredMediaTitleItems} />}
           <div className={classes.container}>
-            {diveDate && point && (
-              <CardTitle values={featuredMediaTitleItems} />
-            )}
             <FeaturedMedia
               url={reef.videoStream}
               featuredImage={reef.featuredImage}
@@ -124,7 +122,12 @@ const ReefDetails = ({
 
       {hasDailyData && (
         <>
-          <Grid container justify="space-between" spacing={4}>
+          <Grid
+            className={classes.metricsWrapper}
+            container
+            justify="space-between"
+            spacing={4}
+          >
             {cards.map(({ Component, props }, index) => (
               <Grid key={index.toString()} item xs={12} sm={6} md={3}>
                 <Component {...props} />
@@ -157,7 +160,6 @@ const styles = (theme: Theme) =>
     },
     container: {
       height: "30rem",
-      marginBottom: "2rem",
       [theme.breakpoints.between("md", 1440)]: {
         height: "25rem",
       },
@@ -165,10 +167,8 @@ const styles = (theme: Theme) =>
         height: "20rem",
       },
     },
-    mediaWrapper: {
-      [theme.breakpoints.down("xs")]: {
-        marginBottom: "3rem",
-      },
+    metricsWrapper: {
+      marginTop: "1rem",
     },
   });
 

--- a/packages/website/src/routes/ReefRoutes/Reef/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/Satellite/__snapshots__/index.test.tsx.snap
@@ -3,11 +3,11 @@
 exports[`renders as expected 1`] = `
 <div>
   <mock-card
-    classname="Satellite-card-7"
+    classname="Satellite-card-1"
     style="background-color: rgb(117, 180, 114);"
   >
     <div
-      class="MuiCardHeader-root Satellite-header-2"
+      class="MuiCardHeader-root Satellite-header-3"
     >
       <div
         class="MuiCardHeader-content"
@@ -25,7 +25,7 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8"
             >
               <mock-typography
-                classname="Satellite-cardTitle-1"
+                classname="Satellite-cardTitle-2"
                 variant="h6"
               >
                 SATELLITE OBSERVATION
@@ -59,13 +59,13 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
           >
             <mock-typography
-              classname="Satellite-contentTextTitles-3"
+              classname="Satellite-contentTextTitles-4"
               variant="subtitle2"
             >
               SURFACE TEMP
             </mock-typography>
             <mock-typography
-              classname="Satellite-contentTextValues-4"
+              classname="Satellite-contentTextValues-5"
               variant="h2"
             >
               26.0 °C
@@ -75,7 +75,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
           >
             <mock-typography
-              classname="Satellite-contentTextTitles-3"
+              classname="Satellite-contentTextTitles-4"
               variant="subtitle2"
             >
               HISTORICAL MAX
@@ -84,7 +84,7 @@ exports[`renders as expected 1`] = `
               title="Historical maximum monthly average over the past 20 years"
             >
               <mock-typography
-                classname="Satellite-contentTextValues-4"
+                classname="Satellite-contentTextValues-5"
                 variant="h2"
               >
                 24.0 °C
@@ -95,7 +95,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
           >
             <mock-typography
-              classname="Satellite-contentTextTitles-3"
+              classname="Satellite-contentTextTitles-4"
               variant="subtitle2"
             >
               HEAT STRESS
@@ -104,7 +104,7 @@ exports[`renders as expected 1`] = `
               title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
             >
               <mock-typography
-                classname="Satellite-contentTextValues-4"
+                classname="Satellite-contentTextValues-5"
                 variant="h2"
               >
                 4.6 DHW

--- a/packages/website/src/routes/ReefRoutes/Reef/Satellite/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/Satellite/index.tsx
@@ -131,6 +131,7 @@ const styles = () =>
   createStyles({
     ...incomingStyles,
     card: {
+      ...incomingStyles.card,
       display: "flex",
       flexDirection: "column",
       height: "100%",

--- a/packages/website/src/routes/ReefRoutes/Reef/Sensor/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/Sensor/__snapshots__/index.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`Sensor Card should render with given state from Redux store 1`] = `
 <div>
   <mock-card
-    classname="Sensor-card-7"
+    classname="Sensor-card-1"
   >
     <div
-      class="MuiCardHeader-root Sensor-header-2"
+      class="MuiCardHeader-root Sensor-header-3"
     >
       <div
         class="MuiCardHeader-content"
@@ -24,7 +24,7 @@ exports[`Sensor Card should render with given state from Redux store 1`] = `
               class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-8"
             >
               <mock-typography
-                classname="Sensor-cardTitle-1"
+                classname="Sensor-cardTitle-2"
                 variant="h6"
               >
                 SENSOR OBSERVATION
@@ -59,13 +59,13 @@ exports[`Sensor Card should render with given state from Redux store 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
           >
             <mock-typography
-              classname="Sensor-contentTextTitles-3"
+              classname="Sensor-contentTextTitles-4"
               variant="subtitle2"
             >
               TEMP AT 1m
             </mock-typography>
             <mock-typography
-              classname="Sensor-contentTextValues-4"
+              classname="Sensor-contentTextValues-5"
               variant="h2"
             >
               - - °C
@@ -75,13 +75,13 @@ exports[`Sensor Card should render with given state from Redux store 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
           >
             <mock-typography
-              classname="Sensor-contentTextTitles-3"
+              classname="Sensor-contentTextTitles-4"
               variant="subtitle2"
             >
               TEMP AT 24m
             </mock-typography>
             <mock-typography
-              classname="Sensor-contentTextValues-4"
+              classname="Sensor-contentTextValues-5"
               variant="h2"
             >
               25.0 °C

--- a/packages/website/src/routes/ReefRoutes/Reef/Sensor/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/Sensor/index.tsx
@@ -127,6 +127,7 @@ const styles = () =>
   createStyles({
     ...incomingStyles,
     card: {
+      ...incomingStyles.card,
       display: "flex",
       flexDirection: "column",
       height: "100%",

--- a/packages/website/src/routes/ReefRoutes/Reef/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/Waves/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`renders as expected 1`] = `
 <div>
   <mock-card
-    classname="Waves-card-7"
+    classname="Waves-card-1"
   >
     <mock-cardcontent
       classname="Waves-contentWrapper-9"
@@ -15,7 +15,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
         >
           <mock-typography
-            classname="Waves-cardTitle-1"
+            classname="Waves-cardTitle-2"
             variant="h6"
           >
             WIND
@@ -33,7 +33,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
           >
             <mock-typography
-              classname="Waves-contentTextTitles-3"
+              classname="Waves-contentTextTitles-4"
               color="textSecondary"
               variant="subtitle2"
             >
@@ -43,14 +43,14 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
             >
               <mock-typography
-                classname="Waves-contentTextValues-4"
+                classname="Waves-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >
                 5.0
               </mock-typography>
               <mock-typography
-                classname="Waves-contentUnits-5"
+                classname="Waves-contentUnits-6"
                 color="textSecondary"
                 variant="h6"
               >
@@ -62,7 +62,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
           >
             <mock-typography
-              classname="Waves-contentTextTitles-3"
+              classname="Waves-contentTextTitles-4"
               color="textSecondary"
               variant="subtitle2"
             >
@@ -78,7 +78,7 @@ exports[`renders as expected 1`] = `
                 style="transform: rotate(276deg);"
               />
               <mock-typography
-                classname="Waves-contentTextValues-4"
+                classname="Waves-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >
@@ -91,7 +91,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
         >
           <mock-typography
-            classname="Waves-cardTitle-1"
+            classname="Waves-cardTitle-2"
             variant="h6"
           >
             WAVES
@@ -109,7 +109,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4"
           >
             <mock-typography
-              classname="Waves-contentTextTitles-3"
+              classname="Waves-contentTextTitles-4"
               color="textSecondary"
               variant="subtitle2"
             >
@@ -119,14 +119,14 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
             >
               <mock-typography
-                classname="Waves-contentTextValues-4"
+                classname="Waves-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >
                 3.0
               </mock-typography>
               <mock-typography
-                classname="Waves-contentUnits-5"
+                classname="Waves-contentUnits-6"
                 color="textSecondary"
                 variant="h6"
               >
@@ -138,7 +138,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3"
           >
             <mock-typography
-              classname="Waves-contentTextTitles-3"
+              classname="Waves-contentTextTitles-4"
               color="textSecondary"
               variant="subtitle2"
             >
@@ -148,14 +148,14 @@ exports[`renders as expected 1`] = `
               class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
             >
               <mock-typography
-                classname="Waves-contentTextValues-4"
+                classname="Waves-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >
                 15
               </mock-typography>
               <mock-typography
-                classname="Waves-contentUnits-5"
+                classname="Waves-contentUnits-6"
                 color="textSecondary"
                 variant="h6"
               >
@@ -167,7 +167,7 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5"
           >
             <mock-typography
-              classname="Waves-contentTextTitles-3"
+              classname="Waves-contentTextTitles-4"
               color="textSecondary"
               variant="subtitle2"
             >
@@ -183,7 +183,7 @@ exports[`renders as expected 1`] = `
                 style="transform: rotate(316deg);"
               />
               <mock-typography
-                classname="Waves-contentTextValues-4"
+                classname="Waves-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >

--- a/packages/website/src/routes/ReefRoutes/Reef/Waves/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/Waves/index.tsx
@@ -202,6 +202,7 @@ const styles = (theme: Theme) =>
   createStyles({
     ...incomingStyles,
     card: {
+      ...incomingStyles.card,
       height: "100%",
       width: "100%",
       backgroundColor: "#eff0f0",

--- a/packages/website/src/routes/ReefRoutes/Reef/styles.ts
+++ b/packages/website/src/routes/ReefRoutes/Reef/styles.ts
@@ -1,6 +1,9 @@
 import theme from "../../../layout/App/theme";
 
 export const styles = {
+  card: {
+    minHeight: "18rem",
+  },
   cardTitle: {
     lineHeight: 1.5,
     [theme.breakpoints.between("md", 1544)]: {


### PR DESCRIPTION
The purpose of this PR is to add uniform spacing between the reef detail page cards. The design implemented looks like this:

![Screenshot from 2020-10-13 13-08-41](https://user-images.githubusercontent.com/64922890/95847496-73233300-0d55-11eb-9691-222e605f5169.png)
