### PR TITLE
Generate google analytics

### DIFF
--- a/packages/website/src/common/MenuDrawer/index.tsx
+++ b/packages/website/src/common/MenuDrawer/index.tsx
@@ -14,7 +14,11 @@ import {
 } from "@material-ui/core";
 import { Clear, GitHub } from "@material-ui/icons";
 import ovioLogo from "../../assets/img/ovio_logo.png";
-import { trackButtonClick } from "../../utils/google-analytics";
+import {
+  GaAction,
+  GaCategory,
+  trackButtonClick,
+} from "../../utils/google-analytics";
 
 const darkBlue = "#095877";
 
@@ -78,7 +82,13 @@ const MenuDrawer = ({ classes, open, onClose }: MenuDrawerProps) => {
           key={text}
           component={Link}
           to={to}
-          onClick={() => trackButtonClick("SIDE_MENU_BUTTON_CLICK", text)}
+          onClick={() =>
+            trackButtonClick(
+              GaCategory.BUTTON_CLICK,
+              GaAction.SIDE_MENU_BUTTON_CLICK,
+              text
+            )
+          }
         >
           <Typography variant="h6">{text}</Typography>
         </Button>

--- a/packages/website/src/common/MenuDrawer/index.tsx
+++ b/packages/website/src/common/MenuDrawer/index.tsx
@@ -14,6 +14,7 @@ import {
 } from "@material-ui/core";
 import { Clear, GitHub } from "@material-ui/icons";
 import ovioLogo from "../../assets/img/ovio_logo.png";
+import { trackButtonClick } from "../../utils/google-analytics";
 
 const darkBlue = "#095877";
 
@@ -77,6 +78,7 @@ const MenuDrawer = ({ classes, open, onClose }: MenuDrawerProps) => {
           key={text}
           component={Link}
           to={to}
+          onClick={() => trackButtonClick("SIDE_MENU_BUTTON_CLICK", text)}
         >
           <Typography variant="h6">{text}</Typography>
         </Button>

--- a/packages/website/src/common/MenuDrawer/index.tsx
+++ b/packages/website/src/common/MenuDrawer/index.tsx
@@ -26,34 +26,42 @@ const menuRoutes = [
   {
     text: "HOME",
     to: "/",
+    gaActionLabel: "Home",
   },
   {
     text: "MAP",
     to: "/map",
+    gaActionLabel: "Map",
   },
   {
     text: "BUOY",
     to: "/buoy",
+    gaActionLabel: "Buoy",
   },
   {
     text: "DRONE",
     to: "/drones",
+    gaActionLabel: "Drone",
   },
   {
     text: "ABOUT",
     to: "/about",
+    gaActionLabel: "About",
   },
   {
     text: "FAQ",
     to: "/faq",
+    gaActionLabel: "Faq",
   },
   {
     text: "TRACK A HEATWAVE",
     to: "/tracker",
+    gaActionLabel: "Track a heatwave",
   },
   {
     text: "REGISTER A SITE",
     to: "/register",
+    gaActionLabel: "Register a site",
   },
 ];
 
@@ -76,7 +84,7 @@ const MenuDrawer = ({ classes, open, onClose }: MenuDrawerProps) => {
       >
         <Clear />
       </IconButton>
-      {menuRoutes.map(({ text, to }) => (
+      {menuRoutes.map(({ text, to, gaActionLabel }) => (
         <Button
           className={classes.menuDrawerButton}
           key={text}
@@ -86,7 +94,7 @@ const MenuDrawer = ({ classes, open, onClose }: MenuDrawerProps) => {
             trackButtonClick(
               GaCategory.BUTTON_CLICK,
               GaAction.SIDE_MENU_BUTTON_CLICK,
-              text
+              gaActionLabel
             )
           }
         >

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -24,6 +24,7 @@ import { formatNumber } from "../../../../helpers/numberUtils";
 import { dhwColorFinder } from "../../../../helpers/degreeHeatingWeeks";
 import { reefOnMapSelector } from "../../../../store/Homepage/homepageSlice";
 import { maxLengths } from "../../../../constants/names";
+import { trackButtonClick } from "../../../../utils/google-analytics";
 
 const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
   const { map } = useLeaflet();
@@ -33,6 +34,10 @@ const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
   const isNameLong = name?.length && name.length > maxLengths.REEF_NAME_POPUP;
 
   const { dhw, satelliteTemperature } = reef.collectionData || {};
+
+  const onExploreButtonClick = () => {
+    trackButtonClick("MAP_PAGE_BUTTON_CLICK", "EXPLORE", "FROM_POPUP");
+  };
 
   useEffect(() => {
     if (
@@ -130,7 +135,12 @@ const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
                 style={{ color: "inherit", textDecoration: "none" }}
                 to={`/reefs/${reef.id}`}
               >
-                <Button size="small" variant="outlined" color="primary">
+                <Button
+                  onClick={onExploreButtonClick}
+                  size="small"
+                  variant="outlined"
+                  color="primary"
+                >
                   EXPLORE
                 </Button>
               </Link>

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -43,7 +43,7 @@ const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
     trackButtonClick(
       GaCategory.BUTTON_CLICK,
       GaAction.MAP_PAGE_BUTTON_CLICK,
-      "EXPLORE"
+      "Explore"
     );
   };
 

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -24,7 +24,11 @@ import { formatNumber } from "../../../../helpers/numberUtils";
 import { dhwColorFinder } from "../../../../helpers/degreeHeatingWeeks";
 import { reefOnMapSelector } from "../../../../store/Homepage/homepageSlice";
 import { maxLengths } from "../../../../constants/names";
-import { trackButtonClick } from "../../../../utils/google-analytics";
+import {
+  GaCategory,
+  GaAction,
+  trackButtonClick,
+} from "../../../../utils/google-analytics";
 
 const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
   const { map } = useLeaflet();
@@ -36,7 +40,11 @@ const Popup = ({ reef, classes, autoOpen }: PopupProps) => {
   const { dhw, satelliteTemperature } = reef.collectionData || {};
 
   const onExploreButtonClick = () => {
-    trackButtonClick("MAP_PAGE_BUTTON_CLICK", "EXPLORE", "FROM_POPUP");
+    trackButtonClick(
+      GaCategory.BUTTON_CLICK,
+      GaAction.MAP_PAGE_BUTTON_CLICK,
+      "EXPLORE"
+    );
   };
 
   useEffect(() => {

--- a/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
@@ -32,7 +32,11 @@ import Chart from "../../../../common/Chart";
 import { surveyListSelector } from "../../../../store/Survey/surveyListSlice";
 import { convertDailyDataToLocalTime } from "../../../../helpers/dates";
 import Chip from "../../../../common/Chip";
-import { trackButtonClick } from "../../../../utils/google-analytics";
+import {
+  GaAction,
+  GaCategory,
+  trackButtonClick,
+} from "../../../../utils/google-analytics";
 
 const useStyles = makeStyles((theme) => ({
   cardWrapper: {
@@ -163,7 +167,11 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
   );
 
   const onExploreButtonClick = () => {
-    trackButtonClick("MAP_PAGE_BUTTON_CLICK", "EXPLORE", "FROM_CARD");
+    trackButtonClick(
+      GaCategory.BUTTON_CLICK,
+      GaAction.MAP_PAGE_BUTTON_CLICK,
+      "EXPLORE"
+    );
   };
 
   return (

--- a/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
@@ -170,7 +170,7 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
     trackButtonClick(
       GaCategory.BUTTON_CLICK,
       GaAction.MAP_PAGE_BUTTON_CLICK,
-      "EXPLORE"
+      "Explore"
     );
   };
 

--- a/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
@@ -32,6 +32,7 @@ import Chart from "../../../../common/Chart";
 import { surveyListSelector } from "../../../../store/Survey/surveyListSlice";
 import { convertDailyDataToLocalTime } from "../../../../helpers/dates";
 import Chip from "../../../../common/Chip";
+import { trackButtonClick } from "../../../../utils/google-analytics";
 
 const useStyles = makeStyles((theme) => ({
   cardWrapper: {
@@ -161,6 +162,10 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
     />
   );
 
+  const onExploreButtonClick = () => {
+    trackButtonClick("MAP_PAGE_BUTTON_CLICK", "EXPLORE", "FROM_CARD");
+  };
+
   return (
     <Grid
       className={
@@ -221,7 +226,12 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
                     style={{ color: "inherit", textDecoration: "none" }}
                     to={`/reefs/${reef.id}`}
                   >
-                    <Button size="small" variant="contained" color="primary">
+                    <Button
+                      onClick={onExploreButtonClick}
+                      size="small"
+                      variant="contained"
+                      color="primary"
+                    >
                       EXPLORE
                     </Button>
                   </Link>

--- a/packages/website/src/routes/Landing/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/Landing/__snapshots__/index.test.tsx.snap
@@ -857,7 +857,7 @@ exports[`Landing Page should render with given state from Redux store 1`] = `
                 class="MuiGrid-root MuiGrid-item"
               >
                 <mock-button
-                  classname="LandingPage-buttons-4 LandingPage-registerButton-5"
+                  classname="LandingPage-buttons-4 LandingPage-whiteColorButton-5"
                   color="primary"
                   component="[object Object]"
                   to="/register"
@@ -874,7 +874,7 @@ exports[`Landing Page should render with given state from Redux store 1`] = `
                 class="MuiGrid-root MuiGrid-item"
               >
                 <mock-button
-                  classname="LandingPage-buttons-4 LandingPage-registerButton-5"
+                  classname="LandingPage-buttons-4 LandingPage-whiteColorButton-5"
                   color="primary"
                   component="[object Object]"
                   to="/tracker"

--- a/packages/website/src/routes/Landing/index.tsx
+++ b/packages/website/src/routes/Landing/index.tsx
@@ -23,7 +23,11 @@ import Footer from "../../common/Footer";
 import Card from "./Card";
 import landingPageImage from "../../assets/img/landing-page/header.jpg";
 import { cardTitles } from "./titles";
-import { trackButtonClick } from "../../utils/google-analytics";
+import {
+  GaAction,
+  GaCategory,
+  trackButtonClick,
+} from "../../utils/google-analytics";
 
 interface LandingPageButton {
   label: string;
@@ -145,7 +149,8 @@ const LandingPage = ({ classes }: LandingPageProps) => {
                           color="primary"
                           onClick={() =>
                             trackButtonClick(
-                              "LANDING_PAGE_BUTTON_CLICK",
+                              GaCategory.BUTTON_CLICK,
+                              GaAction.LANDING_PAGE_BUTTON_CLICK,
                               gaActionLabel
                             )
                           }
@@ -206,18 +211,18 @@ const styles = (theme: Theme) =>
       width: 208,
       textTransform: "none",
       "&:hover": {
-        color: "#ffffff",
+        color: "white",
       },
       [theme.breakpoints.down("xs")]: {
         height: 40,
       },
     },
     whiteColorButton: {
-      color: "#ffffff",
-      border: "2px solid #ffffff",
+      color: "white",
+      border: "2px solid white",
       "&:hover": {
-        color: "#ffffff",
-        border: "2px solid #ffffff",
+        color: "white",
+        border: "2px solid white",
       },
     },
   });

--- a/packages/website/src/routes/Landing/index.tsx
+++ b/packages/website/src/routes/Landing/index.tsx
@@ -33,7 +33,6 @@ interface LandingPageButton {
   label: string;
   to: string;
   variant: ButtonProps["variant"];
-  gaActionLabel: string;
   hasWhiteColor?: boolean;
 }
 
@@ -42,20 +41,17 @@ const landingPageButtons: LandingPageButton[] = [
     label: "View The Map",
     to: "/map",
     variant: "contained",
-    gaActionLabel: "VIEW_MAP",
   },
   {
     label: "Register Your Site",
     to: "/register",
     variant: "outlined",
-    gaActionLabel: "REGISTER_SITE",
     hasWhiteColor: true,
   },
   {
     label: "Track a Heatwave",
     to: "/tracker",
     variant: "outlined",
-    gaActionLabel: "TRACK_HEATWAVE",
     hasWhiteColor: true,
   },
 ];
@@ -137,7 +133,7 @@ const LandingPage = ({ classes }: LandingPageProps) => {
               <Box mt="2rem">
                 <Grid container spacing={2}>
                   {landingPageButtons.map(
-                    ({ label, to, hasWhiteColor, variant, gaActionLabel }) => (
+                    ({ label, to, hasWhiteColor, variant }) => (
                       <Grid key={label} item xs={isTablet ? 12 : undefined}>
                         <Button
                           component={Link}
@@ -151,7 +147,7 @@ const LandingPage = ({ classes }: LandingPageProps) => {
                             trackButtonClick(
                               GaCategory.BUTTON_CLICK,
                               GaAction.LANDING_PAGE_BUTTON_CLICK,
-                              gaActionLabel
+                              label
                             )
                           }
                         >

--- a/packages/website/src/routes/Landing/index.tsx
+++ b/packages/website/src/routes/Landing/index.tsx
@@ -12,15 +12,49 @@ import {
   Button,
   Theme,
   Fab,
+  ButtonProps,
 } from "@material-ui/core";
 import ArrowDownwardIcon from "@material-ui/icons/ArrowDownward";
 import { Link } from "react-router-dom";
 
+import classNames from "classnames";
 import NavBar from "../../common/NavBar";
 import Footer from "../../common/Footer";
 import Card from "./Card";
 import landingPageImage from "../../assets/img/landing-page/header.jpg";
 import { cardTitles } from "./titles";
+import { trackButtonClick } from "../../utils/google-analytics";
+
+interface LandingPageButton {
+  label: string;
+  to: string;
+  variant: ButtonProps["variant"];
+  gaActionLabel: string;
+  hasWhiteColor?: boolean;
+}
+
+const landingPageButtons: LandingPageButton[] = [
+  {
+    label: "View The Map",
+    to: "/map",
+    variant: "contained",
+    gaActionLabel: "VIEW_MAP",
+  },
+  {
+    label: "Register Your Site",
+    to: "/register",
+    variant: "outlined",
+    gaActionLabel: "REGISTER_SITE",
+    hasWhiteColor: true,
+  },
+  {
+    label: "Track a Heatwave",
+    to: "/tracker",
+    variant: "outlined",
+    gaActionLabel: "TRACK_HEATWAVE",
+    hasWhiteColor: true,
+  },
+];
 
 const LandingPage = ({ classes }: LandingPageProps) => {
   const [scrollPosition, setScrollPosition] = useState(0);
@@ -98,39 +132,29 @@ const LandingPage = ({ classes }: LandingPageProps) => {
             <Grid item xs={12}>
               <Box mt="2rem">
                 <Grid container spacing={2}>
-                  <Grid item xs={isTablet ? 12 : undefined}>
-                    <Button
-                      component={Link}
-                      to="/map"
-                      className={classes.buttons}
-                      variant="contained"
-                      color="primary"
-                    >
-                      <Typography variant="h5">View The Map</Typography>
-                    </Button>
-                  </Grid>
-                  <Grid item xs={isTablet ? 12 : undefined}>
-                    <Button
-                      component={Link}
-                      to="/register"
-                      className={`${classes.buttons} ${classes.registerButton}`}
-                      variant="outlined"
-                      color="primary"
-                    >
-                      <Typography variant="h5">Register Your Site</Typography>
-                    </Button>
-                  </Grid>
-                  <Grid item xs={isTablet ? 12 : undefined}>
-                    <Button
-                      component={Link}
-                      to="/tracker"
-                      className={`${classes.buttons} ${classes.registerButton}`}
-                      variant="outlined"
-                      color="primary"
-                    >
-                      <Typography variant="h5">Track a Heatwave</Typography>
-                    </Button>
-                  </Grid>
+                  {landingPageButtons.map(
+                    ({ label, to, hasWhiteColor, variant, gaActionLabel }) => (
+                      <Grid key={label} item xs={isTablet ? 12 : undefined}>
+                        <Button
+                          component={Link}
+                          to={to}
+                          className={classNames(classes.buttons, {
+                            [classes.whiteColorButton]: hasWhiteColor,
+                          })}
+                          variant={variant}
+                          color="primary"
+                          onClick={() =>
+                            trackButtonClick(
+                              "LANDING_PAGE_BUTTON_CLICK",
+                              gaActionLabel
+                            )
+                          }
+                        >
+                          <Typography variant="h5">{label}</Typography>
+                        </Button>
+                      </Grid>
+                    )
+                  )}
                 </Grid>
               </Box>
             </Grid>
@@ -188,7 +212,7 @@ const styles = (theme: Theme) =>
         height: 40,
       },
     },
-    registerButton: {
+    whiteColorButton: {
       color: "#ffffff",
       border: "2px solid #ffffff",
       "&:hover": {

--- a/packages/website/src/utils/google-analytics.ts
+++ b/packages/website/src/utils/google-analytics.ts
@@ -13,3 +13,15 @@ export const initGA = () => {
   ReactGA.initialize(GA_TRACKING_ID);
   ReactGA.pageview(window.location.pathname + window.location.search);
 };
+
+export const trackButtonClick = (
+  category: string,
+  action: string,
+  label?: string
+) => {
+  ReactGA.event({
+    category,
+    action,
+    label,
+  });
+};

--- a/packages/website/src/utils/google-analytics.ts
+++ b/packages/website/src/utils/google-analytics.ts
@@ -14,9 +14,20 @@ export const initGA = () => {
   ReactGA.pageview(window.location.pathname + window.location.search);
 };
 
+export enum GaCategory {
+  BUTTON_CLICK = "Button Click",
+}
+
+export enum GaAction {
+  // Button clicks
+  LANDING_PAGE_BUTTON_CLICK = "Landing page button click",
+  SIDE_MENU_BUTTON_CLICK = "Side menu button click",
+  MAP_PAGE_BUTTON_CLICK = "Map page button click",
+}
+
 export const trackButtonClick = (
-  category: string,
-  action: string,
+  category: GaCategory,
+  action: GaAction,
   label?: string
 ) => {
   ReactGA.event({


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/479.
We generate analytics for:
 - `/` page button clicks
 - `/map` page `"EXPLORE"` button clicks
 - side menu button clicks

Deployed [here](https://aqualink-app-programize.web.app/map).
Analytics can be viewed [here](https://analytics.google.com/analytics/web/#/report-home/a163899403w281402098p248240479) (access needed).