### PR TITLE
Fix - re-filter spotters to "deployed" only

### DIFF
--- a/packages/website/src/helpers/reefUtils.ts
+++ b/packages/website/src/helpers/reefUtils.ts
@@ -58,3 +58,7 @@ export const findInitialReefPosition = (
 
   return null;
 };
+
+// Util function that checks if a reef has a deployed spotter
+export const hasDeployedSpotter = (reef?: Reef | null) =>
+  Boolean(reef?.spotterId && reef?.status === "deployed");

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -26,6 +26,7 @@ import { spotterSelected } from "../../../../assets/spotterSelected";
 import { spotterAnimation } from "../../../../assets/spotterAnimation";
 import { hobo } from "../../../../assets/hobo";
 import { hoboSelected } from "../../../../assets/hoboSelected";
+import { hasDeployedSpotter } from "../../../../helpers/reefUtils";
 
 const buoyIcon = (iconUrl: string) =>
   new L.Icon({
@@ -142,7 +143,7 @@ export const ReefMarkers = () => {
                 }}
                 key={`${reef.id}-${offset}`}
                 icon={markerIcon(
-                  Boolean(reef.spotterId && reef.status === "deployed"),
+                  hasDeployedSpotter(reef),
                   reef.hasHobo,
                   reefOnMap?.id === reef.id,
                   alertColorFinder(weeklyAlertLevel),

--- a/packages/website/src/store/Reefs/reefsListSlice.ts
+++ b/packages/website/src/store/Reefs/reefsListSlice.ts
@@ -6,6 +6,7 @@ import { ReefsListState, ReefsRequestData } from "./types";
 
 import type { RootState, CreateAsyncThunkTypes } from "../configure";
 import reefServices from "../../services/reefServices";
+import { hasDeployedSpotter } from "../../helpers/reefUtils";
 
 const reefsListInitialState: ReefsListState = {
   loading: false,
@@ -26,9 +27,7 @@ export const reefsRequest = createAsyncThunk<
     return {
       list: sortedData,
       reefsToDisplay: withSpotterOnly
-        ? sortedData.filter(
-            (item) => item.spotterId && item.status === "deployed"
-          )
+        ? sortedData.filter((item) => hasDeployedSpotter(item))
         : sortedData,
     };
   } catch (err) {
@@ -44,9 +43,7 @@ const reefsListSlice = createSlice({
     filterReefsWithSpotter: (state, action: PayloadAction<boolean>) => ({
       ...state,
       reefsToDisplay: action.payload
-        ? state.list?.filter(
-            (item) => item.spotterId && item.status === "deployed"
-          )
+        ? state.list?.filter((item) => hasDeployedSpotter(item))
         : state.list,
     }),
   },

--- a/packages/website/src/store/Reefs/reefsListSlice.ts
+++ b/packages/website/src/store/Reefs/reefsListSlice.ts
@@ -26,7 +26,9 @@ export const reefsRequest = createAsyncThunk<
     return {
       list: sortedData,
       reefsToDisplay: withSpotterOnly
-        ? sortedData.filter((item) => item.spotterId)
+        ? sortedData.filter(
+            (item) => item.spotterId && item.status === "deployed"
+          )
         : sortedData,
     };
   } catch (err) {


### PR DESCRIPTION
Noticed a bug on the markers that can be reproduced as follows:
 - Turn on the `deployed buoys only` switch
 - Select a site with spotter on the map
 - Visit its details page
 - Click the back button in order to return to the homepage

You can see several reefs on the map without deployed spotters (i.e. having the old marker)