### PR TITLE
Fix chart tooltip spacing

### DIFF
--- a/packages/website/src/common/Chart/Tooltip/index.tsx
+++ b/packages/website/src/common/Chart/Tooltip/index.tsx
@@ -167,7 +167,7 @@ const styles = () =>
     },
     tooltipHeader: {
       flex: "0 1 auto",
-      padding: "0.5rem 1rem 1rem 1rem",
+      padding: "0.5rem 1rem 1rem",
       height: 30,
     },
     tooltipContent: {

--- a/packages/website/src/common/Chart/Tooltip/index.tsx
+++ b/packages/website/src/common/Chart/Tooltip/index.tsx
@@ -167,7 +167,7 @@ const styles = () =>
     },
     tooltipHeader: {
       flex: "0 1 auto",
-      padding: "0.5rem 1rem 0 1rem",
+      padding: "0.5rem 1rem 1rem 1rem",
       height: 30,
     },
     tooltipContent: {
@@ -176,7 +176,7 @@ const styles = () =>
     },
     tooltipContentItem: {
       width: "120px",
-      height: 30,
+      height: 20,
       margin: "0",
     },
     tooltipArrow: {


### PR DESCRIPTION
<img width="297" alt="Screen Shot 2021-01-22 at 4 08 14 PM" src="https://user-images.githubusercontent.com/16843267/105562285-6f953580-5cce-11eb-8cc1-28be4d4fb1cb.png">
