### PR TITLE
Add autoselect and geolocation to search bar

### DIFF
--- a/packages/website/.env.example
+++ b/packages/website/.env.example
@@ -15,3 +15,7 @@ REACT_APP_CARTO_API_KEY=
 
 # Mapbox token to access custom styles
 REACT_APP_MAPBOX_ACCESS_TOKEN=
+
+# Mapbox API Base URL
+# Proposed value: "https://api.mapbox.com/geocoding/v5/mapbox.places/"
+REACT_APP_MAPBOX_BASE_URL=

--- a/packages/website/.env.example
+++ b/packages/website/.env.example
@@ -15,7 +15,3 @@ REACT_APP_CARTO_API_KEY=
 
 # Mapbox token to access custom styles
 REACT_APP_MAPBOX_ACCESS_TOKEN=
-
-# Mapbox API Base URL
-# Proposed value: "https://api.mapbox.com/geocoding/v5/mapbox.places/"
-REACT_APP_MAPBOX_BASE_URL=

--- a/packages/website/src/common/Search/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/Search/__snapshots__/index.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`Search should render with given state from Redux store 1`] = `
           id="location"
           inputlabelprops="[object Object]"
           inputprops="[object Object]"
-          placeholder="Search by site name"
+          placeholder="Search by site name or country"
           variant="outlined"
         />
       </div>

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -24,12 +24,12 @@ const reefAugmentedName = (reef: Reef) => {
   if (name && region) {
     return `${name}, ${region}`;
   }
-  return `${name || region || ""}`;
+  return name || region || "";
 };
 
 const Search = ({ classes }: SearchProps) => {
   const [searchedReef, setSearchedReef] = useState<Reef | null>(null);
-  const [searchValue, setSearchValue] = useState<string>("");
+  const [searchValue, setSearchValue] = useState("");
   const dispatch = useDispatch();
   // eslint-disable-next-line fp/no-mutating-methods
   const reefs = useSelector(reefsListSelector)
@@ -70,8 +70,7 @@ const Search = ({ classes }: SearchProps) => {
       mapServices
         .getLocation(searchValue)
         .then((data) => dispatch(setSearchResult(data)))
-        // eslint-disable-next-line no-console
-        .catch((error) => console.log(error));
+        .catch(console.error);
     }
   };
 
@@ -97,10 +96,10 @@ const Search = ({ classes }: SearchProps) => {
           className={classes.searchBarInput}
           options={reefs}
           noOptionsText={`No sites found. Press enter to zoom to "${searchValue}"`}
-          getOptionLabel={(reef) => reefAugmentedName(reef)}
+          getOptionLabel={reefAugmentedName}
           value={searchedReef}
           onChange={onDropdownItemSelect}
-          onInputChange={(event, value, reason) =>
+          onInputChange={(_event, _value, reason) =>
             reason === "clear" && setSearchedReef(null)
           }
           renderInput={(params) => (

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -19,35 +19,27 @@ import { reefsListSelector } from "../../store/Reefs/reefsListSlice";
 import { getReefNameAndRegion } from "../../store/Reefs/helpers";
 import mapServices from "../../services/mapServices";
 
+const reefAugmentedName = (reef: Reef) => {
+  const { name, region } = getReefNameAndRegion(reef);
+  if (name && region) {
+    return `${name}, ${region}`;
+  }
+  return `${name || region || ""}`;
+};
+
 const Search = ({ classes }: SearchProps) => {
   const [searchedReef, setSearchedReef] = useState<Reef | null>(null);
   const [searchValue, setSearchValue] = useState<string>("");
   const dispatch = useDispatch();
   // eslint-disable-next-line fp/no-mutating-methods
   const reefs = useSelector(reefsListSelector)
-    .filter((reef) => getReefNameAndRegion(reef).name)
+    .filter((reef) => reefAugmentedName(reef))
     // Sort by formatted name
     .sort((a, b) => {
-      const nameA = getReefNameAndRegion(a).name || "";
-      const nameB = getReefNameAndRegion(b).name || "";
+      const nameA = reefAugmentedName(a);
+      const nameB = reefAugmentedName(b);
       return nameA.localeCompare(nameB);
     });
-
-  const onChangeSearchText = (
-    event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-  ) => {
-    const searchInput = event.target.value;
-    const index = reefs.findIndex(
-      (reef) =>
-        getReefNameAndRegion(reef).name?.toLowerCase() ===
-        searchInput.toLowerCase()
-    );
-    if (index > -1) {
-      setSearchedReef(reefs[index]);
-    } else {
-      setSearchValue(searchInput);
-    }
-  };
 
   const onDropdownItemSelect = (event: ChangeEvent<{}>, value: Reef | null) => {
     if (value) {
@@ -84,11 +76,13 @@ const Search = ({ classes }: SearchProps) => {
 
       <div className={classes.searchBarText}>
         <Autocomplete
-          onKeyPress={onKeyPress}
           id="location"
+          autoHighlight
+          onKeyPress={onKeyPress}
           className={classes.searchBarInput}
           options={reefs}
-          getOptionLabel={(reef) => getReefNameAndRegion(reef).name || ""}
+          noOptionsText={`No sites found. Press enter to zoom to "${searchValue}"`}
+          getOptionLabel={(reef) => reefAugmentedName(reef)}
           value={searchedReef}
           onChange={onDropdownItemSelect}
           onInputChange={(event, value, reason) =>
@@ -97,8 +91,7 @@ const Search = ({ classes }: SearchProps) => {
           renderInput={(params) => (
             <TextField
               {...params}
-              onChange={onChangeSearchText}
-              placeholder="Search by site name"
+              placeholder="Search by site name or country"
               variant="outlined"
               InputLabelProps={{
                 shrink: false,

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -58,7 +58,7 @@ const Search = ({ classes }: SearchProps) => {
 
   const onDropdownItemSelect = (event: ChangeEvent<{}>, value: Reef | null) => {
     if (value) {
-      setSearchedReef(value);
+      setSearchedReef(null);
       dispatch(setReefOnMap(value));
     }
   };
@@ -66,6 +66,7 @@ const Search = ({ classes }: SearchProps) => {
   const onSearchSubmit = () => {
     if (searchedReef) {
       dispatch(setReefOnMap(searchedReef));
+      setSearchedReef(null);
     } else if (searchValue) {
       mapServices
         .getLocation(searchValue)

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -41,6 +41,21 @@ const Search = ({ classes }: SearchProps) => {
       return nameA.localeCompare(nameB);
     });
 
+  const onChangeSearchText = (
+    event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
+  ) => {
+    const searchInput = event.target.value;
+    const index = reefs.findIndex(
+      (reef) =>
+        reefAugmentedName(reef).toLowerCase() === searchInput.toLowerCase()
+    );
+    if (index > -1) {
+      setSearchedReef(reefs[index]);
+    } else {
+      setSearchValue(searchInput);
+    }
+  };
+
   const onDropdownItemSelect = (event: ChangeEvent<{}>, value: Reef | null) => {
     if (value) {
       setSearchedReef(value);
@@ -91,6 +106,7 @@ const Search = ({ classes }: SearchProps) => {
           renderInput={(params) => (
             <TextField
               {...params}
+              onChange={onChangeSearchText}
               placeholder="Search by site name or country"
               variant="outlined"
               InputLabelProps={{

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -14,6 +14,7 @@ import { ReefMarkers } from "./Markers";
 import { SofarLayers } from "./sofarLayers";
 import Legend from "./Legend";
 import AlertLevelLegend from "./alertLevelLegend";
+import { searchResultSelector } from "../../../store/Homepage/homepageSlice";
 
 const INITIAL_CENTER = new LatLng(19, -76.3);
 const INITIAL_ZOOM = 5;
@@ -30,12 +31,19 @@ const attribution = accessToken
 const HomepageMap = ({ classes }: HomepageMapProps) => {
   const [legendName, setLegendName] = useState<string>("");
   const loading = useSelector(reefsListLoadingSelector);
+  const searchResult = useSelector(searchResultSelector);
   const ref = useRef<Map>(null);
 
   useEffect(() => {
     const { current } = ref;
     if (current && current.leafletElement) {
       const map = current.leafletElement;
+      if (searchResult) {
+        map.fitBounds([
+          searchResult.bbox.southWest,
+          searchResult.bbox.northEast,
+        ]);
+      }
       map.on("baselayerchange", (layer: any) => {
         setLegendName(layer.name);
       });

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -21,6 +21,7 @@ import { reefsListSelector } from "../../../store/Reefs/reefsListSlice";
 import {
   reefOnMapSelector,
   setReefOnMap,
+  setSearchResult,
 } from "../../../store/Homepage/homepageSlice";
 import { getComparator, Order, OrderKeys, stableSort } from "./utils";
 import { alertColorFinder } from "../../../helpers/bleachingAlertIntervals";
@@ -111,6 +112,7 @@ const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
 
   const handleClick = (event: unknown, reef: Row) => {
     setSelectedRow(reef.tableData.id);
+    dispatch(setSearchResult());
     dispatch(setReefOnMap(reefsList[reef.tableData.id]));
   };
 

--- a/packages/website/src/services/mapServices.ts
+++ b/packages/website/src/services/mapServices.ts
@@ -2,10 +2,8 @@ import axios from "axios";
 
 import type { MapboxGeolocationData } from "../store/Homepage/types";
 
-const {
-  REACT_APP_MAPBOX_BASE_URL: mapboxBaseUrl,
-  REACT_APP_MAPBOX_ACCESS_TOKEN: mapboxToken,
-} = process.env;
+const { REACT_APP_MAPBOX_ACCESS_TOKEN: mapboxToken } = process.env;
+const mapboxBaseUrl = "https://api.mapbox.com/geocoding/v5/mapbox.places/";
 
 const getLocation = (location: string) =>
   axios({

--- a/packages/website/src/services/mapServices.ts
+++ b/packages/website/src/services/mapServices.ts
@@ -1,0 +1,29 @@
+import axios from "axios";
+
+import type { MapboxGeolocationData } from "../store/Homepage/types";
+
+const {
+  REACT_APP_MAPBOX_BASE_URL: mapboxBaseUrl,
+  REACT_APP_MAPBOX_ACCESS_TOKEN: mapboxToken,
+} = process.env;
+
+const getLocation = (location: string) =>
+  axios({
+    method: "GET",
+    url: `${mapboxBaseUrl}${location}.json`,
+    params: {
+      access_token: mapboxToken,
+    },
+  }).then(({ data }) => {
+    const feature = data.features[0];
+    const response: MapboxGeolocationData = {
+      bbox: {
+        southWest: [feature.bbox[1], feature.bbox[0]],
+        northEast: [feature.bbox[3], feature.bbox[2]],
+      },
+      placeName: feature.place_name,
+    };
+    return response;
+  });
+
+export default { getLocation };

--- a/packages/website/src/store/Homepage/homepageSlice.ts
+++ b/packages/website/src/store/Homepage/homepageSlice.ts
@@ -12,6 +12,13 @@ const homepageSlice = createSlice({
   name: "homepage",
   initialState: homepageInitialState,
   reducers: {
+    setSearchResult: (
+      state,
+      action: PayloadAction<HomePageState["searchResult"]>
+    ) => ({
+      ...state,
+      searchResult: action.payload,
+    }),
     setReefOnMap: (state, action: PayloadAction<Reef>) => ({
       ...state,
       reefOnMap: action.payload,
@@ -26,6 +33,14 @@ export const reefOnMapSelector = (
   state: RootState
 ): HomePageState["reefOnMap"] => state.homepage.reefOnMap;
 
-export const { setReefOnMap, unsetReefOnMap } = homepageSlice.actions;
+export const searchResultSelector = (
+  state: RootState
+): HomePageState["searchResult"] => state.homepage.searchResult;
+
+export const {
+  setSearchResult,
+  setReefOnMap,
+  unsetReefOnMap,
+} = homepageSlice.actions;
 
 export default homepageSlice.reducer;

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -1,7 +1,16 @@
 import { Reef } from "../Reefs/types";
 
+export interface MapboxGeolocationData {
+  bbox: {
+    southWest: [number, number];
+    northEast: [number, number];
+  };
+  placeName: string;
+}
+
 export interface HomePageState {
   reefOnMap: Reef | null;
+  searchResult?: MapboxGeolocationData;
 }
 
 export interface TableRow {


### PR DESCRIPTION
This PR:
- adds the region name to the searchable text and display
- autoselects the first row so that clicking enter zooms on it
- if no site is found, propose to use geolocation on `enter`

<img width="602" alt="Screen Shot 2020-11-13 at 3 17 08 PM" src="https://user-images.githubusercontent.com/16843267/99130473-461ca700-25c5-11eb-8930-76ee38c003d2.png">
<img width="520" alt="Screen Shot 2020-11-13 at 3 17 20 PM" src="https://user-images.githubusercontent.com/16843267/99130470-44eb7a00-25c5-11eb-9006-74059400f661.png">
