### PR TITLE
Fix Mobile Drawer scrolling issues

### DIFF
--- a/packages/website/src/routes/HomeMap/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/ReefTable/__snapshots__/index.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
         classname="ReefTable-topHandle-5"
       />
       <mock-typography
-        classname="ReefTable-allReefsText-6"
+        classname="ReefTable-allReefsText-7"
         color="textSecondary"
         variant="h5"
       >
@@ -45,7 +45,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             <mock-tablerow>
               <mock-tablecell
                 align="left"
-                classname="EnhancedTableHead-headCells-7"
+                classname="EnhancedTableHead-headCells-9"
                 padding="default"
                 sortdirection="false"
                 style="width: 40%;"
@@ -65,7 +65,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablecell>
               <mock-tablecell
                 align="left"
-                classname="EnhancedTableHead-headCells-7"
+                classname="EnhancedTableHead-headCells-9"
                 padding="default"
                 sortdirection="false"
               >
@@ -91,7 +91,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablecell>
               <mock-tablecell
                 align="left"
-                classname="EnhancedTableHead-headCells-7"
+                classname="EnhancedTableHead-headCells-9"
                 padding="default"
                 sortdirection="false"
               >
@@ -117,7 +117,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-tablecell>
               <mock-tablecell
                 align="left"
-                classname="EnhancedTableHead-headCells-7"
+                classname="EnhancedTableHead-headCells-9"
                 padding="default"
                 sortdirection="desc"
                 style="width: 5%;"
@@ -147,7 +147,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
             tabindex="-1"
           >
             <mock-tablecell
-              classname="ReefTableBody-nameCells-8"
+              classname="ReefTableBody-nameCells-10"
             >
               <mock-typography
                 align="left"
@@ -158,10 +158,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              classname="ReefTableBody-cellTextAlign-11"
+              classname="ReefTableBody-cellTextAlign-13"
             >
               <mock-typography
-                classname="ReefTableBody-numberCellsTitle-10"
+                classname="ReefTableBody-numberCellsTitle-12"
                 style="color: rgb(22, 141, 189);"
                 variant="h6"
               >
@@ -180,10 +180,10 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              classname="ReefTableBody-cellTextAlign-11"
+              classname="ReefTableBody-cellTextAlign-13"
             >
               <mock-typography
-                classname="ReefTableBody-numberCellsTitle-10"
+                classname="ReefTableBody-numberCellsTitle-12"
                 style="color: rgb(117, 180, 114);"
                 variant="h6"
               >
@@ -202,7 +202,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               </mock-typography>
             </mock-tablecell>
             <mock-tablecell
-              classname="ReefTableBody-cellTextAlign-11"
+              classname="ReefTableBody-cellTextAlign-13"
             >
               <svg
                 aria-hidden="true"

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -6,6 +6,8 @@ import {
   TableRow,
   Theme,
   Typography,
+  useMediaQuery,
+  useTheme,
   WithStyles,
   withStyles,
 } from "@material-ui/core";
@@ -104,11 +106,19 @@ RowNumberCell.defaultProps = {
   decimalPlaces: 1,
 };
 
-const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
+const ReefTableBody = ({
+  order,
+  orderBy,
+  classes,
+  isDrawerOpen,
+}: ReefTableBodyProps) => {
   const dispatch = useDispatch();
   const reefsList = useSelector(reefsToDisplayListSelector) || [];
   const reefOnMap = useSelector(reefOnMapSelector);
   const [selectedRow, setSelectedRow] = useState<number>();
+
+  const theme = useTheme();
+  const isMobile = useMediaQuery(theme.breakpoints.only("xs"));
 
   const handleClick = (event: unknown, reef: Row) => {
     setSelectedRow(reef.tableData.id);
@@ -121,12 +131,17 @@ const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
     setSelectedRow(index);
   }, [reefOnMap, reefsList]);
 
