### PR TITLE
Show historic max line and values for small intervals

### DIFF
--- a/packages/website/src/common/Chart/ChartWithCard/Chart.tsx
+++ b/packages/website/src/common/Chart/ChartWithCard/Chart.tsx
@@ -192,6 +192,7 @@ const Chart = ({
                 pickerSize="small"
                 autoOk={false}
                 onChange={onStartDateChange}
+                timeZone={reef.timezone}
               />
             </Grid>
             <Grid item>
@@ -202,6 +203,7 @@ const Chart = ({
                 pickerSize="small"
                 autoOk={false}
                 onChange={onEndDateChange}
+                timeZone={reef.timezone}
               />
             </Grid>
           </Grid>

--- a/packages/website/src/common/Chart/ChartWithCard/helpers.ts
+++ b/packages/website/src/common/Chart/ChartWithCard/helpers.ts
@@ -1,4 +1,4 @@
-import { minBy, maxBy, meanBy, some } from "lodash";
+import { minBy, maxBy, meanBy } from "lodash";
 import moment from "moment";
 import {
   findMarginalDate,
@@ -91,15 +91,12 @@ export const findDataLimits = (
   );
   const filteredSpotterData = filterTimeSeriesData(spotter, startDate, endDate);
 
-  const hasData = some(
-    [
-      filteredMaxMonthlyData,
-      filteredDailyData,
-      filteredSpotterData?.bottomTemperature,
-      filteredSpotterData?.surfaceTemperature,
-      filteredHoboData,
-    ],
-    (item) => !!item?.[0]
+  const hasData = Boolean(
+    filteredMaxMonthlyData?.[0] ||
+      filteredDailyData?.[0] ||
+      filteredSpotterData?.bottomTemperature?.[0] ||
+      filteredSpotterData?.surfaceTemperature?.[0] ||
+      filteredHoboData?.[0]
   );
 
   return [

--- a/packages/website/src/common/Chart/ChartWithCard/index.tsx
+++ b/packages/website/src/common/Chart/ChartWithCard/index.tsx
@@ -365,8 +365,8 @@ const ChartWithCard = ({
               )}
             >
               <DownloadCSVButton
-                startDate={startDate}
-                endDate={endDate}
+                startDate={pickerStartDate}
+                endDate={pickerEndDate}
                 reefId={reef.id}
                 pointId={pointId}
                 className={classes.button}

--- a/packages/website/src/common/Chart/ChartWithCard/index.tsx
+++ b/packages/website/src/common/Chart/ChartWithCard/index.tsx
@@ -22,18 +22,13 @@ import {
 } from "../../../store/Reefs/selectedReefSlice";
 import { Reef } from "../../../store/Reefs/types";
 import {
-  findMarginalDate,
   generateMonthlyMaxTimestamps,
   isBefore,
   setTimeZone,
   subtractFromDate,
 } from "../../../helpers/dates";
-import {
-  filterDailyData,
-  filterMaxMonthlyData,
-  filterSofarData,
-  filterTimeSeriesData,
-} from "../utils";
+import { findDataLimits } from "./helpers";
+import { filterSofarData, filterTimeSeriesData } from "../utils";
 import { RangeValue } from "./types";
 import ViewRange from "./ViewRange";
 import DownloadCSVButton from "./DownloadCSVButton";
@@ -52,8 +47,8 @@ const ChartWithCard = ({
 
   const dispatch = useDispatch();
   const granularDailyData = useSelector(reefGranularDailyDataSelector);
-  const { hobo: hoboData, spotter: spotterData } =
-    useSelector(reefTimeSeriesDataSelector) || {};
+  const timeSeriesData = useSelector(reefTimeSeriesDataSelector);
+  const { hobo: hoboData, spotter: spotterData } = timeSeriesData || {};
   const { bottomTemperature: hoboBottomTemperature } = hoboData || {};
   const { bottomTemperature: hoboBottomTemperatureRange } =
     useSelector(reefTimeSeriesDataRangeSelector)?.hobo || {};
@@ -126,91 +121,42 @@ const ChartWithCard = ({
 
   // Set chart start/end dates based on data received
   useEffect(() => {
-    const maxMonthlyData = generateMonthlyMaxTimestamps(
+    const [minDataDate, maxDataDate] = findDataLimits(
       reef.monthlyMax,
+      granularDailyData,
+      timeSeriesData,
       pickerStartDate,
       pickerEndDate
     );
-    const filteredMaxMonthlyData = filterMaxMonthlyData(
-      maxMonthlyData,
-      pickerStartDate,
-      pickerEndDate
-    );
-    const filteredDailyData = filterDailyData(
-      granularDailyData || [],
-      pickerStartDate,
-      pickerEndDate
-    );
-    const filteredHoboData = filterSofarData(
-      hoboBottomTemperature || [],
-      pickerStartDate,
-      pickerEndDate
-    );
-    const filteredSpotterData = filterTimeSeriesData(
-      spotterData,
-      pickerStartDate,
-      pickerEndDate
-    );
-    if (
-      filteredMaxMonthlyData?.[0] ||
-      filteredDailyData?.[0] ||
-      filteredSpotterData?.bottomTemperature?.[0] ||
-      filteredSpotterData?.surfaceTemperature?.[0] ||
-      filteredHoboData?.[0]
-    ) {
-      const maxDataDate = new Date(
-        findMarginalDate(
-          filteredMaxMonthlyData,
-          filteredDailyData,
-          filteredSpotterData,
-          filteredHoboData
-        )
-      ).toISOString();
-      const minDataDate = new Date(
-        findMarginalDate(
-          filteredMaxMonthlyData,
-          filteredDailyData,
-          filteredSpotterData,
-          filteredHoboData,
-          "min"
-        )
-      ).toISOString();
-      const reefLocalEndDate = new Date(
-        setTimeZone(
-          new Date(moment(pickerEndDate).format("MM/DD/YYYY")),
-          reef?.timezone
-        )
-      ).toISOString();
-      const reefLocalStartDate = new Date(
-        setTimeZone(
-          new Date(moment(pickerStartDate).format("MM/DD/YYYY")),
-          reef?.timezone
-        )
-      ).toISOString();
+    const pickerLocalEndDate = new Date(
+      setTimeZone(
+        new Date(moment(pickerEndDate).format("MM/DD/YYYY")),
+        reef?.timezone
+      )
+    ).toISOString();
+    const pickerLocalStartDate = new Date(
+      setTimeZone(
+        new Date(moment(pickerStartDate).format("MM/DD/YYYY")),
+        reef?.timezone
+      )
+    ).toISOString();
 
-      if (moment(maxDataDate).isAfter(moment(reefLocalEndDate))) {
-        setEndDate(reefLocalEndDate);
-      } else {
-        setEndDate(maxDataDate);
-      }
+    setStartDate(
+      minDataDate
+        ? moment
+            .max(moment(minDataDate), moment(pickerLocalStartDate))
+            .toISOString()
+        : pickerLocalStartDate
+    );
 
-      if (moment(minDataDate).isAfter(moment(reefLocalStartDate))) {
-        setStartDate(minDataDate);
-      } else {
-        setStartDate(reefLocalStartDate);
-      }
-    } else {
-      setStartDate(undefined);
-      setEndDate(undefined);
-    }
-  }, [
-    granularDailyData,
-    hoboBottomTemperature,
-    pickerEndDate,
-    pickerStartDate,
-    reef,
-    spotterData,
-  ]);
+    setEndDate(
+      maxDataDate
+        ? moment
+            .min(moment(maxDataDate), moment(pickerLocalEndDate))
+            .toISOString()
+        : pickerLocalEndDate
+    );
+  }, [granularDailyData, pickerEndDate, pickerStartDate, reef, timeSeriesData]);
 
   // Set picker error
   useEffect(() => {
@@ -257,7 +203,14 @@ const ChartWithCard = ({
       setRange("custom");
       switch (type) {
         case "start":
-          setPickerStartDate(moment(dateString).startOf("day").toISOString());
+          // Set picker start date only if input date is after zero time
+          if (
+            moment(dateString)
+              .startOf("day")
+              .isSameOrAfter(moment(0).startOf("day"))
+          ) {
+            setPickerStartDate(moment(dateString).startOf("day").toISOString());
+          }
           break;
         case "end":
           // Set picker end date only if input date is before today
@@ -318,10 +271,8 @@ const ChartWithCard = ({
             )}
             pickerStartDate={pickerStartDate || subtractFromDate(today, "week")}
             pickerEndDate={pickerEndDate || today}
-            startDate={
-              startDate || pickerStartDate || subtractFromDate(today, "week")
-            }
-            endDate={endDate || pickerEndDate || today}
+            startDate={startDate || subtractFromDate(today, "week")}
+            endDate={endDate || today}
             onStartDateChange={onPickerDateChange("start")}
             onEndDateChange={onPickerDateChange("end")}
             pickerErrored={pickerErrored}
@@ -342,10 +293,8 @@ const ChartWithCard = ({
                 pickerStartDate || subtractFromDate(today, "week")
               }
               pickerEndDate={pickerEndDate || today}
-              chartStartDate={
-                startDate || pickerStartDate || subtractFromDate(today, "week")
-              }
-              chartEndDate={endDate || pickerEndDate || today}
+              chartStartDate={startDate || subtractFromDate(today, "week")}
+              chartEndDate={endDate || today}
               depth={reef.depth}
               spotterData={filterTimeSeriesData(
                 spotterData,

--- a/packages/website/src/common/Chart/ChartWithTooltip.tsx
+++ b/packages/website/src/common/Chart/ChartWithTooltip.tsx
@@ -6,6 +6,7 @@ import React, {
 } from "react";
 import { Line } from "react-chartjs-2";
 import type { ChartTooltipModel } from "chart.js";
+import moment from "moment";
 import Chart, { ChartProps } from ".";
 import Tooltip, { TooltipData } from "./Tooltip";
 import {
@@ -127,7 +128,10 @@ function ChartWithTooltip({
       tooltipModel.caretY -
       ((surveyId ? 30 : 0) + nValues * 20 + 48);
 
-    if (nValues > 0) {
+    if (
+      nValues > 0 &&
+      moment(date).isBetween(moment(startDate), moment(endDate))
+    ) {
       setTooltipPosition({ top, left });
       setTooltipData({
         ...tooltipData,

--- a/packages/website/src/common/Chart/ChartWithTooltip.tsx
+++ b/packages/website/src/common/Chart/ChartWithTooltip.tsx
@@ -6,6 +6,7 @@ import React, {
 } from "react";
 import { Line } from "react-chartjs-2";
 import type { ChartTooltipModel } from "chart.js";
+import { last } from "lodash";
 import moment from "moment";
 import Chart, { ChartProps } from ".";
 import Tooltip, { TooltipData } from "./Tooltip";
@@ -130,7 +131,10 @@ function ChartWithTooltip({
 
     if (
       nValues > 0 &&
-      moment(date).isBetween(moment(startDate), moment(endDate))
+      moment(date).isBetween(
+        moment(startDate || last(filteredDailyData)?.date),
+        moment(endDate || filteredDailyData?.[0]?.date)
+      )
     ) {
       setTooltipPosition({ top, left });
       setTooltipData({

--- a/packages/website/src/common/Chart/utils.ts
+++ b/packages/website/src/common/Chart/utils.ts
@@ -222,9 +222,7 @@ export const filterMaxMonthlyData = (
     inRange(moment(item.date).valueOf(), start.valueOf(), end.valueOf() + 1)
   );
 
-  return filteredData.length > 0
-    ? filteredData
-    : [...closestToStartArray, ...closestToEndArray];
+  return [...closestToStartArray, ...filteredData, ...closestToEndArray];
 };
 
 export function getSofarDataClosestToDate(

--- a/packages/website/src/common/Chart/utils.ts
+++ b/packages/website/src/common/Chart/utils.ts
@@ -43,23 +43,6 @@ export const filterDailyData = (
   return ret;
 };
 
-export const filterMaxMonthlyData = (
-  monthlyMax: MonthlyMaxData[],
-  from?: string,
-  to?: string
-) => {
-  if (!from || !to) {
-    return monthlyMax;
-  }
-
-  const start = moment(from);
-  const end = moment(to);
-
-  return monthlyMax.filter((item) =>
-    inRange(moment(item.date).valueOf(), start.valueOf(), end.valueOf() + 1)
-  );
-};
-
 export const filterSofarData = (
   sofarData: SofarValue[],
   from?: string,
@@ -206,6 +189,43 @@ export function getMonthlyMaxDataClosestToDate(
       )
     : undefined;
 }
+
+export const filterMaxMonthlyData = (
+  monthlyMax: MonthlyMaxData[],
+  from?: string,
+  to?: string
+) => {
+  if (!from || !to) {
+    return monthlyMax;
+  }
+
+  const start = moment(from);
+  const end = moment(to);
+
+  const closestToStart = getMonthlyMaxDataClosestToDate(
+    monthlyMax,
+    new Date(start.toISOString())
+  )?.value;
+  const closestToEnd = getMonthlyMaxDataClosestToDate(
+    monthlyMax,
+    new Date(end.toISOString())
+  )?.value;
+
+  const closestToStartArray: MonthlyMaxData[] = closestToStart
+    ? [{ date: start.toISOString(), value: closestToStart }]
+    : [];
+  const closestToEndArray: MonthlyMaxData[] = closestToEnd
+    ? [{ date: end.toISOString(), value: closestToEnd }]
+    : [];
+
+  const filteredData = monthlyMax.filter((item) =>
+    inRange(moment(item.date).valueOf(), start.valueOf(), end.valueOf() + 1)
+  );
+
+  return filteredData.length > 0
+    ? filteredData
+    : [...closestToStartArray, ...closestToEndArray];
+};
 
 export function getSofarDataClosestToDate(
   spotterData: SofarValue[],

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -17,6 +17,7 @@ import {
   MuiPickersUtilsProvider,
 } from "@material-ui/pickers";
 import DateFnsUtils from "@date-io/date-fns";
+import moment from "moment";
 
 const DatePicker = ({
   value,
@@ -24,6 +25,7 @@ const DatePicker = ({
   dateNameTextVariant,
   pickerSize,
   autoOk,
+  timeZone,
   onChange,
   classes,
 }: DatePickerProps) => {
@@ -42,7 +44,9 @@ const DatePicker = ({
               disableToolbar
               format="MM/dd/yyyy"
               name="datePicker"
-              disableFuture
+              maxDate={moment()
+                .tz(timeZone || "UTC")
+                .format("YYYY/MM/DD")}
               autoOk={autoOk}
               showTodayButton
               value={value || null}
@@ -91,6 +95,7 @@ interface DatePickerIncomingProps {
   dateNameTextVariant?: TypographyProps["variant"];
   pickerSize?: KeyboardDatePickerProps["size"];
   autoOk?: boolean;
+  timeZone: string | null | undefined;
   onChange: (date: MaterialUiPickersDate, value?: string | null) => void;
 }
 

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -74,7 +74,7 @@ const styles = (theme: Theme) =>
       paddingBottom: 2,
     },
     textField: {
-      width: 110,
+      width: 115,
       color: "black",
       "&:hover .MuiOutlinedInput-root .MuiOutlinedInput-notchedOutline": {
         borderColor: "rgba(0, 0, 0, 0.23)",

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -47,6 +47,7 @@ const DatePicker = ({
               maxDate={moment()
                 .tz(timeZone || "UTC")
                 .format("YYYY/MM/DD")}
+              minDate={moment(0).format("YYYY/MM/DD")}
               autoOk={autoOk}
               showTodayButton
               value={value || null}

--- a/packages/website/src/helpers/dates.ts
+++ b/packages/website/src/helpers/dates.ts
@@ -293,6 +293,10 @@ export const generateMonthlyMaxTimestamps = (
   endDate?: string,
   timeZone?: string | null
 ): MonthlyMaxData[] => {
+  if (monthlyMax.length < 12) {
+    return [];
+  }
+
   const firstDate = moment(startDate)
     .tz(timeZone || "UTC")
     .subtract(1, "months")

--- a/packages/website/src/helpers/dates.ts
+++ b/packages/website/src/helpers/dates.ts
@@ -285,44 +285,35 @@ export const convertSurveyDataToLocalTime = (
       : survey.diveDate,
   }));
 
-// Return a copy of monthly max data for each year
+// Generate data for all months between start date's previous month and
+// end date's next month
 export const generateMonthlyMaxTimestamps = (
   monthlyMax: MonthlyMax[],
   startDate?: string,
   endDate?: string,
   timeZone?: string | null
 ): MonthlyMaxData[] => {
-  const startYear = startDate
-    ? new Date(startDate).getFullYear()
-    : new Date().getFullYear();
-  const endYear = endDate
-    ? new Date(endDate).getFullYear()
-    : new Date().getFullYear();
+  const firstDate = moment(startDate)
+    .tz(timeZone || "UTC")
+    .subtract(1, "months")
+    .set("date", 15)
+    .startOf("day");
+  const lastDate = moment(endDate)
+    .tz(timeZone || "UTC")
+    .add(1, "months")
+    .set("date", 15)
+    .startOf("day");
 
-  const years = createRange(startYear - 1, endYear + 1);
-
-  const yearlyData = years.map((year) => {
-    return monthlyMax.map(({ month, temperature }) => ({
-      value: temperature,
-      date: convertToLocalTime(
-        moment()
-          .set({
-            year,
-            month: month - 1,
-            date: 15,
-            hour: 0,
-            minute: 0,
-            second: 0,
-            millisecond: 0,
-          })
-          .toISOString(),
-        timeZone
-      ),
-    }));
-  });
-
-  return yearlyData.reduce<MonthlyMaxData[]>(
-    (curr, item) => [...curr, ...item],
-    []
+  const monthsRange = createRange(
+    moment(lastDate).diff(moment(firstDate), "months") + 1
   );
+
+  return monthsRange.map((months) => {
+    const date = moment(firstDate).add(months, "months");
+
+    return {
+      date: date.toISOString(),
+      value: monthlyMax[date.month()].temperature,
+    };
+  });
 };


### PR DESCRIPTION
The purpose of this PR is to fix the `HISTORIC` column hiding for small ranges issue.
The previous approach was looking for `maxMonthly` values in the range of `[pickerStartDate, pickerEndDate]`, and if it didn't find anything it returned nothing. Now, if no value exists to this interval, we return an array of the form:
```
[{pickerStartDate, valueClosestToStartDate}, ...filteredData, {pickerEndDate, valueClosestToEndDate}]
```

![Screenshot_20210401_182145](https://user-images.githubusercontent.com/64922890/113316551-22a98d00-9317-11eb-82f5-f0d63a896043.png)

