### PR TITLE
Hide spotter chart when site has no spotter

### DIFF
--- a/packages/website/src/common/Chart/ChartWithTooltip.tsx
+++ b/packages/website/src/common/Chart/ChartWithTooltip.tsx
@@ -9,7 +9,6 @@ import type { ChartTooltipModel } from "chart.js";
 import Chart, { ChartProps } from ".";
 import Tooltip, { TooltipData } from "./Tooltip";
 import {
-  CHART_BOTTOM_TEMP_ENABLED,
   getDailyDataClosestToDate,
   getSpotterDataClosestToDate,
   sameDay,
@@ -78,8 +77,7 @@ function ChartWithTooltip({
         )?.value) ||
       null;
 
-    const bottomTemperature =
-      bottomTemp || (CHART_BOTTOM_TEMP_ENABLED ? avgBottomTemperature : null);
+    const bottomTemperature = bottomTemp || avgBottomTemperature;
 
     const nValues = [
       satelliteTemperature,

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
@@ -7,6 +7,7 @@ import {
   Theme,
   Box,
   CircularProgress,
+  Typography,
 } from "@material-ui/core";
 import { MaterialUiPickersDate } from "@material-ui/pickers/typings/date";
 import moment from "moment";
@@ -181,8 +182,7 @@ const ReefDetails = ({
                   <CircularProgress size="6rem" thickness={1} />
                 </Box>
               ) : (
-                spotterData &&
-                spotterData.bottomTemperature.length > 1 && (
+                (spotterData && spotterData.bottomTemperature.length > 1 && (
                   <Charts
                     title="HOURLY WATER TEMPERATURE (°C)"
                     dailyData={reef.dailyData}
@@ -196,6 +196,12 @@ const ReefDetails = ({
                     temperatureThreshold={null}
                     background={false}
                   />
+                )) || (
+                  <Box mt="2rem">
+                    <Typography>
+                      No Smart Buoy data available in this time range.
+                    </Typography>
+                  </Box>
                 )
               ))}
             <Surveys reefId={reef.id} />

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
@@ -181,7 +181,8 @@ const ReefDetails = ({
                   <CircularProgress size="6rem" thickness={1} />
                 </Box>
               ) : (
-                spotterData && (
+                spotterData &&
+                spotterData.length > 1 && (
                   <Charts
                     title="HOURLY WATER TEMPERATURE (°C)"
                     dailyData={reef.dailyData}

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
@@ -168,34 +168,35 @@ const ReefDetails = ({
                 <DatePicker value={pickerDate} onChange={onDateChange} />
               </Grid>
             )}
-            {spotterDataLoading ? (
-              <Box
-                height="20rem"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                textAlign="center"
-                p={4}
-              >
-                <CircularProgress size="6rem" thickness={1} />
-              </Box>
-            ) : (
-              spotterData && (
-                <Charts
-                  title="HOURLY WATER TEMPERATURE (°C)"
-                  dailyData={reef.dailyData}
-                  spotterData={spotterData}
-                  startDate={startDate}
-                  endDate={endDate}
-                  chartPeriod={chartPeriod}
-                  surveys={[]}
-                  depth={reef.depth}
-                  maxMonthlyMean={null}
-                  temperatureThreshold={null}
-                  background={false}
-                />
-              )
-            )}
+            {hasSpotter &&
+              (spotterDataLoading ? (
+                <Box
+                  height="20rem"
+                  display="flex"
+                  alignItems="center"
+                  justifyContent="center"
+                  textAlign="center"
+                  p={4}
+                >
+                  <CircularProgress size="6rem" thickness={1} />
+                </Box>
+              ) : (
+                spotterData && (
+                  <Charts
+                    title="HOURLY WATER TEMPERATURE (°C)"
+                    dailyData={reef.dailyData}
+                    spotterData={spotterData}
+                    startDate={startDate}
+                    endDate={endDate}
+                    chartPeriod={chartPeriod}
+                    surveys={[]}
+                    depth={reef.depth}
+                    maxMonthlyMean={null}
+                    temperatureThreshold={null}
+                    background={false}
+                  />
+                )
+              ))}
             <Surveys reefId={reef.id} />
           </Box>
         </>

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefDetails.tsx
@@ -182,7 +182,7 @@ const ReefDetails = ({
                 </Box>
               ) : (
                 spotterData &&
-                spotterData.length > 1 && (
+                spotterData.bottomTemperature.length > 1 && (
                   <Charts
                     title="HOURLY WATER TEMPERATURE (°C)"
                     dailyData={reef.dailyData}

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -25,6 +25,7 @@ import {
   reefRequest,
   reefSpotterDataRequest,
   reefSpotterDataSelector,
+  setReefSpotterData,
 } from "../../../store/Reefs/selectedReefSlice";
 import {
   surveysRequest,
@@ -141,6 +142,9 @@ const Reef = ({ match, classes }: ReefProps) => {
           endDate: pickerDate,
         })
       );
+    } else {
+      // Clear possible spotter data from previously selected reef
+      dispatch(setReefSpotterData(null));
     }
   }, [dispatch, reefId, hasSpotter, range, pickerDate]);
 

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -25,7 +25,7 @@ import {
   reefRequest,
   reefSpotterDataRequest,
   reefSpotterDataSelector,
-  setReefSpotterData,
+  clearReefSpotterData,
 } from "../../../store/Reefs/selectedReefSlice";
 import {
   surveysRequest,
@@ -144,7 +144,7 @@ const Reef = ({ match, classes }: ReefProps) => {
       );
     } else {
       // Clear possible spotter data from previously selected reef
-      dispatch(setReefSpotterData(null));
+      dispatch(clearReefSpotterData(null));
     }
   }, [dispatch, reefId, hasSpotter, range, pickerDate]);
 

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -144,7 +144,7 @@ const Reef = ({ match, classes }: ReefProps) => {
       );
     } else {
       // Clear possible spotter data from previously selected reef
-      dispatch(clearReefSpotterData(null));
+      dispatch(clearReefSpotterData());
     }
   }, [dispatch, reefId, hasSpotter, range, pickerDate]);
 

--- a/packages/website/src/store/Reefs/selectedReefSlice.ts
+++ b/packages/website/src/store/Reefs/selectedReefSlice.ts
@@ -99,7 +99,7 @@ const selectedReefSlice = createSlice({
       }
       return state;
     },
-    setReefSpotterData: (
+    clearReefSpotterData: (
       state,
       action: PayloadAction<SelectedReefState["spotterData"]>
     ) => ({
@@ -199,7 +199,7 @@ export const {
   setReefDraft,
   setSelectedReef,
   setReefData,
-  setReefSpotterData,
+  clearReefSpotterData,
 } = selectedReefSlice.actions;
 
 export default selectedReefSlice.reducer;

--- a/packages/website/src/store/Reefs/selectedReefSlice.ts
+++ b/packages/website/src/store/Reefs/selectedReefSlice.ts
@@ -99,12 +99,9 @@ const selectedReefSlice = createSlice({
       }
       return state;
     },
-    clearReefSpotterData: (
-      state,
-      action: PayloadAction<SelectedReefState["spotterData"]>
-    ) => ({
+    clearReefSpotterData: (state) => ({
       ...state,
-      spotterData: action.payload,
+      spotterData: null,
     }),
   },
   extraReducers: (builder) => {

--- a/packages/website/src/store/Reefs/selectedReefSlice.ts
+++ b/packages/website/src/store/Reefs/selectedReefSlice.ts
@@ -99,6 +99,13 @@ const selectedReefSlice = createSlice({
       }
       return state;
     },
+    setReefSpotterData: (
+      state,
+      action: PayloadAction<SelectedReefState["spotterData"]>
+    ) => ({
+      ...state,
+      spotterData: action.payload,
+    }),
   },
   extraReducers: (builder) => {
     builder.addCase(
@@ -192,6 +199,7 @@ export const {
   setReefDraft,
   setSelectedReef,
   setReefData,
+  setReefSpotterData,
 } = selectedReefSlice.actions;
 
 export default selectedReefSlice.reducer;

--- a/packages/website/src/store/Reefs/types.ts
+++ b/packages/website/src/store/Reefs/types.ts
@@ -145,7 +145,7 @@ export interface ReefsListState {
 export interface SelectedReefState {
   draft: ReefUpdateParams | null;
   details?: Reef | null;
-  spotterData?: SpotterData;
+  spotterData?: SpotterData | null;
   spotterDataLoading: boolean;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
We noticed that when visiting a site with no spotter after visiting a site with a spotter, the spotter chart would sometimes stay on with data from the previous site.

This PR is adding an `hasSpotter` check before displaying spotter charts.

We could also look into making sure that `spotterData` get's removed properly when a new site is selected.

@tleraj let me know what you think