### PR TITLE
FIX - Update 'sofar_api' split in the frontend

### DIFF
--- a/packages/website/src/mocks/mockHoboDataRange.ts
+++ b/packages/website/src/mocks/mockHoboDataRange.ts
@@ -32,7 +32,20 @@ export const mockHoboDataRange: TimeSeriesDataRange = {
     windSpeed: [],
     windDirection: [],
   },
-  sofarApi: {
+  sofarNoaa: {
+    bottomTemperature: [],
+    alert: [],
+    dhw: [],
+    satelliteTemperature: [],
+    topTemperature: [],
+    sstAnomaly: [],
+    significantWaveHeight: [],
+    wavePeakPeriod: [],
+    waveMeanDirection: [],
+    windSpeed: [],
+    windDirection: [],
+  },
+  sofarGfs: {
     bottomTemperature: [],
     alert: [],
     dhw: [],

--- a/packages/website/src/store/Reefs/helpers.ts
+++ b/packages/website/src/store/Reefs/helpers.ts
@@ -74,7 +74,8 @@ export const mapTimeSeriesData = (
 ): TimeSeriesData => ({
   hobo: mapMetrics(timeSeriesData.hobo),
   spotter: mapMetrics(timeSeriesData.spotter),
-  sofarApi: mapMetrics(timeSeriesData.sofar_api),
+  sofarNoaa: mapMetrics(timeSeriesData.noaa),
+  sofarGfs: mapMetrics(timeSeriesData.gfs),
 });
 
 export const mapTimeSeriesDataRanges = (
@@ -82,5 +83,6 @@ export const mapTimeSeriesDataRanges = (
 ): TimeSeriesDataRange => ({
   hobo: mapMetrics(ranges.hobo),
   spotter: mapMetrics(ranges.spotter),
-  sofarApi: mapMetrics(ranges.sofar_api),
+  sofarNoaa: mapMetrics(ranges.noaa),
+  sofarGfs: mapMetrics(ranges.gfs),
 });

--- a/packages/website/src/store/Reefs/types.ts
+++ b/packages/website/src/store/Reefs/types.ts
@@ -141,9 +141,9 @@ export type Metrics =
   | "windSpeed"
   | "windDirection";
 
-export type SourcesKeys = "spotter" | "hobo" | "sofar_api";
+export type SourcesKeys = "spotter" | "hobo" | "noaa" | "gfs";
 
-export type Sources = "spotter" | "hobo" | "sofarApi";
+export type Sources = "spotter" | "hobo" | "sofarNoaa" | "sofarGfs";
 
 export type TimeSeries = Record<Metrics, SofarValue[]>;
 


### PR DESCRIPTION
In the #505 PR that was just merged the sensor data schema has changed a bit, which broke the frontend.

This is a first pass at fixing it but I think we should have a better structure for the sensor data in the frontend. Most of them will never have all these fields but simply a subset.