### PR TITLE
Extend backfill days for hourly SST updates

### DIFF
--- a/packages/api/src/utils/liveData.ts
+++ b/packages/api/src/utils/liveData.ts
@@ -43,7 +43,7 @@ export const getLiveData = async (
       latitude,
       longitude,
       now,
-      72,
+      96,
     ),
     sofarForecast(
       SofarModels.NOAAOperationalWaveModel,

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -100,7 +100,7 @@ export async function getDailyData(
       latitude,
       longitude,
       endOfDate,
-      48,
+      96,
     ),
     getSofarHindcastData(
       SofarModels.NOAAOperationalWaveModel,

--- a/packages/api/src/workers/sstTimeSeries.ts
+++ b/packages/api/src/workers/sstTimeSeries.ts
@@ -5,7 +5,7 @@ import { TimeSeries } from '../time-series/time-series.entity';
 import { updateSST } from '../utils/sst-time-series';
 
 export function runSSTTimeSeriesUpdate(connection: Connection) {
-  return updateSST([], 3, connection, {
+  return updateSST([], 4, connection, {
     reefRepository: connection.getRepository(Reef),
     timeSeriesRepository: connection.getRepository(TimeSeries),
     sourceRepository: connection.getRepository(Sources),

--- a/packages/api/src/workers/sstTimeSeries.ts
+++ b/packages/api/src/workers/sstTimeSeries.ts
@@ -5,7 +5,7 @@ import { TimeSeries } from '../time-series/time-series.entity';
 import { updateSST } from '../utils/sst-time-series';
 
 export function runSSTTimeSeriesUpdate(connection: Connection) {
-  return updateSST([], 1, connection, {
+  return updateSST([], 3, connection, {
     reefRepository: connection.getRepository(Reef),
     timeSeriesRepository: connection.getRepository(TimeSeries),
     sourceRepository: connection.getRepository(Sources),


### PR DESCRIPTION
Because NOAA only publishes data one or two days late, the hourly update needs to look back more than 24 hours to find data to update with more certainty.