### PR TITLE
[WIP] Add timescaledb plugin

### DIFF
--- a/packages/api/docker-compose.yml
+++ b/packages/api/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.4'
 services:
   aqua-postgres:
-    image: kartoza/postgis:12.1
+    image: timescale/timescaledb-postgis:2.0.1-pg12
     restart: always
     ports:
       - 54321:5432

--- a/packages/api/migration/1611844221733-InitTimescale.ts
+++ b/packages/api/migration/1611844221733-InitTimescale.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class InitTimescale1611844221733 implements MigrationInterface {
+  name = 'InitTimescale1611844221733';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('CREATE EXTENSION IF NOT EXISTS "timescaledb"');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('DROP EXTENSION IF EXISTS "timescaledb"');
+  }
+}


### PR DESCRIPTION
The docker-composer yml has been updated to install timescaledb as well
PostgreSQL has been upgraded to 12.4 which might cause some incompatibilities

## Resolve compatibility issues
- Data might not get imported properly by postgres 12.4 so we will need to export them and import them in the new database
On your old database run the following for each table (except the 'migrations' table):
```
COPY table_name TO '/tmp/table_name.csv' DELIMITER ',' CSV HEADER;
```
- Move exported csv to the shared folder
```
mv /tmp/*.csv /var/lib/postgresql
```
- Grab the csv from the shared volume and save them somewhere in your computer
- Delete the db_data folder and re-run the docker-compose.yml file
- Run migrations
- Move csv files in the db_data folder and from there to the tmp directory of the container so that the database can read them
- Import data into database
```
COPY table_name FROM  '/tmp/table_name.csv'  DELIMITER ','  CSV HEADER;
```