### PR TITLE
Exclusion date section for reef admins

### DIFF
--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -281,6 +281,11 @@ export async function getReefsDailyData(
     async (reef) => {
       const includeSpotterData =
         reef.spotterId &&
+        /** TODO - Now that we are considering exclusion times,
+        /* instead we should use the exclusion dates to filter the spotterData results
+        /* similar to what we are doing when we get the spotterData for the charts.
+        /* We can then build a simple utility function taking isExcluded(exclusion dates, date) or similar in JS
+        */
         isNil(
           await exclusionDatesRepository
             .createQueryBuilder('exclusion')

--- a/packages/website/src/routes/ReefRoutes/Reef/ReefInfo/EditForm/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/ReefInfo/EditForm/index.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, ChangeEvent } from "react";
+import React, { useCallback, useEffect, ChangeEvent, useState } from "react";
 import {
   withStyles,
   WithStyles,
@@ -9,6 +9,12 @@ import {
   Theme,
   Typography,
 } from "@material-ui/core";
+import {
+  KeyboardDatePicker,
+  MuiPickersUtilsProvider,
+} from "@material-ui/pickers";
+import DateFnsUtils from "@date-io/date-fns";
+import moment from "moment";
 import Alert from "@material-ui/lab/Alert";
 import { useForm } from "react-hook-form";
 import { useDispatch, useSelector } from "react-redux";
@@ -23,6 +29,7 @@ import {
 const EditForm = ({ reef, onClose, onSubmit, classes }: EditFormProps) => {
   const dispatch = useDispatch();
   const draftReef = useSelector(reefDraftSelector);
+  const [exclusionDate, setExclusionDate] = useState<Date | null>(null);
   const reefName = getReefNameAndRegion(reef).name || "";
   const location = reef.polygon.type === "Point" ? reef.polygon : null;
   const { latitude: draftLatitude, longitude: draftLongitude } =
@@ -31,6 +38,8 @@ const EditForm = ({ reef, onClose, onSubmit, classes }: EditFormProps) => {
   const { register, errors, handleSubmit, setValue } = useForm({
     reValidateMode: "onSubmit",
   });
+
+  const onEclusionDateChange = (date: Date | null) => setExclusionDate(date);
 
   const formSubmit = useCallback(
     (data: any) => {
@@ -117,6 +126,48 @@ const EditForm = ({ reef, onClose, onSubmit, classes }: EditFormProps) => {
               error={!!errors.depth}
               helperText={errors?.depth?.message || ""}
             />
+          </Grid>
+          <Grid item container spacing={2} alignItems="center">
+            <Grid item sm={6} xs={12}>
+              <Alert icon={false} severity="info">
+                <Typography variant="subtitle2">
+                  Spotter data before this date will not be displayed
+                </Typography>
+              </Alert>
+            </Grid>
+            <Grid item sm={6} xs={12}>
+              <MuiPickersUtilsProvider utils={DateFnsUtils}>
+                <KeyboardDatePicker
+                  className={classes.textField}
+                  disableToolbar
+                  format="MM/dd/yyyy"
+                  id="exclusion-date"
+                  name="exclusionDate"
+                  autoOk
+                  showTodayButton
+                  fullWidth
+                  helperText={errors?.exclusionDate?.message || ""}
+                  inputRef={register({
+                    required: "This is a required field",
+                    validate: {
+                      validDate: (value) =>
+                        moment(value, "MM/DD/YYYY", true).isValid() ||
+                        "Invalid date",
+                    },
+                  })}
+                  error={!!errors.exclusionDate}
+                  value={exclusionDate}
+                  onChange={onEclusionDateChange}
+                  KeyboardButtonProps={{
+                    "aria-label": "change date",
+                  }}
+                  inputProps={{
+                    className: classes.textField,
+                  }}
+                  inputVariant="outlined"
+                />
+              </MuiPickersUtilsProvider>
+            </Grid>
           </Grid>
           <Grid item xs={12}>
             <Alert className={classes.infoAlert} icon={false} severity="info">

--- a/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
@@ -801,7 +801,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         <div
           class="MuiAlert-message"
         >
-          Currently no Smart Buoy deployed at this reef location. All values are derived from a combination of NOAA satellite readings and weather models.
+          Currently no Smart Buoy deployed at this location. All values are derived from a combination of NOAA satellite readings and weather models.
         </div>
       </div>
     </mock-box>
@@ -2844,7 +2844,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         <div
           class="MuiAlert-message"
         >
-          Currently no Smart Buoy deployed at this reef location. All values are derived from a combination of NOAA satellite readings and weather models.
+          Currently no Smart Buoy deployed at this location. All values are derived from a combination of NOAA satellite readings and weather models.
         </div>
       </div>
     </mock-box>

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -54,7 +54,7 @@ const getAlertMessage = (
   const isManager = isAdmin(user, parseInt(reefId, 10));
 
   const defaultMessage =
-    "Currently no Smart Buoy deployed at this reef location. All values are derived from a combination of NOAA satellite readings and weather models.";
+    "Currently no Smart Buoy deployed at this location. All values are derived from a combination of NOAA satellite readings and weather models.";
 
   switch (true) {
     case !isManager:


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/387. 

### Frontend:  ![](https://progress-bar.dev/50/?title=completed&width=120)
   - [x] Add date and time textfields
   - [ ] Connect with the api
 
### API:  ![](https://progress-bar.dev/0/?title=completed&width=120)
   - [ ] Augment the already existing `/reefs/:reef_id, PUT` endpoint, in order to receive the `endDate` param as well and
store it in the respective table.

Designs:

| Desktop | iPad | Mobile |
|---|---|---|
| ![Screenshot_20201223_161530](https://user-images.githubusercontent.com/64922890/103007247-be1eab00-453b-11eb-8a97-f5778016a577.png) | ![Screenshot_20201223_161630](https://user-images.githubusercontent.com/64922890/103007264-c545b900-453b-11eb-98f8-aa3ec4b38165.png) | ![Screenshot_20201223_161706](https://user-images.githubusercontent.com/64922890/103007272-c840a980-453b-11eb-92be-9902c0a56329.png) |
