### PR TITLE
Add fallback to latest_data table for live data

### DIFF
--- a/packages/api/src/reefs/reefs.service.ts
+++ b/packages/api/src/reefs/reefs.service.ts
@@ -319,29 +319,26 @@ export class ReefsService {
       metric: Metric.SATELLITE_TEMPERATURE,
     });
 
-    const sstAnomaly = await this.latestDataRepository.findOne({
-      reef,
-      source: SourceType.NOAA,
-      metric: Metric.SST_ANOMALY,
-    });
-
-    const satelliteTemperatureEntry = sst
-      ? {
-          satelliteTemperature: {
-            value: sst.value,
-            timestamp: sst.timestamp.toISOString(),
-          },
-        }
-      : {};
+    const satelliteTemperatureEntry =
+      (liveData.satelliteTemperature && {
+        satelliteTemperature: liveData.satelliteTemperature,
+      }) ||
+      (sst
+        ? {
+            satelliteTemperature: {
+              value: sst.value,
+              timestamp: sst.timestamp.toISOString(),
+            },
+          }
+        : {});
 
     return {
-      ...satelliteTemperatureEntry,
       ...liveData,
-      sstAnomaly:
-        getSstAnomaly(
-          reef.historicalMonthlyMean,
-          liveData.satelliteTemperature,
-        ) || sstAnomaly?.value,
+      sstAnomaly: getSstAnomaly(
+        reef.historicalMonthlyMean,
+        satelliteTemperatureEntry.satelliteTemperature,
+      ),
+      ...satelliteTemperatureEntry,
       weeklyAlertLevel: getMaxAlert(liveData.dailyAlertLevel, weeklyAlertLevel),
     };
   }

--- a/packages/api/src/time-series/latest-data.entity.ts
+++ b/packages/api/src/time-series/latest-data.entity.ts
@@ -28,6 +28,8 @@ import { TimeSeries } from './time-series.entity';
     return connection
       .createQueryBuilder()
       .from(() => subQuery, 'time_series')
+      .addSelect('reef_id')
+      .addSelect('poi_id')
       .innerJoin('sources', 'source', 'source.id = time_series.source_id');
   },
   materialized: true,


### PR DESCRIPTION
Fallback to latest_data table for `SST` and `SST_ANOMALY`, if live data from Sofar does not contain the `satelliteTemperature` metric, in order to avoid null values.