### PR TITLE
Remove non-null assertion operator

### DIFF
--- a/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.tsx
@@ -46,7 +46,7 @@ const SurveyCard = ({
         </Grid>
         <Grid className={classes.infoWrapper} container item xs={12} md={7}>
           <Grid className={classes.info} container item xs={12}>
-            {survey.userId!.fullName && (
+            {survey.userId?.fullName && (
               <Grid container alignItems="center" item xs={12}>
                 <Typography className={classes.cardFields} variant="h6">
                   User:
@@ -55,7 +55,7 @@ const SurveyCard = ({
                   className={`${classes.cardValues} ${classes.valuesWithMargin}`}
                   variant="h6"
                 >
-                  {survey.userId!.fullName}
+                  {survey.userId.fullName}
                 </Typography>
               </Grid>
             )}


### PR DESCRIPTION
Noticed that we use the `!.` non-null-assertion operator in one place, which is error prone and causes the app to break in the very rare case that we get a survey with a user equal to `null`.