### PR TITLE
Ignore redirect endpoint on api docs

### DIFF
--- a/packages/api/src/app.controller.ts
+++ b/packages/api/src/app.controller.ts
@@ -1,9 +1,11 @@
 import { Controller, Get, Logger, Redirect } from '@nestjs/common';
+import { ApiExcludeEndpoint } from '@nestjs/swagger';
 
 @Controller('')
 export class AppController {
   private readonly logger = new Logger(AppController.name);
 
+  @ApiExcludeEndpoint()
   @Get()
   @Redirect('/api/docs')
   getDocs() {


### PR DESCRIPTION
Ignore redirect endpoint GET /api on swagger API docs