### PR TITLE
Run daily update at 4am PST

### DIFF
--- a/packages/api/cloud-functions/index.ts
+++ b/packages/api/cloud-functions/index.ts
@@ -59,7 +59,8 @@ exports.dailyUpdate = functions
 
 exports.scheduledDailyUpdate = functions
   .runWith({ timeoutSeconds: 540 })
-  .pubsub.schedule('every 24 hours')
+  .pubsub.schedule('0 4 * * *')
+  .timeZone('America/Los_Angeles')
   .onRun(async () => {
     const dbUrl = functions.config().database.url;
     // eslint-disable-next-line fp/no-mutation


### PR DESCRIPTION
According to this guide https://firebase.google.com/docs/functions/schedule-functions we can add a crontab string to schedule the function with a custom period.
Also we can set the timezone which will be used to match the above filled pattern. (The default is America/Los_Angeles but we set it to be more verbose)

Related issue https://github.com/aqualinkorg/aqualink-app/issues/304