+  // scroll to the relevant reef row when reef is selected.
   useEffect(() => {
     const child = document.getElementById(`homepage-table-row-${selectedRow}`);
-    if (child) {
-      child.scrollIntoView({ block: "center", behavior: "smooth" });
+    // only scroll if mobile drawer is open. Mobile drawer doesn't exist if not on mobile.
+    if (child && (isDrawerOpen || !isMobile)) {
+      setTimeout(
+        () => child.scrollIntoView({ block: "center", behavior: "smooth" }),
+        100
+      );
     }
-  }, [selectedRow]);
+  }, [isDrawerOpen, selectedRow]);
 
   return (
     <TableBody>
@@ -195,6 +210,8 @@ const styles = (theme: Theme) =>
 type ReefTableBodyIncomingProps = {
   order: Order;
   orderBy: OrderKeys;
+  // used when in mobile to decide when to autoscroll to the relevant reef.
+  isDrawerOpen: boolean;
 };
 
 type ReefTableBodyProps = WithStyles<typeof styles> &

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -106,12 +106,7 @@ RowNumberCell.defaultProps = {
   decimalPlaces: 1,
 };
 
-const ReefTableBody = ({
-  order,
-  orderBy,
-  classes,
-  isDrawerOpen,
-}: ReefTableBodyProps) => {
+const ReefTableBody = ({ order, orderBy, classes }: ReefTableBodyProps) => {
   const dispatch = useDispatch();
   const reefsList = useSelector(reefsToDisplayListSelector) || [];
   const reefOnMap = useSelector(reefOnMapSelector);
@@ -134,14 +129,11 @@ const ReefTableBody = ({
   // scroll to the relevant reef row when reef is selected.
   useEffect(() => {
     const child = document.getElementById(`homepage-table-row-${selectedRow}`);
-    // only scroll if mobile drawer is open. Mobile drawer doesn't exist if not on mobile.
-    if (child && (isDrawerOpen || !isMobile)) {
-      setTimeout(
-        () => child.scrollIntoView({ block: "center", behavior: "smooth" }),
-        100
-      );
+    // only scroll if not on mobile (info at the top is more useful than the reef row)
+    if (child && !isMobile) {
+      child.scrollIntoView({ block: "center", behavior: "smooth" });
     }
-  }, [isDrawerOpen, selectedRow]);
+  }, [isMobile, selectedRow]);
 
   return (
     <TableBody>
@@ -210,8 +202,6 @@ const styles = (theme: Theme) =>
 type ReefTableBodyIncomingProps = {
   order: Order;
   orderBy: OrderKeys;
-  // used when in mobile to decide when to autoscroll to the relevant reef.
-  isDrawerOpen: boolean;
 };
 
 type ReefTableBodyProps = WithStyles<typeof styles> &

--- a/packages/website/src/routes/HomeMap/ReefTable/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/index.test.tsx
@@ -39,7 +39,7 @@ describe("ReefTable", () => {
 
     element = render(
       <Provider store={store}>
-        <ReefTable openDrawer={openDrawer} />
+        <ReefTable isDrawerOpen={openDrawer} />
       </Provider>
     ).container;
   });

--- a/packages/website/src/routes/HomeMap/ReefTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/index.tsx
@@ -13,7 +13,6 @@ import {
   WithStyles,
 } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
-import { makeStyles } from "@material-ui/core/styles";
 import classNames from "classnames";
 import SelectedReefCard from "./SelectedReefCard";
 import ReefTableBody from "./body";

--- a/packages/website/src/routes/HomeMap/ReefTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/index.tsx
@@ -9,6 +9,8 @@ import {
   TableContainer,
   Theme,
   Typography,
+  withStyles,
+  WithStyles,
 } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
 import { makeStyles } from "@material-ui/core/styles";
@@ -32,56 +34,10 @@ import {
 import { getReefNameAndRegion } from "../../../store/Reefs/helpers";
 
 const SMALL_HEIGHT = 720;
-const useStyles = makeStyles((theme: Theme) =>
-  createStyles({
-    tableHolder: {
-      paddingLeft: 10,
-      [theme.breakpoints.down("xs")]: {
-        paddingLeft: 0,
-        height: "auto",
-      },
-    },
-    scrollable: {
-      overflowY: "auto",
-    },
-    table: {
-      [theme.breakpoints.down("xs")]: {
-        tableLayout: "fixed",
-      },
-    },
-    switchWrapper: {
-      padding: "0 16px",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "flex-end",
-    },
-    topHandle: {
-      width: 50,
-      height: 10,
-      backgroundColor: theme.palette.grey["400"],
-      borderRadius: "20px",
-    },
-    bounce: { animation: "$bounce 1s infinite alternate" },
-    allReefsText: {
-      position: "absolute",
-      left: 25,
-      top: 25,
-      whiteSpace: "nowrap",
-      overflow: "hidden",
-      textOverflow: "ellipsis",
-      maxWidth: "90vw",
-    },
-    "@keyframes bounce": {
-      "0%": { transform: "translateY(0px)" },
-      "100%": { transform: "translateY(-5px)" },
-    },
-  })
-);
 
-const ReefTable = ({ isDrawerOpen }: ReefTableProps) => {
+const ReefTable = ({ isDrawerOpen, classes }: ReefTableProps) => {
   const loading = useSelector(reefsListLoadingSelector);
   const reefOnMap = useSelector(reefOnMapSelector);
-  const classes = useStyles();
   const user = useSelector(userInfoSelector);
   const withSpotterOnly = useSelector(withSpotterOnlySelector);
   const dispatch = useDispatch();
@@ -169,11 +125,7 @@ const ReefTable = ({ isDrawerOpen }: ReefTableProps) => {
                 onRequestSort={handleRequestSort}
               />
             </Hidden>
-            <ReefTableBody
-              order={order}
-              orderBy={orderBy}
-              isDrawerOpen={isDrawerOpen}
-            />
+            <ReefTableBody order={order} orderBy={orderBy} />
           </Table>
         </TableContainer>
         {loading && (
@@ -190,10 +142,58 @@ const ReefTable = ({ isDrawerOpen }: ReefTableProps) => {
     </>
   );
 };
+const styles = (theme: Theme) =>
+  createStyles({
+    tableHolder: {
+      paddingLeft: 10,
+      [theme.breakpoints.down("xs")]: {
+        paddingLeft: 0,
+        height: "auto",
+      },
+    },
+    scrollable: {
+      overflowY: "auto",
+    },
+    table: {
+      [theme.breakpoints.down("xs")]: {
+        tableLayout: "fixed",
+      },
+    },
+    switchWrapper: {
+      padding: "0 16px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "flex-end",
+    },
+    topHandle: {
+      width: 50,
+      height: 10,
+      backgroundColor: theme.palette.grey["400"],
+      borderRadius: "20px",
+    },
+    bounce: { animation: "$bounce 1s infinite alternate" },
+    allReefsText: {
+      position: "absolute",
+      left: 25,
+      top: 25,
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      maxWidth: "90vw",
+    },
+    "@keyframes bounce": {
+      "0%": { transform: "translateY(0px)" },
+      "100%": { transform: "translateY(-5px)" },
+    },
+  });
 
-interface ReefTableProps {
+interface ReefTableProps
+  extends ReefTableIncomingProps,
+    WithStyles<typeof styles> {}
+
+interface ReefTableIncomingProps {
   // used on mobile to add descriptive elements if the drawer is closed.
   isDrawerOpen: boolean;
 }
 
-export default ReefTable;
+export default withStyles(styles)(ReefTable);

--- a/packages/website/src/routes/HomeMap/ReefTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/index.tsx
@@ -9,10 +9,10 @@ import {
   TableContainer,
   Theme,
   Typography,
-  withStyles,
-  WithStyles,
 } from "@material-ui/core";
 import { useDispatch, useSelector } from "react-redux";
+import { makeStyles } from "@material-ui/core/styles";
+import classNames from "classnames";
 import SelectedReefCard from "./SelectedReefCard";
 import ReefTableBody from "./body";
 import { Order, OrderKeys } from "./utils";
@@ -25,14 +25,63 @@ import { useWindowSize } from "../../../helpers/useWindowSize";
 import { userInfoSelector } from "../../../store/User/userSlice";
 import { isSuperAdmin } from "../../../helpers/user";
 import {
+  reefOnMapSelector,
   setWithSpotterOnly,
   withSpotterOnlySelector,
 } from "../../../store/Homepage/homepageSlice";
+import { getReefNameAndRegion } from "../../../store/Reefs/helpers";
 
 const SMALL_HEIGHT = 720;
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    tableHolder: {
+      paddingLeft: 10,
+      [theme.breakpoints.down("xs")]: {
+        paddingLeft: 0,
+        height: "auto",
+      },
+    },
+    scrollable: {
+      overflowY: "auto",
+    },
+    table: {
+      [theme.breakpoints.down("xs")]: {
+        tableLayout: "fixed",
+      },
+    },
+    switchWrapper: {
+      padding: "0 16px",
+      display: "flex",
+      alignItems: "center",
+      justifyContent: "flex-end",
+    },
+    topHandle: {
+      width: 50,
+      height: 10,
+      backgroundColor: theme.palette.grey["400"],
+      borderRadius: "20px",
+    },
+    bounce: { animation: "$bounce 1s infinite alternate" },
+    allReefsText: {
+      position: "absolute",
+      left: 25,
+      top: 25,
+      whiteSpace: "nowrap",
+      overflow: "hidden",
+      textOverflow: "ellipsis",
+      maxWidth: "90vw",
+    },
+    "@keyframes bounce": {
+      "0%": { transform: "translateY(0px)" },
+      "100%": { transform: "translateY(-5px)" },
+    },
+  })
+);
 
-const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
+const ReefTable = ({ isDrawerOpen }: ReefTableProps) => {
   const loading = useSelector(reefsListLoadingSelector);
+  const reefOnMap = useSelector(reefOnMapSelector);
+  const classes = useStyles();
   const user = useSelector(userInfoSelector);
   const withSpotterOnly = useSelector(withSpotterOnlySelector);
   const dispatch = useDispatch();
@@ -71,14 +120,18 @@ const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
           marginTop={2}
           marginBottom={3}
         >
-          <Box className={classes.topHandle} />
-          {!openDrawer && (
+          <Box
+            className={classNames(classes.topHandle, {
+              [classes.bounce]: !!reefOnMap && !isDrawerOpen,
+            })}
+          />
+          {!isDrawerOpen && (
             <Typography
               className={classes.allReefsText}
               variant="h5"
               color="textSecondary"
             >
-              All Reefs
+              {reefOnMap ? getReefNameAndRegion(reefOnMap).name : "All Reefs"}
             </Typography>
           )}
         </Box>
@@ -116,7 +169,11 @@ const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
                 onRequestSort={handleRequestSort}
               />
             </Hidden>
-            <ReefTableBody order={order} orderBy={orderBy} />
+            <ReefTableBody
+              order={order}
+              orderBy={orderBy}
+              isDrawerOpen={isDrawerOpen}
+            />
           </Table>
         </TableContainer>
         {loading && (
@@ -134,45 +191,9 @@ const ReefTable = ({ openDrawer, classes }: ReefTableProps) => {
   );
 };
 
-const styles = (theme: Theme) =>
-  createStyles({
-    tableHolder: {
-      paddingLeft: 10,
-      [theme.breakpoints.down("xs")]: {
-        paddingLeft: 0,
-        height: "auto",
-      },
-    },
-    scrollable: {
-      overflowY: "auto",
-    },
-    table: {
-      [theme.breakpoints.down("xs")]: {
-        tableLayout: "fixed",
-      },
-    },
-    switchWrapper: {
-      padding: "0 16px",
-      display: "flex",
-      alignItems: "center",
-      justifyContent: "flex-end",
-    },
-    topHandle: {
-      width: 50,
-      height: 10,
-      backgroundColor: theme.palette.grey["400"],
-      borderRadius: "20px",
-    },
-    allReefsText: {
-      position: "absolute",
-      left: 25,
-    },
-  });
-
-interface ReefTableIncomingProps {
-  openDrawer: boolean;
+interface ReefTableProps {
+  // used on mobile to add descriptive elements if the drawer is closed.
+  isDrawerOpen: boolean;
 }
 
-type ReefTableProps = ReefTableIncomingProps & WithStyles<typeof styles>;
-
-export default withStyles(styles)(ReefTable);
+export default ReefTable;

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
           class="MuiGrid-root Homepage-reefTable-3 MuiGrid-item MuiGrid-grid-sm-6"
         >
           <mock-reeftable
-            opendrawer="false"
+            isdraweropen="false"
           />
         </div>
       </mock-hidden>
@@ -61,7 +61,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
                     role="presentation"
                   >
                     <mock-reeftable
-                      opendrawer="false"
+                      isdraweropen="false"
                     />
                   </div>
                 </div>

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -68,7 +68,7 @@ const Homepage = ({ classes }: HomepageProps) => {
           </Grid>
           <Hidden xsDown>
             <Grid className={classes.reefTable} item sm={6}>
-              <ReefTable openDrawer={isDrawerOpen} />
+              <ReefTable isDrawerOpen={isDrawerOpen} />
             </Grid>
           </Hidden>
           <Hidden smUp>
@@ -83,7 +83,7 @@ const Homepage = ({ classes }: HomepageProps) => {
               open={isDrawerOpen}
             >
               <div role="presentation" onClick={toggleDrawer}>
-                <ReefTable openDrawer={isDrawerOpen} />
+                <ReefTable isDrawerOpen={isDrawerOpen} />
               </div>
             </SwipeableBottomSheet>
           </Hidden>


### PR DESCRIPTION
Test: http://aqua-drawer.surge.sh
This PR fixes a bug where the mobile drawer would scroll while closed causing a confusing overlay to show:
![image](https://user-images.githubusercontent.com/25571542/108661504-15330300-7520-11eb-883e-7ae71abe433b.png)

The mobile drawer now doesn't scroll at all, as any information the user needs would be at the top.
A bouncing pill animation was also added to encourage users to use the drawer after they selected a point on the map. The selected reef name is also shown at the bottom instead of 'all reefs'