### PR TITLE
Remove `ActiveReefListener` component

### DIFF
--- a/packages/website/src/routes/HomeMap/Map/Popup/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/Map/Popup/__snapshots__/index.test.tsx.snap
@@ -1,8 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`renders as expected 1`] = `
+exports[`Popup should render with given state from Redux store 1`] = `
 <div>
   <mock-leafletpopup
+    autopan="false"
     classname="Popup-popup-3"
     closebutton="false"
   >

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.test.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import { Provider } from "react-redux";
 import { render } from "@testing-library/react";
+import configureStore from "redux-mock-store";
 
 import { BrowserRouter as Router } from "react-router-dom";
 import Popup from ".";
@@ -7,15 +9,37 @@ import { mockReef } from "../../../../mocks/mockReef";
 
 jest.mock("react-leaflet", () => ({
   __esModule: true,
+  useLeaflet: () => {
+    return {
+      map: jest.requireActual("react").createElement("mock-LeafletPopup", {}),
+    };
+  },
   Popup: (props: any) =>
     jest.requireActual("react").createElement("mock-LeafletPopup", props),
 }));
 
-test("renders as expected", () => {
-  const { container } = render(
-    <Router>
-      <Popup reef={mockReef} />
-    </Router>
-  );
-  expect(container).toMatchSnapshot();
+const mockStore = configureStore([]);
+describe("Popup", () => {
+  let element: HTMLElement;
+  beforeEach(() => {
+    const store = mockStore({
+      homepage: {
+        reefOnMap: mockReef,
+      },
+    });
+
+    store.dispatch = jest.fn();
+
+    element = render(
+      <Provider store={store}>
+        <Router>
+          <Popup reef={mockReef} />
+        </Router>
+      </Provider>
+    ).container;
+  });
+
+  it("should render with given state from Redux store", () => {
+    expect(element).toMatchSnapshot();
+  });
 });

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect, useRef } from "react";
 import {
   withStyles,
   WithStyles,
@@ -13,7 +13,8 @@ import {
   Tooltip,
 } from "@material-ui/core";
 import { Link } from "react-router-dom";
-import { Popup as LeafletPopup } from "react-leaflet";
+import { Popup as LeafletPopup, useLeaflet } from "react-leaflet";
+import { useSelector } from "react-redux";
 
 import { Reef } from "../../../../store/Reefs/types";
 import { getReefNameAndRegion } from "../../../../store/Reefs/helpers";
@@ -23,13 +24,30 @@ import {
   dhwColorFinder,
   degreeHeatingWeeksCalculator,
 } from "../../../../helpers/degreeHeatingWeeks";
+import { reefOnMapSelector } from "../../../../store/Homepage/homepageSlice";
 
 const Popup = ({ reef, classes }: PopupProps) => {
+  const { map } = useLeaflet();
+  const reefOnMap = useSelector(reefOnMapSelector);
+  const popupRef = useRef<LeafletPopup>(null);
   const { degreeHeatingDays, maxBottomTemperature, satelliteTemperature } =
     reef.latestDailyData || {};
 
+  useEffect(() => {
+    if (map && popupRef?.current && reefOnMap?.polygon.type === "Point") {
+      const { leafletElement: popup } = popupRef.current;
+      const [lng, lat] = reefOnMap.polygon.coordinates;
+      popup.setLatLng([lat, lng]).openOn(map);
+    }
+  }, [map, reefOnMap]);
+
   return (
-    <LeafletPopup closeButton={false} className={classes.popup}>
+    <LeafletPopup
+      ref={reefOnMap?.id === reef.id ? popupRef : null}
+      closeButton={false}
+      className={classes.popup}
+      autoPan={false}
+    >
       <Card>
         <CardHeader
           className={classes.popupHeader}


### PR DESCRIPTION
This PR is scheduled to fix the homepage map crashing issue. It basically removes the `ActiveReefListener` component, which used `leaflet`'s `"moveend"`, which seemed to cause the issue. This approach passes a `ref` to the selected reef's `Popup` and opens it via `popup.setLatLng([lat, lng]).openOn(map)`.