### PR TITLE
Add search bar to site and survey details pages

### DIFF
--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -98,7 +98,7 @@ const NavBar = ({
             {searchLocation && (
               <Hidden xsDown>
                 <Grid item sm={3}>
-                  <Search geolocationEnabled={Boolean(geolocationEnabled)} />
+                  <Search geolocationEnabled={geolocationEnabled} />
                 </Grid>
               </Hidden>
             )}
@@ -178,7 +178,7 @@ const NavBar = ({
             {searchLocation && (
               <Hidden smUp>
                 <Grid item xs={12} style={{ margin: 0, paddingTop: 0 }}>
-                  <Search geolocationEnabled={Boolean(geolocationEnabled)} />
+                  <Search geolocationEnabled={geolocationEnabled} />
                 </Grid>
               </Hidden>
             )}
@@ -248,7 +248,7 @@ interface NavBarIncomingProps {
 }
 
 NavBar.defaultProps = {
-  geolocationEnabled: true,
+  geolocationEnabled: false,
   routeButtons: false,
 };
 

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -29,7 +29,12 @@ import RouteButtons from "../RouteButtons";
 import MenuDrawer from "../MenuDrawer";
 import { userInfoSelector, signOutUser } from "../../store/User/userSlice";
 
-const NavBar = ({ searchLocation, routeButtons, classes }: NavBarProps) => {
+const NavBar = ({
+  searchLocation,
+  geolocationEnabled,
+  routeButtons,
+  classes,
+}: NavBarProps) => {
   const user = useSelector(userInfoSelector);
   const dispatch = useDispatch();
   const [registerDialogOpen, setRegisterDialogOpen] = useState<boolean>(false);
@@ -93,7 +98,7 @@ const NavBar = ({ searchLocation, routeButtons, classes }: NavBarProps) => {
             {searchLocation && (
               <Hidden xsDown>
                 <Grid item sm={3}>
-                  <Search />
+                  <Search geolocationEnabled={Boolean(geolocationEnabled)} />
                 </Grid>
               </Hidden>
             )}
@@ -173,7 +178,7 @@ const NavBar = ({ searchLocation, routeButtons, classes }: NavBarProps) => {
             {searchLocation && (
               <Hidden smUp>
                 <Grid item xs={12} style={{ margin: 0, paddingTop: 0 }}>
-                  <Search />
+                  <Search geolocationEnabled={Boolean(geolocationEnabled)} />
                 </Grid>
               </Hidden>
             )}
@@ -238,10 +243,12 @@ const styles = (theme: Theme) =>
 
 interface NavBarIncomingProps {
   searchLocation: boolean;
+  geolocationEnabled?: boolean;
   routeButtons?: boolean;
 }
 
 NavBar.defaultProps = {
+  geolocationEnabled: true,
   routeButtons: false,
 };
 

--- a/packages/website/src/common/Search/index.test.tsx
+++ b/packages/website/src/common/Search/index.test.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { Provider } from "react-redux";
+import { BrowserRouter as Router } from "react-router-dom";
 import { render } from "@testing-library/react";
 import configureStore from "redux-mock-store";
 
@@ -17,13 +18,18 @@ describe("Search", () => {
         loading: false,
         error: null,
       },
+      homepage: {
+        reefOnMap: mockReef,
+      },
     });
 
     store.dispatch = jest.fn();
 
     element = render(
       <Provider store={store}>
-        <Search />
+        <Router>
+          <Search />
+        </Router>
       </Provider>
     ).container;
   });

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -1,4 +1,4 @@
-import React, { useState, ChangeEvent, KeyboardEvent } from "react";
+import React, { useState, useEffect, ChangeEvent, KeyboardEvent } from "react";
 import { useDispatch, useSelector } from "react-redux";
 import {
   withStyles,
@@ -16,7 +16,10 @@ import {
   setSearchResult,
 } from "../../store/Homepage/homepageSlice";
 import type { Reef } from "../../store/Reefs/types";
-import { reefsListSelector } from "../../store/Reefs/reefsListSlice";
+import {
+  reefsListSelector,
+  reefsRequest,
+} from "../../store/Reefs/reefsListSlice";
 import { getReefNameAndRegion } from "../../store/Reefs/helpers";
 import mapServices from "../../services/mapServices";
 
@@ -42,6 +45,13 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
       const nameB = reefAugmentedName(b);
       return nameA.localeCompare(nameB);
     });
+
+  // Fetch reefs for the search bar
+  useEffect(() => {
+    if (reefs.length === 0) {
+      dispatch(reefsRequest());
+    }
+  }, [dispatch, reefs]);
 
   const onChangeSearchText = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -12,6 +12,7 @@ import Autocomplete from "@material-ui/lab/Autocomplete";
 import { Redirect } from "react-router-dom";
 
 import {
+  reefOnMapSelector,
   setReefOnMap,
   setSearchResult,
 } from "../../store/Homepage/homepageSlice";
@@ -33,10 +34,10 @@ const reefAugmentedName = (reef: Reef) => {
 
 const Search = ({ geolocationEnabled, classes }: SearchProps) => {
   const [searchedReef, setSearchedReef] = useState<Reef | null>(null);
-  const [searchedReefId, setSearchedReefId] = useState<number | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const dispatch = useDispatch();
   const reefs = useSelector(reefsListSelector);
+  const reefOnMap = useSelector(reefOnMapSelector);
   // eslint-disable-next-line fp/no-mutating-methods
   const filteredReefs = (reefs || [])
     .filter((reef) => reefAugmentedName(reef))
@@ -72,7 +73,6 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
   const onDropdownItemSelect = (event: ChangeEvent<{}>, value: Reef | null) => {
     if (value) {
       setSearchedReef(null);
-      setSearchedReefId(value.id);
       dispatch(setReefOnMap(value));
     }
   };
@@ -80,7 +80,6 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
   const onSearchSubmit = () => {
     if (searchedReef) {
       dispatch(setReefOnMap(searchedReef));
-      setSearchedReefId(searchedReef.id);
       setSearchedReef(null);
     } else if (searchValue && geolocationEnabled) {
       mapServices
@@ -98,8 +97,8 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
 
   return (
     <>
-      {!geolocationEnabled && searchedReefId && (
-        <Redirect to={`/reefs/${searchedReefId}`} />
+      {!geolocationEnabled && reefOnMap?.id && (
+        <Redirect to={`/reefs/${reefOnMap?.id}`} />
       )}
       <div className={classes.searchBar}>
         <div className={classes.searchBarIcon}>
@@ -179,8 +178,12 @@ const styles = () =>
   });
 
 interface SearchIncomingProps {
-  geolocationEnabled: boolean;
+  geolocationEnabled?: boolean;
 }
+
+Search.defaultProps = {
+  geolocationEnabled: false,
+};
 
 type SearchProps = SearchIncomingProps & WithStyles<typeof styles>;
 

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -36,8 +36,9 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
   const [searchedReefId, setSearchedReefId] = useState<number | null>(null);
   const [searchValue, setSearchValue] = useState("");
   const dispatch = useDispatch();
+  const reefs = useSelector(reefsListSelector);
   // eslint-disable-next-line fp/no-mutating-methods
-  const reefs = useSelector(reefsListSelector)
+  const filteredReefs = (reefs || [])
     .filter((reef) => reefAugmentedName(reef))
     // Sort by formatted name
     .sort((a, b) => {
@@ -48,7 +49,7 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
 
   // Fetch reefs for the search bar
   useEffect(() => {
-    if (reefs.length === 0) {
+    if (!reefs) {
       dispatch(reefsRequest());
     }
   }, [dispatch, reefs]);
@@ -57,12 +58,12 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
   ) => {
     const searchInput = event.target.value;
-    const index = reefs.findIndex(
+    const index = filteredReefs.findIndex(
       (reef) =>
         reefAugmentedName(reef).toLowerCase() === searchInput.toLowerCase()
     );
     if (index > -1) {
-      setSearchedReef(reefs[index]);
+      setSearchedReef(filteredReefs[index]);
     } else {
       setSearchValue(searchInput);
     }
@@ -113,7 +114,7 @@ const Search = ({ geolocationEnabled, classes }: SearchProps) => {
             autoHighlight
             onKeyPress={onKeyPress}
             className={classes.searchBarInput}
-            options={reefs}
+            options={filteredReefs}
             noOptionsText={
               geolocationEnabled
                 ? `No sites found. Press enter to zoom to "${searchValue}"`

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -45,7 +45,7 @@ const clusterIcon = (cluster: any) => {
 };
 
 export const ReefMarkers = () => {
-  const reefsList = useSelector(reefsToDisplayListSelector);
+  const reefsList = useSelector(reefsToDisplayListSelector) || [];
   const reefOnMap = useSelector(reefOnMapSelector);
   const { map } = useLeaflet();
   const dispatch = useDispatch();

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -52,7 +52,7 @@ const HomepageMap = ({ classes }: HomepageMapProps) => {
     setCurrentLocationErrorMessage,
   ] = useState<string>();
   const loading = useSelector(reefsListLoadingSelector);
-  const reefs = useSelector(reefsListSelector);
+  const reefs = useSelector(reefsListSelector) || [];
   const searchResult = useSelector(searchResultSelector);
   const ref = useRef<Map>(null);
 

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useSelector } from "react-redux";
 import { Map, TileLayer, Marker, Circle } from "react-leaflet";
-import L, { LatLng } from "leaflet";
+import L, { LatLng, LayersControlEvent } from "leaflet";
 import {
   createStyles,
   withStyles,
@@ -99,11 +99,12 @@ const HomepageMap = ({ classes }: HomepageMapProps) => {
           searchResult.bbox.northEast,
         ]);
       }
-      map.on("baselayerchange", (layer: any) => {
-        setLegendName(layer.name);
-      });
     }
-  });
+  }, [searchResult]);
+
+  const onBaseLayerChange = ({ name }: LayersControlEvent) => {
+    setLegendName(name);
+  };
 
   return loading ? (
     <div className={classes.loading}>
@@ -119,6 +120,7 @@ const HomepageMap = ({ classes }: HomepageMapProps) => {
       zoom={INITIAL_ZOOM}
       minZoom={2}
       worldCopyJump
+      onbaselayerchange={onBaseLayerChange}
     >
       <Snackbar
         open={Boolean(currentLocationErrorMessage)}

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -106,7 +106,7 @@ RowNumberCell.defaultProps = {
 
 const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
   const dispatch = useDispatch();
-  const reefsList = useSelector(reefsToDisplayListSelector);
+  const reefsList = useSelector(reefsToDisplayListSelector) || [];
   const reefOnMap = useSelector(reefOnMapSelector);
   const [selectedRow, setSelectedRow] = useState<number>();
 

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -6,6 +6,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
     role="presentation"
   >
     <mock-navbar
+      geolocationenabled="true"
       searchlocation="true"
     />
   </div>

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -47,7 +47,7 @@ const Homepage = ({ classes }: HomepageProps) => {
   return (
     <>
       <div role="presentation" onClick={openDrawer ? toggleDrawer : () => {}}>
-        <HomepageNavBar searchLocation />
+        <HomepageNavBar searchLocation geolocationEnabled />
       </div>
       <div className={classes.root}>
         <Grid container>

--- a/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/ReefRoutes/Reef/__snapshots__/index.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Reef Detail Page should render with given state from Redux store: snapshot-with-data 1`] = `
 <div>
   <mock-appbar
-    classname="NavBar-appBar-133"
+    classname="NavBar-appBar-137 NavBar-appBarXs-139"
     color="primary"
     position="static"
   >
     <mock-toolbar
-      classname="NavBar-toolbar-136"
+      classname="NavBar-toolbar-140"
     >
       <mock-drawer
         anchor="left"
@@ -76,7 +76,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             role="group"
           >
             <mock-button
-              classname="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContained MenuDrawer-contributeButton-143"
+              classname="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContained MenuDrawer-contributeButton-147"
               color="default"
               disabled="false"
               disableelevation="false"
@@ -92,7 +92,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               GitHub
             </mock-button>
             <mock-button
-              classname="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContained MenuDrawer-contributeButton-143"
+              classname="MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContained MenuDrawer-contributeButton-147"
               color="default"
               disabled="false"
               disableelevation="false"
@@ -116,7 +116,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-5 MuiGrid-grid-sm-4"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-5 MuiGrid-grid-sm-6"
         >
           <mock-box
             alignitems="center"
@@ -139,7 +139,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               </svg>
             </mock-iconbutton>
             <mock-link
-              classname="NavBar-navBarLink-134"
+              classname="NavBar-navBarLink-138"
               href="/map"
             >
               <mock-typography
@@ -157,8 +157,57 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             </mock-link>
           </mock-box>
         </div>
+        <mock-hidden
+          xsdown="true"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-3"
+          >
+            <div
+              class="Search-searchBar-148"
+            >
+              <div
+                class="Search-searchBarIcon-149"
+              >
+                <mock-iconbutton
+                  size="small"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </mock-iconbutton>
+              </div>
+              <div
+                class="Search-searchBarText-150"
+              >
+                <div
+                  aria-expanded="false"
+                  class="MuiAutocomplete-root Search-searchBarInput-151 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                  role="combobox"
+                >
+                  <mock-textfield
+                    disabled="false"
+                    fullwidth="true"
+                    id="location"
+                    inputlabelprops="[object Object]"
+                    inputprops="[object Object]"
+                    placeholder="Search by site name or country"
+                    variant="outlined"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </mock-hidden>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-7 MuiGrid-grid-sm-8"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-7 MuiGrid-grid-sm-3"
         >
           <mock-box
             alignitems="center"
@@ -167,11 +216,11 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           >
             Mock User
             <mock-iconbutton
-              classname="NavBar-button-141"
+              classname="NavBar-button-145"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root NavBar-expandIcon-140"
+                class="MuiSvgIcon-root NavBar-expandIcon-144"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -181,18 +230,68 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               </svg>
             </mock-iconbutton>
             <mock-menu
-              classname="NavBar-userMenu-137"
+              classname="NavBar-userMenu-141"
               keepmounted="true"
               open="false"
             >
               <mock-menuitem
-                classname="NavBar-menuItem-138"
+                classname="NavBar-menuItem-142"
               >
                 Logout
               </mock-menuitem>
             </mock-menu>
           </mock-box>
         </div>
+        <mock-hidden
+          smup="true"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+            style="margin: 0px; padding-top: 0px;"
+          >
+            <div
+              class="Search-searchBar-148"
+            >
+              <div
+                class="Search-searchBarIcon-149"
+              >
+                <mock-iconbutton
+                  size="small"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </mock-iconbutton>
+              </div>
+              <div
+                class="Search-searchBarText-150"
+              >
+                <div
+                  aria-expanded="false"
+                  class="MuiAutocomplete-root Search-searchBarInput-151 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                  role="combobox"
+                >
+                  <mock-textfield
+                    disabled="false"
+                    fullwidth="true"
+                    id="location"
+                    inputlabelprops="[object Object]"
+                    inputprops="[object Object]"
+                    placeholder="Search by site name or country"
+                    variant="outlined"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </mock-hidden>
       </div>
     </mock-toolbar>
   </mock-appbar>
@@ -203,7 +302,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root RegisterDialog-dialogHeader-145"
+        class="MuiCardHeader-root RegisterDialog-dialogHeader-153"
       >
         <div
           class="MuiCardHeader-content"
@@ -229,7 +328,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="RegisterDialog-dialogHeaderSecondPart-146"
+                    classname="RegisterDialog-dialogHeaderSecondPart-154"
                     variant="h4"
                   >
                     link
@@ -239,7 +338,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
                 >
                   <mock-iconbutton
-                    classname="RegisterDialog-closeButton-144"
+                    classname="RegisterDialog-closeButton-152"
                     size="small"
                   >
                     <svg
@@ -260,13 +359,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         </div>
       </div>
       <mock-cardcontent
-        classname="RegisterDialog-contentWrapper-153"
+        classname="RegisterDialog-contentWrapper-161"
       >
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
         >
           <div
-            class="MuiGrid-root RegisterDialog-dialogContentTitle-147 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
+            class="MuiGrid-root RegisterDialog-dialogContentTitle-155 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -283,10 +382,10 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <form
-              class="RegisterDialog-form-148"
+              class="RegisterDialog-form-156"
             >
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-149 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-157 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -301,7 +400,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-149 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-157 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -316,7 +415,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-149 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-157 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -331,7 +430,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-149 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-157 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -346,7 +445,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-149 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-157 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -369,7 +468,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 >
                   <mock-checkbox
                     checked="false"
-                    classname="RegisterDialog-termsCheckbox-154"
+                    classname="RegisterDialog-termsCheckbox-162"
                     color="primary"
                   />
                 </div>
@@ -377,14 +476,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-10"
                 >
                   <mock-typography
-                    classname="RegisterDialog-formText-151"
+                    classname="RegisterDialog-formText-159"
                     color="textSecondary"
                     variant="subtitle1"
                   >
                     I have read the
                      
                     <a
-                      class="RegisterDialog-termsLink-155"
+                      class="RegisterDialog-termsLink-163"
                       href="/terms"
                     >
                       Terms and Conditions
@@ -393,7 +492,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </div>
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-button-152 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-button-160 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
                   color="primary"
@@ -410,7 +509,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="RegisterDialog-formText-151"
+                  classname="RegisterDialog-formText-159"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -435,7 +534,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root SignInDialog-dialogHeader-157"
+        class="MuiCardHeader-root SignInDialog-dialogHeader-165"
       >
         <div
           class="MuiCardHeader-content"
@@ -461,7 +560,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="SignInDialog-dialogHeaderSecondPart-158"
+                    classname="SignInDialog-dialogHeaderSecondPart-166"
                     variant="h4"
                   >
                     link
@@ -471,7 +570,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
                 >
                   <mock-iconbutton
-                    classname="SignInDialog-closeButton-156"
+                    classname="SignInDialog-closeButton-164"
                     size="small"
                   >
                     <svg
@@ -553,7 +652,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
         >
           <div
-            class="MuiGrid-root SignInDialog-dialogContentTitle-159 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
+            class="MuiGrid-root SignInDialog-dialogContentTitle-167 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -570,13 +669,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <form
-              class="SignInDialog-form-160"
+              class="SignInDialog-form-168"
             >
               <div
-                class="MuiGrid-root SignInDialog-textFieldWrapper-161 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-textFieldWrapper-169 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-163"
+                  classname="SignInDialog-formText-171"
                   variant="subtitle2"
                 >
                   or login with email address
@@ -594,7 +693,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root SignInDialog-textFieldWrapper-161 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-textFieldWrapper-169 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -613,7 +712,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
-                  classname="SignInDialog-forgotPasswordButton-165"
+                  classname="SignInDialog-forgotPasswordButton-173"
                 >
                   <mock-typography
                     color="textSecondary"
@@ -624,7 +723,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </mock-button>
               </div>
               <div
-                class="MuiGrid-root SignInDialog-button-164 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-button-172 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
                   color="primary"
@@ -640,7 +739,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-163"
+                  classname="SignInDialog-formText-171"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -719,7 +818,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
       </div>
     </div>
     <div
-      class="MuiGrid-root ReefNavBar-root-166 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+      class="MuiGrid-root ReefNavBar-root-174 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
@@ -809,7 +908,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
       mt="1rem"
     >
       <mock-box
-        classname="CardTitle-root-172"
+        classname="CardTitle-root-180"
       >
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
@@ -843,7 +942,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6"
         >
           <div
-            class="ReefDetails-container-170"
+            class="ReefDetails-container-178"
           >
             <mock-map
               polygon="[object Object]"
@@ -854,7 +953,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6"
         >
           <div
-            class="ReefDetails-container-170"
+            class="ReefDetails-container-178"
           >
             <mock-featuredmedia
               reefid="1"
@@ -863,17 +962,17 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         </div>
       </div>
       <div
-        class="MuiGrid-root ReefDetails-metricsWrapper-171 MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-justify-xs-space-between"
+        class="MuiGrid-root ReefDetails-metricsWrapper-179 MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-justify-xs-space-between"
       >
         <div
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3"
         >
           <mock-card
-            classname="Satellite-card-175"
+            classname="Satellite-card-183"
             style="background-color: rgb(117, 180, 114);"
           >
             <div
-              class="MuiCardHeader-root Satellite-header-177"
+              class="MuiCardHeader-root Satellite-header-185"
             >
               <div
                 class="MuiCardHeader-content"
@@ -891,7 +990,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       class="MuiGrid-root MuiGrid-item"
                     >
                       <mock-typography
-                        classname="Satellite-cardTitle-176"
+                        classname="Satellite-cardTitle-184"
                         variant="h6"
                       >
                         SATELLITE OBSERVATION
@@ -902,7 +1001,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               </div>
             </div>
             <mock-cardcontent
-              classname="Satellite-content-182"
+              classname="Satellite-content-190"
             >
               <mock-box
                 display="flex"
@@ -916,13 +1015,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
                   >
                     <mock-typography
-                      classname="Satellite-contentTextTitles-178"
+                      classname="Satellite-contentTextTitles-186"
                       variant="subtitle2"
                     >
                       SURFACE TEMP
                     </mock-typography>
                     <mock-typography
-                      classname="Satellite-contentTextValues-179"
+                      classname="Satellite-contentTextValues-187"
                       variant="h3"
                     >
                       29.0 °C
@@ -932,7 +1031,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
                   >
                     <mock-typography
-                      classname="Satellite-contentTextTitles-178"
+                      classname="Satellite-contentTextTitles-186"
                       variant="subtitle2"
                     >
                       HISTORICAL MAX
@@ -941,7 +1040,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       title="Historical maximum monthly average over the past 20 years"
                     >
                       <mock-typography
-                        classname="Satellite-contentTextValues-179"
+                        classname="Satellite-contentTextValues-187"
                         variant="h3"
                       >
                         0.0 °C
@@ -952,7 +1051,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
                   >
                     <mock-typography
-                      classname="Satellite-contentTextTitles-178"
+                      classname="Satellite-contentTextTitles-186"
                       variant="subtitle2"
                     >
                       HEAT STRESS
@@ -961,7 +1060,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
                     >
                       <mock-typography
-                        classname="Satellite-contentTextValues-179"
+                        classname="Satellite-contentTextValues-187"
                         variant="h3"
                       >
                         4.9 DHW
@@ -1155,7 +1254,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </div>
               </div>
               <div
-                class="MuiGrid-root UpdateInfo-updateInfo-184 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+                class="MuiGrid-root UpdateInfo-updateInfo-192 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
@@ -1168,7 +1267,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root UpdateInfo-updateIcon-186 MuiSvgIcon-fontSizeSmall"
+                        class="MuiSvgIcon-root UpdateInfo-updateIcon-194 MuiSvgIcon-fontSizeSmall"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
@@ -1185,7 +1284,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         flexdirection="column"
                       >
                         <mock-typography
-                          classname="UpdateInfo-updateInfoText-187"
+                          classname="UpdateInfo-updateInfoText-195"
                           variant="caption"
                         >
                           Last data received
@@ -1193,7 +1292,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                           5 min. ago
                         </mock-typography>
                         <mock-typography
-                          classname="UpdateInfo-updateInfoText-187"
+                          classname="UpdateInfo-updateInfoText-195"
                           variant="caption"
                         >
                           Updated 
@@ -1204,24 +1303,24 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root UpdateInfo-nooaChip-188 MuiGrid-item"
+                  class="MuiGrid-root UpdateInfo-nooaChip-196 MuiGrid-item"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
                   >
                     <a
-                      class="UpdateInfo-nooaLink-189"
+                      class="UpdateInfo-nooaLink-197"
                       href="https://coralreefwatch.noaa.gov/"
                       target="_blank"
                     >
                       <mock-typography
-                        classname="UpdateInfo-nooaChipText-190"
+                        classname="UpdateInfo-nooaChipText-198"
                       >
                         NOAA
                       </mock-typography>
                       <img
                         alt="sensor-type"
-                        class="UpdateInfo-sensorImage-191"
+                        class="UpdateInfo-sensorImage-199"
                         src="satellite.svg"
                       />
                     </a>
@@ -1235,10 +1334,10 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3"
         >
           <mock-card
-            classname="Sensor-card-193"
+            classname="Sensor-card-201"
           >
             <div
-              class="MuiCardHeader-root Sensor-header-195"
+              class="MuiCardHeader-root Sensor-header-203"
             >
               <div
                 class="MuiCardHeader-content"
@@ -1256,7 +1355,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       class="MuiGrid-root MuiGrid-item"
                     >
                       <mock-typography
-                        classname="Sensor-cardTitle-194"
+                        classname="Sensor-cardTitle-202"
                         variant="h6"
                       >
                         SENSOR OBSERVATION
@@ -1267,7 +1366,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               </div>
             </div>
             <mock-cardcontent
-              classname="Sensor-content-201"
+              classname="Sensor-content-209"
             >
               <mock-box
                 display="flex"
@@ -1282,13 +1381,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
                   >
                     <mock-typography
-                      classname="Sensor-contentTextTitles-196"
+                      classname="Sensor-contentTextTitles-204"
                       variant="subtitle2"
                     >
                       TEMP AT 1m
                     </mock-typography>
                     <mock-typography
-                      classname="Sensor-contentTextValues-197"
+                      classname="Sensor-contentTextValues-205"
                       variant="h3"
                     >
                       - - °C
@@ -1298,13 +1397,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
                   >
                     <mock-typography
-                      classname="Sensor-contentTextTitles-196"
+                      classname="Sensor-contentTextTitles-204"
                       variant="subtitle2"
                     >
                       TEMP AT 0m
                     </mock-typography>
                     <mock-typography
-                      classname="Sensor-contentTextValues-197"
+                      classname="Sensor-contentTextValues-205"
                       variant="h3"
                     >
                       39.0 °C
@@ -1323,7 +1422,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </mock-box>
               </mock-box>
               <div
-                class="MuiGrid-root UpdateInfo-updateInfo-184 UpdateInfo-withMargin-185 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+                class="MuiGrid-root UpdateInfo-updateInfo-192 UpdateInfo-withMargin-193 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
               >
                 <div
                   class="MuiGrid-root MuiGrid-item"
@@ -1336,7 +1435,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     >
                       <svg
                         aria-hidden="true"
-                        class="MuiSvgIcon-root UpdateInfo-updateIcon-186 MuiSvgIcon-fontSizeSmall"
+                        class="MuiSvgIcon-root UpdateInfo-updateIcon-194 MuiSvgIcon-fontSizeSmall"
                         focusable="false"
                         viewBox="0 0 24 24"
                       >
@@ -1353,7 +1452,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         flexdirection="column"
                       >
                         <mock-typography
-                          classname="UpdateInfo-updateInfoText-187"
+                          classname="UpdateInfo-updateInfoText-195"
                           variant="caption"
                         >
                           Last data received
@@ -1361,7 +1460,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                           5 min. ago
                         </mock-typography>
                         <mock-typography
-                          classname="UpdateInfo-updateInfoText-187"
+                          classname="UpdateInfo-updateInfoText-195"
                           variant="caption"
                         >
                           Updated 
@@ -1372,16 +1471,16 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root UpdateInfo-nooaChip-188 MuiGrid-item"
+                  class="MuiGrid-root UpdateInfo-nooaChip-196 MuiGrid-item"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
                   >
                     <div
-                      class="UpdateInfo-circle-192"
+                      class="UpdateInfo-circle-200"
                     />
                     <mock-typography
-                      classname="UpdateInfo-nooaChipText-190"
+                      classname="UpdateInfo-nooaChipText-198"
                     >
                       LIVE
                     </mock-typography>
@@ -1395,10 +1494,10 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3"
         >
           <mock-card
-            classname="Bleaching-card-205"
+            classname="Bleaching-card-213"
           >
             <div
-              class="MuiCardHeader-root Bleaching-header-207"
+              class="MuiCardHeader-root Bleaching-header-215"
             >
               <div
                 class="MuiCardHeader-content"
@@ -1427,18 +1526,18 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
               </div>
             </div>
             <mock-cardcontent
-              classname="Bleaching-contentWrapper-212"
+              classname="Bleaching-contentWrapper-220"
             >
               <div
-                class="MuiGrid-root Bleaching-content-213 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-align-content-xs-space-between MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
+                class="MuiGrid-root Bleaching-content-221 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-align-content-xs-space-between MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
               >
                 <img
                   alt="alert-level"
-                  class="Bleaching-alertImage-214"
+                  class="Bleaching-alertImage-222"
                   src="alert_nostress.svg"
                 />
                 <div
-                  class="MuiGrid-root UpdateInfo-updateInfo-184 UpdateInfo-withMargin-185 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+                  class="MuiGrid-root UpdateInfo-updateInfo-192 UpdateInfo-withMargin-193 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item"
@@ -1451,7 +1550,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root UpdateInfo-updateIcon-186 MuiSvgIcon-fontSizeSmall"
+                          class="MuiSvgIcon-root UpdateInfo-updateIcon-194 MuiSvgIcon-fontSizeSmall"
                           focusable="false"
                           viewBox="0 0 24 24"
                         >
@@ -1468,7 +1567,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                           flexdirection="column"
                         >
                           <mock-typography
-                            classname="UpdateInfo-updateInfoText-187"
+                            classname="UpdateInfo-updateInfoText-195"
                             variant="caption"
                           >
                             Last data received
@@ -1476,7 +1575,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                             5 min. ago
                           </mock-typography>
                           <mock-typography
-                            classname="UpdateInfo-updateInfoText-187"
+                            classname="UpdateInfo-updateInfoText-195"
                             variant="caption"
                           >
                             Updated 
@@ -1487,18 +1586,18 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root UpdateInfo-nooaChip-188 MuiGrid-item"
+                    class="MuiGrid-root UpdateInfo-nooaChip-196 MuiGrid-item"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
                     >
                       <a
-                        class="UpdateInfo-nooaLink-189"
+                        class="UpdateInfo-nooaLink-197"
                         href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa_max_r07d.php"
                         target="_blank"
                       >
                         <mock-typography
-                          classname="UpdateInfo-nooaChipText-190"
+                          classname="UpdateInfo-nooaChipText-198"
                         >
                           NOAA CRW
                         </mock-typography>
@@ -1514,37 +1613,37 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3"
         >
           <mock-card
-            classname="Waves-card-215"
+            classname="Waves-card-223"
           >
             <mock-cardcontent
-              classname="Waves-contentWrapper-224"
+              classname="Waves-contentWrapper-232"
             >
               <div
-                class="MuiGrid-root Waves-content-225 MuiGrid-container MuiGrid-item MuiGrid-align-content-xs-space-between MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
+                class="MuiGrid-root Waves-content-233 MuiGrid-container MuiGrid-item MuiGrid-align-content-xs-space-between MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
               >
                 <div
-                  class="MuiGrid-root Waves-paddingContainer-223 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+                  class="MuiGrid-root Waves-paddingContainer-231 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
                 >
                   <mock-typography
-                    classname="Waves-cardTitle-216"
+                    classname="Waves-cardTitle-224"
                     variant="h6"
                   >
                     WIND
                   </mock-typography>
                   <img
                     alt="wind"
-                    class="Waves-titleImages-222"
+                    class="Waves-titleImages-230"
                     src="wind.svg"
                   />
                 </div>
                 <div
-                  class="MuiGrid-root Waves-paddingContainer-223 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+                  class="MuiGrid-root Waves-paddingContainer-231 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
                   >
                     <mock-typography
-                      classname="Waves-contentTextTitles-218"
+                      classname="Waves-contentTextTitles-226"
                       color="textSecondary"
                       variant="subtitle2"
                     >
@@ -1554,14 +1653,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
                     >
                       <mock-typography
-                        classname="Waves-contentTextValues-219"
+                        classname="Waves-contentTextValues-227"
                         color="textSecondary"
                         variant="h3"
                       >
                         21.6
                       </mock-typography>
                       <mock-typography
-                        classname="Waves-contentUnits-220"
+                        classname="Waves-contentUnits-228"
                         color="textSecondary"
                         variant="h6"
                       >
@@ -1573,7 +1672,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6"
                   >
                     <mock-typography
-                      classname="Waves-contentTextTitles-218"
+                      classname="Waves-contentTextTitles-226"
                       color="textSecondary"
                       variant="subtitle2"
                     >
@@ -1584,12 +1683,12 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     >
                       <img
                         alt="arrow"
-                        class="Waves-arrow-226"
+                        class="Waves-arrow-234"
                         src="directioncircle.svg"
                         style="transform: rotate(360deg);"
                       />
                       <mock-typography
-                        classname="Waves-contentTextValues-219"
+                        classname="Waves-contentTextValues-227"
                         color="textSecondary"
                         variant="h3"
                       >
@@ -1599,28 +1698,28 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root Waves-paddingContainer-223 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+                  class="MuiGrid-root Waves-paddingContainer-231 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
                 >
                   <mock-typography
-                    classname="Waves-cardTitle-216"
+                    classname="Waves-cardTitle-224"
                     variant="h6"
                   >
                     WAVES
                   </mock-typography>
                   <img
                     alt="waves"
-                    class="Waves-titleImages-222"
+                    class="Waves-titleImages-230"
                     src="waves.svg"
                   />
                 </div>
                 <div
-                  class="MuiGrid-root Waves-paddingContainer-223 MuiGrid-container MuiGrid-item MuiGrid-justify-xs-space-between MuiGrid-grid-xs-12"
+                  class="MuiGrid-root Waves-paddingContainer-231 MuiGrid-container MuiGrid-item MuiGrid-justify-xs-space-between MuiGrid-grid-xs-12"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4"
                   >
                     <mock-typography
-                      classname="Waves-contentTextTitles-218"
+                      classname="Waves-contentTextTitles-226"
                       color="textSecondary"
                       variant="subtitle2"
                     >
@@ -1630,14 +1729,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
                     >
                       <mock-typography
-                        classname="Waves-contentTextValues-219"
+                        classname="Waves-contentTextValues-227"
                         color="textSecondary"
                         variant="h3"
                       >
                         1.0
                       </mock-typography>
                       <mock-typography
-                        classname="Waves-contentUnits-220"
+                        classname="Waves-contentUnits-228"
                         color="textSecondary"
                         variant="h6"
                       >
@@ -1649,7 +1748,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3"
                   >
                     <mock-typography
-                      classname="Waves-contentTextTitles-218"
+                      classname="Waves-contentTextTitles-226"
                       color="textSecondary"
                       variant="subtitle2"
                     >
@@ -1659,14 +1758,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
                     >
                       <mock-typography
-                        classname="Waves-contentTextValues-219"
+                        classname="Waves-contentTextValues-227"
                         color="textSecondary"
                         variant="h3"
                       >
                         3
                       </mock-typography>
                       <mock-typography
-                        classname="Waves-contentUnits-220"
+                        classname="Waves-contentUnits-228"
                         color="textSecondary"
                         variant="h6"
                       >
@@ -1678,7 +1777,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5"
                   >
                     <mock-typography
-                      classname="Waves-contentTextTitles-218"
+                      classname="Waves-contentTextTitles-226"
                       color="textSecondary"
                       variant="subtitle2"
                     >
@@ -1689,12 +1788,12 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     >
                       <img
                         alt="arrow"
-                        class="Waves-arrow-226"
+                        class="Waves-arrow-234"
                         src="directioncircle.svg"
                         style="transform: rotate(270deg);"
                       />
                       <mock-typography
-                        classname="Waves-contentTextValues-219"
+                        classname="Waves-contentTextValues-227"
                         color="textSecondary"
                         variant="h3"
                       >
@@ -1705,7 +1804,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   </div>
                 </div>
                 <div
-                  class="MuiGrid-root UpdateInfo-updateInfo-184 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+                  class="MuiGrid-root UpdateInfo-updateInfo-192 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-item"
@@ -1718,7 +1817,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                       >
                         <svg
                           aria-hidden="true"
-                          class="MuiSvgIcon-root UpdateInfo-updateIcon-186 MuiSvgIcon-fontSizeSmall"
+                          class="MuiSvgIcon-root UpdateInfo-updateIcon-194 MuiSvgIcon-fontSizeSmall"
                           focusable="false"
                           viewBox="0 0 24 24"
                         >
@@ -1735,7 +1834,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                           flexdirection="column"
                         >
                           <mock-typography
-                            classname="UpdateInfo-updateInfoText-187"
+                            classname="UpdateInfo-updateInfoText-195"
                             variant="caption"
                           >
                             Last data received
@@ -1743,7 +1842,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                             5 min. ago
                           </mock-typography>
                           <mock-typography
-                            classname="UpdateInfo-updateInfoText-187"
+                            classname="UpdateInfo-updateInfoText-195"
                             variant="caption"
                           >
                             Updated 
@@ -1754,16 +1853,16 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root UpdateInfo-nooaChip-188 MuiGrid-item"
+                    class="MuiGrid-root UpdateInfo-nooaChip-196 MuiGrid-item"
                   >
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
                     >
                       <div
-                        class="UpdateInfo-circle-192"
+                        class="UpdateInfo-circle-200"
                       />
                       <mock-typography
-                        classname="UpdateInfo-nooaChipText-190"
+                        classname="UpdateInfo-nooaChipText-198"
                       >
                         LIVE
                       </mock-typography>
@@ -1780,10 +1879,10 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
       >
         <div>
           <div
-            class="CombinedCharts-chart-227"
+            class="CombinedCharts-chart-235"
           >
             <mock-typography
-              classname="CombinedCharts-graphTitle-228"
+              classname="CombinedCharts-graphTitle-236"
               variant="h6"
             >
               DAILY WATER TEMPERATURE (°C)
@@ -1795,7 +1894,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           open="false"
         >
           <mock-dialogtitle
-            classname="Dialog-dialogTitle-237"
+            classname="Dialog-dialogTitle-245"
           >
             <mock-typography>
               Are you sure you want to delete this survey point? It will be deleted across all surveys.
@@ -1820,7 +1919,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           </mock-dialogactions>
         </mock-dialog>
         <div
-          class="MuiGrid-root Surveys-root-229 MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-justify-xs-center"
+          class="MuiGrid-root Surveys-root-237 MuiGrid-container MuiGrid-spacing-xs-2 MuiGrid-justify-xs-center"
         >
           <mock-box
             bgcolor="#f5f6f6"
@@ -1829,13 +1928,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             zindex="-1"
           />
           <div
-            class="MuiGrid-root Surveys-surveyWrapper-230 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-baseline MuiGrid-justify-xs-space-between MuiGrid-grid-xs-11 MuiGrid-grid-lg-12"
+            class="MuiGrid-root Surveys-surveyWrapper-238 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-baseline MuiGrid-justify-xs-space-between MuiGrid-grid-xs-11 MuiGrid-grid-lg-12"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-md-12 MuiGrid-grid-lg-4"
             >
               <mock-typography
-                classname="Surveys-title-231"
+                classname="Surveys-title-239"
               >
                 Survey History
               </mock-typography>
@@ -1847,7 +1946,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-item"
               >
                 <mock-typography
-                  classname="PointSelector-subTitle-238"
+                  classname="PointSelector-subTitle-246"
                   variant="h6"
                 >
                   Survey Point:
@@ -1861,7 +1960,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-item"
               >
                 <mock-typography
-                  classname="Surveys-subTitle-232"
+                  classname="Surveys-subTitle-240"
                   variant="h6"
                 >
                   Observation:
@@ -1871,21 +1970,21 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-item"
               >
                 <div
-                  class="MuiFormControl-root Surveys-formControl-233"
+                  class="MuiFormControl-root Surveys-formControl-241"
                 >
                   <div
-                    class="MuiInputBase-root MuiInput-root MuiInput-underline Surveys-selectedItem-234 MuiInputBase-formControl MuiInput-formControl"
+                    class="MuiInputBase-root MuiInput-root MuiInput-underline Surveys-selectedItem-242 MuiInputBase-formControl MuiInput-formControl"
                   >
                     <div
                       aria-haspopup="listbox"
                       aria-labelledby="survey-observation survey-observation"
-                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input Surveys-textField-236"
+                      class="MuiSelect-root MuiSelect-select MuiSelect-selectMenu MuiInputBase-input MuiInput-input Surveys-textField-244"
                       id="survey-observation"
                       role="button"
                       tabindex="0"
                     >
                       <mock-typography
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         variant="h6"
                       >
                         Any
@@ -1922,14 +2021,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         selected="true"
                       >
                         <mock-typography
-                          classname="Surveys-menuItem-235"
+                          classname="Surveys-menuItem-243"
                           variant="h6"
                         >
                           Any
                         </mock-typography>
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="healthy"
                         role="option"
                         selected="false"
@@ -1937,7 +2036,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         Appears healthy
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="possible-disease"
                         role="option"
                         selected="false"
@@ -1945,7 +2044,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         Showing possible signs of disease
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="evident-disease"
                         role="option"
                         selected="false"
@@ -1953,7 +2052,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         Signs of disease are evident
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="mortality"
                         role="option"
                         selected="false"
@@ -1961,7 +2060,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         Signs of mortality are evident
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="environmental"
                         role="option"
                         selected="false"
@@ -1969,7 +2068,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                         Signs of environmental disturbance are evident (e.g.,storm damage)
                       </mock-menuitem>
                       <mock-menuitem
-                        classname="Surveys-menuItem-235"
+                        classname="Surveys-menuItem-243"
                         data-value="anthropogenic"
                         role="option"
                         selected="false"
@@ -1986,7 +2085,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-11 MuiGrid-grid-lg-12"
           >
             <div
-              class="SurveyTimeline-root-255"
+              class="SurveyTimeline-root-263"
             >
               <mock-hidden
                 mddown="true"
@@ -2009,7 +2108,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
     </mock-box>
   </div>
   <mock-appbar
-    classname="Footer-appBar-173"
+    classname="Footer-appBar-181"
     position="static"
   >
     <mock-toolbar>
@@ -2020,7 +2119,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
         >
           <mock-link
-            classname="Footer-navBarLink-174"
+            classname="Footer-navBarLink-182"
             href="/map"
           >
             <mock-typography
@@ -2046,7 +2145,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
 exports[`Reef Detail Page should render with given state from Redux store: snapshot-with-no-data 1`] = `
 <div>
   <mock-appbar
-    classname="NavBar-appBar-3"
+    classname="NavBar-appBar-3 NavBar-appBarXs-5"
     color="primary"
     position="static"
   >
@@ -2159,7 +2258,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-5 MuiGrid-grid-sm-4"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-5 MuiGrid-grid-sm-6"
         >
           <mock-box
             alignitems="center"
@@ -2200,8 +2299,57 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             </mock-link>
           </mock-box>
         </div>
+        <mock-hidden
+          xsdown="true"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-3"
+          >
+            <div
+              class="Search-searchBar-14"
+            >
+              <div
+                class="Search-searchBarIcon-15"
+              >
+                <mock-iconbutton
+                  size="small"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </mock-iconbutton>
+              </div>
+              <div
+                class="Search-searchBarText-16"
+              >
+                <div
+                  aria-expanded="false"
+                  class="MuiAutocomplete-root Search-searchBarInput-17 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                  role="combobox"
+                >
+                  <mock-textfield
+                    disabled="false"
+                    fullwidth="true"
+                    id="location"
+                    inputlabelprops="[object Object]"
+                    inputprops="[object Object]"
+                    placeholder="Search by site name or country"
+                    variant="outlined"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </mock-hidden>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-7 MuiGrid-grid-sm-8"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-7 MuiGrid-grid-sm-3"
         >
           <mock-box
             alignitems="center"
@@ -2236,6 +2384,56 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             </mock-menu>
           </mock-box>
         </div>
+        <mock-hidden
+          smup="true"
+        >
+          <div
+            class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
+            style="margin: 0px; padding-top: 0px;"
+          >
+            <div
+              class="Search-searchBar-14"
+            >
+              <div
+                class="Search-searchBarIcon-15"
+              >
+                <mock-iconbutton
+                  size="small"
+                >
+                  <svg
+                    aria-hidden="true"
+                    class="MuiSvgIcon-root"
+                    focusable="false"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      d="M15.5 14h-.79l-.28-.27C15.41 12.59 16 11.11 16 9.5 16 5.91 13.09 3 9.5 3S3 5.91 3 9.5 5.91 16 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5 14 7.01 14 9.5 11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </mock-iconbutton>
+              </div>
+              <div
+                class="Search-searchBarText-16"
+              >
+                <div
+                  aria-expanded="false"
+                  class="MuiAutocomplete-root Search-searchBarInput-17 MuiAutocomplete-hasClearIcon MuiAutocomplete-hasPopupIcon"
+                  role="combobox"
+                >
+                  <mock-textfield
+                    disabled="false"
+                    fullwidth="true"
+                    id="location"
+                    inputlabelprops="[object Object]"
+                    inputprops="[object Object]"
+                    placeholder="Search by site name or country"
+                    variant="outlined"
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+        </mock-hidden>
       </div>
     </mock-toolbar>
   </mock-appbar>
@@ -2246,7 +2444,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root RegisterDialog-dialogHeader-15"
+        class="MuiCardHeader-root RegisterDialog-dialogHeader-19"
       >
         <div
           class="MuiCardHeader-content"
@@ -2272,7 +2470,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="RegisterDialog-dialogHeaderSecondPart-16"
+                    classname="RegisterDialog-dialogHeaderSecondPart-20"
                     variant="h4"
                   >
                     link
@@ -2282,7 +2480,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
                 >
                   <mock-iconbutton
-                    classname="RegisterDialog-closeButton-14"
+                    classname="RegisterDialog-closeButton-18"
                     size="small"
                   >
                     <svg
@@ -2303,13 +2501,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
         </div>
       </div>
       <mock-cardcontent
-        classname="RegisterDialog-contentWrapper-23"
+        classname="RegisterDialog-contentWrapper-27"
       >
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
         >
           <div
-            class="MuiGrid-root RegisterDialog-dialogContentTitle-17 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
+            class="MuiGrid-root RegisterDialog-dialogContentTitle-21 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -2326,10 +2524,10 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <form
-              class="RegisterDialog-form-18"
+              class="RegisterDialog-form-22"
             >
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-19 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-23 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2344,7 +2542,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-19 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-23 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2359,7 +2557,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-19 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-23 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2374,7 +2572,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-19 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-23 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2389,7 +2587,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-textFieldWrapper-19 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-textFieldWrapper-23 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2412,7 +2610,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 >
                   <mock-checkbox
                     checked="false"
-                    classname="RegisterDialog-termsCheckbox-24"
+                    classname="RegisterDialog-termsCheckbox-28"
                     color="primary"
                   />
                 </div>
@@ -2420,14 +2618,14 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-10"
                 >
                   <mock-typography
-                    classname="RegisterDialog-formText-21"
+                    classname="RegisterDialog-formText-25"
                     color="textSecondary"
                     variant="subtitle1"
                   >
                     I have read the
                      
                     <a
-                      class="RegisterDialog-termsLink-25"
+                      class="RegisterDialog-termsLink-29"
                       href="/terms"
                     >
                       Terms and Conditions
@@ -2436,7 +2634,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </div>
               </div>
               <div
-                class="MuiGrid-root RegisterDialog-button-22 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root RegisterDialog-button-26 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
                   color="primary"
@@ -2453,7 +2651,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="RegisterDialog-formText-21"
+                  classname="RegisterDialog-formText-25"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -2478,7 +2676,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root SignInDialog-dialogHeader-27"
+        class="MuiCardHeader-root SignInDialog-dialogHeader-31"
       >
         <div
           class="MuiCardHeader-content"
@@ -2504,7 +2702,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="SignInDialog-dialogHeaderSecondPart-28"
+                    classname="SignInDialog-dialogHeaderSecondPart-32"
                     variant="h4"
                   >
                     link
@@ -2514,7 +2712,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-flex-end MuiGrid-grid-xs-1"
                 >
                   <mock-iconbutton
-                    classname="SignInDialog-closeButton-26"
+                    classname="SignInDialog-closeButton-30"
                     size="small"
                   >
                     <svg
@@ -2596,7 +2794,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-justify-xs-center MuiGrid-grid-xs-12"
         >
           <div
-            class="MuiGrid-root SignInDialog-dialogContentTitle-29 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
+            class="MuiGrid-root SignInDialog-dialogContentTitle-33 MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <div
               class="MuiGrid-root MuiGrid-item"
@@ -2613,13 +2811,13 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
           >
             <form
-              class="SignInDialog-form-30"
+              class="SignInDialog-form-34"
             >
               <div
-                class="MuiGrid-root SignInDialog-textFieldWrapper-31 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-textFieldWrapper-35 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-33"
+                  classname="SignInDialog-formText-37"
                   variant="subtitle2"
                 >
                   or login with email address
@@ -2637,7 +2835,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 />
               </div>
               <div
-                class="MuiGrid-root SignInDialog-textFieldWrapper-31 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-textFieldWrapper-35 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-textfield
                   error="false"
@@ -2656,7 +2854,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
-                  classname="SignInDialog-forgotPasswordButton-35"
+                  classname="SignInDialog-forgotPasswordButton-39"
                 >
                   <mock-typography
                     color="textSecondary"
@@ -2667,7 +2865,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 </mock-button>
               </div>
               <div
-                class="MuiGrid-root SignInDialog-button-34 MuiGrid-item MuiGrid-grid-xs-12"
+                class="MuiGrid-root SignInDialog-button-38 MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-button
                   color="primary"
@@ -2683,7 +2881,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-33"
+                  classname="SignInDialog-formText-37"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -2762,7 +2960,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
       </div>
     </div>
     <div
-      class="MuiGrid-root ReefNavBar-root-36 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+      class="MuiGrid-root ReefNavBar-root-40 MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
     >
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
@@ -2852,7 +3050,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
       mt="1rem"
     >
       <mock-box
-        classname="CardTitle-root-42"
+        classname="CardTitle-root-46"
       >
         <div
           class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-baseline"
@@ -2886,7 +3084,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6"
         >
           <div
-            class="ReefDetails-container-40"
+            class="ReefDetails-container-44"
           >
             <mock-map
               polygon="[object Object]"
@@ -2897,7 +3095,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6"
         >
           <div
-            class="ReefDetails-container-40"
+            class="ReefDetails-container-44"
           >
             <mock-featuredmedia
               reefid="1"
@@ -2908,7 +3106,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
     </mock-box>
   </div>
   <mock-appbar
-    classname="Footer-appBar-43"
+    classname="Footer-appBar-47"
     position="static"
   >
     <mock-toolbar>
@@ -2919,7 +3117,7 @@ exports[`Reef Detail Page should render with given state from Redux store: snaps
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10"
         >
           <mock-link
-            classname="Footer-navBarLink-44"
+            classname="Footer-navBarLink-48"
             href="/map"
           >
             <mock-typography

--- a/packages/website/src/routes/ReefRoutes/Reef/index.test.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.test.tsx
@@ -38,6 +38,9 @@ describe("Reef Detail Page", () => {
         error: null,
         loading: false,
       },
+      homepage: {
+        reefOnMap: mockReef,
+      },
       reefsList: {
         list: [],
         loading: false,
@@ -65,6 +68,9 @@ describe("Reef Detail Page", () => {
         userInfo: mockUser,
         error: null,
         loading: false,
+      },
+      homepage: {
+        reefOnMap: mockReef,
       },
       reefsList: {
         list: [mockReef],

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -199,7 +199,7 @@ const Reef = ({ match, classes }: ReefProps) => {
 
   return (
     <>
-      <ReefNavBar searchLocation geolocationEnabled={false} />
+      <ReefNavBar searchLocation />
       <Container className={!hasDailyData ? classes.noDataWrapper : ""}>
         {reefDetails && liveData && !error ? (
           <>

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -43,6 +43,10 @@ import {
   findChartPeriod,
 } from "../../../helpers/dates";
 import { Range } from "../../../store/Reefs/types";
+import {
+  reefsListSelector,
+  reefsRequest,
+} from "../../../store/Reefs/reefsListSlice";
 
 const getAlertMessage = (
   user: User | null,
@@ -102,6 +106,7 @@ const getAlertMessage = (
 
 const Reef = ({ match, classes }: ReefProps) => {
   const reefDetails = useSelector(reefDetailsSelector);
+  const reefsList = useSelector(reefsListSelector);
   const user = useSelector(userInfoSelector);
   const loading = useSelector(reefLoadingSelector);
   const error = useSelector(reefErrorSelector);
@@ -129,6 +134,13 @@ const Reef = ({ match, classes }: ReefProps) => {
   const [endDate, setEndDate] = useState<string>();
   const [pickerDate, setPickerDate] = useState<string>(today.toISOString());
 
+  // Fetch reefs for the search bar
+  useEffect(() => {
+    if (reefsList.length === 0) {
+      dispatch(reefsRequest());
+    }
+  }, [dispatch, reefsList]);
+
   // fetch the reef and spotter data
   useEffect(() => {
     dispatch(reefRequest(reefId));
@@ -138,7 +150,7 @@ const Reef = ({ match, classes }: ReefProps) => {
   // fetch spotter data from api, also filter the range we're interested in.
   useEffect(() => {
     // make sure we've loaded the reef, before attempting to get its spotter data.
-    if (hasSpotterData && !loading) {
+    if (reefId === reefDetails?.id.toString() && hasSpotterData && !loading) {
       dispatch(
         reefSpotterDataRequest({
           id: reefId,
@@ -150,7 +162,15 @@ const Reef = ({ match, classes }: ReefProps) => {
       // Clear possible spotter data from previously selected reef
       dispatch(clearReefSpotterData());
     }
-  }, [dispatch, reefId, hasSpotterData, range, pickerDate, loading]);
+  }, [
+    dispatch,
+    reefId,
+    hasSpotterData,
+    range,
+    pickerDate,
+    loading,
+    reefDetails,
+  ]);
 
   // update the end date once spotter data changes. Happens when `range` is changed.
   useEffect(() => {
@@ -191,7 +211,7 @@ const Reef = ({ match, classes }: ReefProps) => {
 
   return (
     <>
-      <ReefNavBar searchLocation={false} />
+      <ReefNavBar searchLocation geolocationEnabled={false} />
       <Container className={!hasDailyData ? classes.noDataWrapper : ""}>
         {reefDetails && liveData && !error ? (
           <>

--- a/packages/website/src/routes/ReefRoutes/Reef/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/Reef/index.tsx
@@ -43,10 +43,6 @@ import {
   findChartPeriod,
 } from "../../../helpers/dates";
 import { Range } from "../../../store/Reefs/types";
-import {
-  reefsListSelector,
-  reefsRequest,
-} from "../../../store/Reefs/reefsListSlice";
 
 const getAlertMessage = (
   user: User | null,
@@ -106,7 +102,6 @@ const getAlertMessage = (
 
 const Reef = ({ match, classes }: ReefProps) => {
   const reefDetails = useSelector(reefDetailsSelector);
-  const reefsList = useSelector(reefsListSelector);
   const user = useSelector(userInfoSelector);
   const loading = useSelector(reefLoadingSelector);
   const error = useSelector(reefErrorSelector);
@@ -133,13 +128,6 @@ const Reef = ({ match, classes }: ReefProps) => {
   const today = new Date();
   const [endDate, setEndDate] = useState<string>();
   const [pickerDate, setPickerDate] = useState<string>(today.toISOString());
-
-  // Fetch reefs for the search bar
-  useEffect(() => {
-    if (reefsList.length === 0) {
-      dispatch(reefsRequest());
-    }
-  }, [dispatch, reefsList]);
 
   // fetch the reef and spotter data
   useEffect(() => {

--- a/packages/website/src/routes/ReefRoutes/ReefsList/index.tsx
+++ b/packages/website/src/routes/ReefRoutes/ReefsList/index.tsx
@@ -17,7 +17,7 @@ import {
 } from "../../../store/Reefs/reefsListSlice";
 
 const ReefsList = ({ classes }: ReefsListProps) => {
-  const reefsList = useSelector(reefsListSelector);
+  const reefsList = useSelector(reefsListSelector) || [];
   const dispatch = useDispatch();
 
   useEffect(() => {

--- a/packages/website/src/routes/Surveys/index.tsx
+++ b/packages/website/src/routes/Surveys/index.tsx
@@ -21,26 +21,14 @@ import NavBar from "../../common/NavBar";
 import Footer from "../../common/Footer";
 import NewSurvey from "./New";
 import ViewSurvey from "./View";
-import {
-  reefsListSelector,
-  reefsRequest,
-} from "../../store/Reefs/reefsListSlice";
 
 const Surveys = ({ match, isView, classes }: SurveysProps) => {
   const reefDetails = useSelector(reefDetailsSelector);
-  const reefsList = useSelector(reefsListSelector);
   const loading = useSelector(reefLoadingSelector);
   const error = useSelector(reefErrorSelector);
   const dispatch = useDispatch();
   const reefId = match.params.id;
   const surveyId = match.params.sid;
-
-  // Fetch reefs for the search bar
-  useEffect(() => {
-    if (reefsList.length === 0) {
-      dispatch(reefsRequest());
-    }
-  }, [dispatch, reefsList]);
 
   useEffect(() => {
     if (!reefDetails) {

--- a/packages/website/src/routes/Surveys/index.tsx
+++ b/packages/website/src/routes/Surveys/index.tsx
@@ -47,7 +47,7 @@ const Surveys = ({ match, isView, classes }: SurveysProps) => {
 
   return (
     <>
-      <NavBar searchLocation geolocationEnabled={false} />
+      <NavBar searchLocation />
       <>
         {/* eslint-disable-next-line no-nested-ternary */}
         {reefDetails && !error ? (

--- a/packages/website/src/routes/Surveys/index.tsx
+++ b/packages/website/src/routes/Surveys/index.tsx
@@ -21,14 +21,26 @@ import NavBar from "../../common/NavBar";
 import Footer from "../../common/Footer";
 import NewSurvey from "./New";
 import ViewSurvey from "./View";
+import {
+  reefsListSelector,
+  reefsRequest,
+} from "../../store/Reefs/reefsListSlice";
 
 const Surveys = ({ match, isView, classes }: SurveysProps) => {
   const reefDetails = useSelector(reefDetailsSelector);
+  const reefsList = useSelector(reefsListSelector);
   const loading = useSelector(reefLoadingSelector);
   const error = useSelector(reefErrorSelector);
   const dispatch = useDispatch();
   const reefId = match.params.id;
   const surveyId = match.params.sid;
+
+  // Fetch reefs for the search bar
+  useEffect(() => {
+    if (reefsList.length === 0) {
+      dispatch(reefsRequest());
+    }
+  }, [dispatch, reefsList]);
 
   useEffect(() => {
     if (!reefDetails) {
@@ -47,7 +59,7 @@ const Surveys = ({ match, isView, classes }: SurveysProps) => {
 
   return (
     <>
-      <NavBar searchLocation={false} />
+      <NavBar searchLocation geolocationEnabled={false} />
       <>
         {/* eslint-disable-next-line no-nested-ternary */}
         {reefDetails && !error ? (

--- a/packages/website/src/store/Reefs/reefsListSlice.ts
+++ b/packages/website/src/store/Reefs/reefsListSlice.ts
@@ -8,8 +8,6 @@ import type { RootState, CreateAsyncThunkTypes } from "../configure";
 import reefServices from "../../services/reefServices";
 
 const reefsListInitialState: ReefsListState = {
-  list: [],
-  reefsToDisplay: [],
   loading: false,
   error: null,
 };
@@ -44,7 +42,7 @@ const reefsListSlice = createSlice({
     filterReefsWithSpotter: (state, action: PayloadAction<boolean>) => ({
       ...state,
       reefsToDisplay: action.payload
-        ? state.list.filter(
+        ? state.list?.filter(
             (item) => item.spotterId && item.status === "deployed"
           )
         : state.list,

--- a/packages/website/src/store/Reefs/types.ts
+++ b/packages/website/src/store/Reefs/types.ts
@@ -172,8 +172,8 @@ export interface ReefsRequestData {
 }
 
 export interface ReefsListState {
-  list: Reef[];
-  reefsToDisplay: Reef[];
+  list?: Reef[];
+  reefsToDisplay?: Reef[];
   loading: boolean;
   error?: string | null;
 }


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/432. When the user is on site or survey details page and searches for a reef in the search bar, he gets redirected on the searched site's detail page.
Designs:

| desktop | mobile |
|---|---|
| ![Screenshot_20210201_152216](https://user-images.githubusercontent.com/64922890/106464467-601da580-64a1-11eb-9cde-f274d0d4a70b.png) | ![Screenshot_20210201_152202](https://user-images.githubusercontent.com/64922890/106464521-6b70d100-64a1-11eb-8403-1474012927ab.png) |
