### PR TITLE
Fix No Data Found bug

### DIFF
--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -134,7 +134,8 @@ const Reef = ({ match, classes }: ReefProps) => {
 
   // fetch spotter data from api, also filter the range we're interested in.
   useEffect(() => {
-    if (hasSpotterData) {
+    // make sure we've loaded the reef, before attempting to get its spotter data.
+    if (hasSpotterData && !loading) {
       dispatch(
         reefSpotterDataRequest({
           id: reefId,
@@ -146,7 +147,7 @@ const Reef = ({ match, classes }: ReefProps) => {
       // Clear possible spotter data from previously selected reef
       dispatch(clearReefSpotterData());
     }
-  }, [dispatch, reefId, hasSpotterData, range, pickerDate]);
+  }, [dispatch, reefId, hasSpotterData, range, pickerDate, loading]);
 
   // update the end date once spotter data changes. Happens when `range` is changed.
   useEffect(() => {


### PR DESCRIPTION
Fixes #409 
test: http://aqua-bug.surge.sh
This bug can be replicated as follows:
1. On the map, pick any reef which has spotters.
2. Then, pick a reef which doesn't support spotters.
3. Before the new reef finishes loading, click explore
4. No Data Found

This happens because https://github.com/aqualinkorg/aqualink-app/blob/695fae2ceee75c7b5b7e552ee6a71b98afb95d33/packages/website/src/routes/ReefRoutes/Reef/index.tsx#L119 is calculated using the old reef, before the new reef gets a chance to load. In doing so, we end up requesting spotter data for a reef that doesn't support it, causing an error.