### PR TITLE
Change text from "register" to "sign up"

### DIFF
--- a/packages/website/src/common/ErrorPage/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/ErrorPage/__snapshots__/index.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`Error Page should render with given state from Redux store 1`] = `
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div
@@ -649,7 +649,7 @@ exports[`Error Page should render with given state from Redux store 1`] = `
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -158,7 +158,7 @@ const NavBar = ({ searchLocation, routeButtons, classes }: NavBarProps) => {
                 <>
                   <Grid item>
                     <Button onClick={() => handleSignInDialog(true)}>
-                      LOG IN
+                      SIGN IN
                     </Button>
                   </Grid>
                   <Grid item>

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -158,12 +158,12 @@ const NavBar = ({ searchLocation, routeButtons, classes }: NavBarProps) => {
                 <>
                   <Grid item>
                     <Button onClick={() => handleSignInDialog(true)}>
-                      SIGN IN
+                      LOG IN
                     </Button>
                   </Grid>
                   <Grid item>
                     <Button onClick={() => handleRegisterDialog(true)}>
-                      REGISTER
+                      SIGN UP
                     </Button>
                   </Grid>
                 </>

--- a/packages/website/src/common/RegisterDialog/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/RegisterDialog/__snapshots__/index.test.tsx.snap
@@ -209,7 +209,7 @@ exports[`RegisterDialog should render with given state from Redux store 1`] = `
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div

--- a/packages/website/src/common/RegisterDialog/index.tsx
+++ b/packages/website/src/common/RegisterDialog/index.tsx
@@ -276,7 +276,7 @@ const RegisterDialog = ({
                     size="large"
                     disabled={!readTerms}
                   >
-                    REGISTER NOW
+                    CREATE ACCOUNT
                   </Button>
                 </Grid>
                 <Grid container item xs={12}>

--- a/packages/website/src/common/SignInDialog/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SignInDialog/__snapshots__/index.test.tsx.snap
@@ -222,7 +222,7 @@ exports[`SignInDialog should render with given state from Redux store 1`] = `
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>

--- a/packages/website/src/common/SignInDialog/index.tsx
+++ b/packages/website/src/common/SignInDialog/index.tsx
@@ -256,7 +256,7 @@ const SignInDialog = ({
                       }}
                       color="primary"
                     >
-                      REGISTER
+                      SIGN UP
                     </Button>
                   </Typography>
                 </Grid>

--- a/packages/website/src/routes/Landing/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Landing/__snapshots__/index.test.tsx.snap
@@ -444,7 +444,7 @@ exports[`Landing Page should render with given state from Redux store 1`] = `
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div
@@ -690,7 +690,7 @@ exports[`Landing Page should render with given state from Redux store 1`] = `
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>

--- a/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div
@@ -649,7 +649,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>
@@ -2142,7 +2142,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div
@@ -2388,7 +2388,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>

--- a/packages/website/src/routes/Terms/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Terms/__snapshots__/index.test.tsx.snap
@@ -403,7 +403,7 @@ exports[`Terms page should render with given state from Redux store 1`] = `
                   type="submit"
                   variant="contained"
                 >
-                  REGISTER NOW
+                  CREATE ACCOUNT
                 </mock-button>
               </div>
               <div
@@ -649,7 +649,7 @@ exports[`Terms page should render with given state from Redux store 1`] = `
                   <mock-button
                     color="primary"
                   >
-                    REGISTER
+                    SIGN UP
                   </mock-button>
                 </mock-typography>
               </div>


### PR DESCRIPTION
Text update to help differentiate between account creation and site registration.

<img width="400" alt="Screen Shot 2020-12-03 at 11 36 41 PM" src="https://user-images.githubusercontent.com/16843267/101197881-877a0280-3617-11eb-898a-23e85bd319dc.png">
<img width="413" alt="Screen Shot 2020-12-03 at 11 38 11 PM" src="https://user-images.githubusercontent.com/16843267/101197885-88ab2f80-3617-11eb-890c-f4c0c9d686f8.png">
