### PR TITLE
Handle duplicate reef location

### DIFF
--- a/packages/api/src/reef-applications/reef-applications.service.ts
+++ b/packages/api/src/reef-applications/reef-applications.service.ts
@@ -12,7 +12,11 @@ import {
 } from './dto/update-reef-application.dto';
 import { Reef } from '../reefs/reefs.entity';
 import { Region } from '../regions/regions.entity';
-import { getRegion, getTimezones } from '../utils/reef.utils';
+import {
+  getRegion,
+  getTimezones,
+  handleDuplicateReef,
+} from '../utils/reef.utils';
 import { getMMM } from '../utils/temperature';
 import { AdminLevel, User } from '../users/users.entity';
 import { backfillReefData } from '../workers/backfill-reef-data';
@@ -42,18 +46,20 @@ export class ReefApplicationsService {
     const maxMonthlyMean = await getMMM(longitude, latitude);
     const timezones = getTimezones(latitude, longitude) as string[];
 
-    const reef = await this.reefRepository.save({
-      name,
-      depth,
-      polygon: {
-        type: 'Point',
-        coordinates: [longitude, latitude],
-      },
-      maxMonthlyMean,
-      timezone: timezones[0],
-      approved: false,
-      region,
-    });
+    const reef = await this.reefRepository
+      .save({
+        name,
+        depth,
+        polygon: {
+          type: 'Point',
+          coordinates: [longitude, latitude],
+        },
+        maxMonthlyMean,
+        timezone: timezones[0],
+        approved: false,
+        region,
+      })
+      .catch(handleDuplicateReef);
 
     // Elevate user to ReefManager
     if (user.adminLevel === AdminLevel.Default) {

--- a/packages/api/src/utils/reef.utils.ts
+++ b/packages/api/src/utils/reef.utils.ts
@@ -3,7 +3,11 @@ import {
   AddressType,
   GeocodeResult,
 } from '@googlemaps/google-maps-services-js';
-import { Logger } from '@nestjs/common';
+import {
+  BadRequestException,
+  InternalServerErrorException,
+  Logger,
+} from '@nestjs/common';
 import { Repository } from 'typeorm';
 import { Point } from 'geojson';
 import geoTz from 'geo-tz';
@@ -86,4 +90,14 @@ export const getRegion = async (
 
 export const getTimezones = (latitude: number, longitude: number) => {
   return geoTz(latitude, longitude);
+};
+
+export const handleDuplicateReef = (err) => {
+  // Unique Violation: A reef already exists at these coordinates
+  if (err.code === '23505') {
+    throw new BadRequestException('A reef already exists at these coordinates');
+  }
+
+  logger.error('An unexpected error occurred', err);
+  throw new InternalServerErrorException('An unexpected error occurred');
 };


### PR DESCRIPTION
Add error handler to recognize and send a more user-friendly message when a reef update/insert fails due to a unique violation on the polygon (location) field.