### PR TITLE
Fix homepage map bug

### DIFF
--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -8,6 +8,7 @@ import { Reef } from "../../../../store/Reefs/types";
 import {
   reefOnMapSelector,
   setReefOnMap,
+  setSearchResult,
 } from "../../../../store/Homepage/homepageSlice";
 import Popup from "../Popup";
 import "leaflet/dist/leaflet.css";
@@ -82,6 +83,7 @@ export const ReefMarkers = () => {
             return lngOffsets.map((offset) => (
               <Marker
                 onClick={() => {
+                  dispatch(setSearchResult());
                   dispatch(setReefOnMap(reef));
                 }}
                 key={`${reef.id}-${offset}`}


### PR DESCRIPTION
The purpose of this PR is to fix the following bug:
Whenever we make a search on the homepage map and the click on a marker, the map centers to the search result again instead of centering into the marker.