### PR TITLE
Set mobile design breakpoint at 960px for `/map`

### DIFF
--- a/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/__snapshots__/index.test.tsx.snap
@@ -34,7 +34,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root makeStyles-cardWrapper-1 makeStyles-mobileCardWrapperWithNoImage-3 MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-lg-10"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-12 MuiGrid-grid-lg-10"
           style="margin-bottom: 2rem; max-height: 14rem;"
         >
           <mock-box
@@ -44,7 +44,7 @@ exports[`renders as expected 1`] = `
             pt="1.5rem"
           >
             <mock-hidden
-              xsdown="false"
+              smdown="false"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
@@ -83,14 +83,14 @@ exports[`renders as expected 1`] = `
             </mock-typography>
           </mock-box>
           <mock-hidden
-            xsdown="true"
+            smdown="true"
           >
             <div>
               Mock-Line
             </div>
           </mock-hidden>
           <mock-hidden
-            smup="true"
+            mdup="true"
           >
             Mock-Line
           </mock-hidden>
@@ -207,7 +207,7 @@ exports[`renders loading as expected 1`] = `
         class="MuiGrid-root makeStyles-cardWrapper-12 makeStyles-mobileCardWrapperWithNoImage-14 MuiGrid-container MuiGrid-spacing-xs-1 MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-12 MuiGrid-grid-lg-10"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-12 MuiGrid-grid-lg-10"
           style="margin-bottom: 2rem; max-height: 14rem;"
         >
           <mock-box
@@ -217,7 +217,7 @@ exports[`renders loading as expected 1`] = `
             pt="1.5rem"
           >
             <mock-hidden
-              xsdown="false"
+              smdown="false"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center"
@@ -256,14 +256,14 @@ exports[`renders loading as expected 1`] = `
             </mock-typography>
           </mock-box>
           <mock-hidden
-            xsdown="true"
+            smdown="true"
           >
             <div>
               Mock-Line
             </div>
           </mock-hidden>
           <mock-hidden
-            smup="true"
+            mdup="true"
           >
             Mock-Line
           </mock-hidden>

--- a/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/SelectedReefCard/index.tsx
@@ -41,17 +41,17 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   mobileCardWrapperWithImage: {
-    [theme.breakpoints.down("xs")]: {
+    [theme.breakpoints.down("sm")]: {
       height: "42rem",
     },
   },
   mobileCardWrapperWithNoImage: {
-    [theme.breakpoints.down("xs")]: {
+    [theme.breakpoints.down("sm")]: {
       height: "27rem",
     },
   },
   card: {
-    [theme.breakpoints.down("xs")]: {
+    [theme.breakpoints.down("sm")]: {
       padding: 10,
     },
     padding: 20,
@@ -60,7 +60,7 @@ const useStyles = makeStyles((theme) => ({
     borderRadius: "4px 0 0 4px",
     height: "100%",
 
-    [theme.breakpoints.down("xs")]: {
+    [theme.breakpoints.down("sm")]: {
       height: 300,
     },
   },
@@ -70,7 +70,7 @@ const useStyles = makeStyles((theme) => ({
     alignItems: "center",
     flexDirection: "row",
     width: "100%",
-    [theme.breakpoints.down("xs")]: {
+    [theme.breakpoints.down("sm")]: {
       marginTop: theme.spacing(3),
       marginBottom: theme.spacing(3),
     },
@@ -119,7 +119,7 @@ type SelectedReefContentProps = {
 const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
   const classes = useStyles();
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.down("xs"));
+  const isTablet = useMediaQuery(theme.breakpoints.down("sm"));
   const sortedDailyData = sortByDate(reef.dailyData, "date");
   const dailyDataLen = sortedDailyData.length;
   const { maxBottomTemperature, satelliteTemperature, degreeHeatingDays } =
@@ -173,13 +173,13 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
       spacing={1}
     >
       {imageUrl && (
-        <Grid item xs={12} sm={6} lg={4}>
+        <Grid item xs={12} md={6} lg={4}>
           <Box position="relative" height="100%">
             <Link to={`/reefs/${reef.id}`}>
               <CardMedia className={classes.cardImage} image={imageUrl} />
             </Link>
 
-            <Hidden smUp>
+            <Hidden mdUp>
               <Box
                 bgcolor="rgba(3, 48, 66, 0.75)"
                 height="55%"
@@ -205,10 +205,10 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
                 container
                 alignItems="center"
                 justify={
-                  reef.videoStream && isMobile ? "space-between" : "flex-end"
+                  reef.videoStream && isTablet ? "space-between" : "flex-end"
                 }
               >
-                {reef.videoStream && isMobile && (
+                {reef.videoStream && isTablet && (
                   <Chip
                     live
                     liveText="LIVE VIDEO"
@@ -235,12 +235,12 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
       <Grid
         item
         xs={12}
-        sm={imageUrl ? 6 : 12}
+        md={imageUrl ? 6 : 12}
         lg={imageUrl ? 6 : 10}
         style={{ marginBottom: "2rem", maxHeight: "14rem" }}
       >
         <Box pb="0.5rem" pl="0.5rem" pt="1.5rem" fontWeight={400}>
-          <Hidden xsDown={Boolean(imageUrl)}>
+          <Hidden smDown={Boolean(imageUrl)}>
             <Grid container alignItems="center">
               <Grid item className={classes.cardTitleWrapper}>
                 <Typography
@@ -272,10 +272,10 @@ const SelectedReefContent = ({ reef, imageUrl }: SelectedReefContentProps) => {
             DAILY SURFACE TEMP. (°C)
           </Typography>
         </Box>
-        <Hidden xsDown>
+        <Hidden smDown>
           <div>{ChartComponent}</div>
         </Hidden>
-        <Hidden smUp>{ChartComponent}</Hidden>
+        <Hidden mdUp>{ChartComponent}</Hidden>
       </Grid>
 
       <Grid

--- a/packages/website/src/routes/HomeMap/ReefTable/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/ReefTable/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`ReefTable should render with given state from Redux store 1`] = `
 <div>
   <mock-hidden
-    smup="true"
+    mdup="true"
   >
     <mock-box
       display="flex"
@@ -39,7 +39,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
     </mock-typography>
   </mock-box>
   <mock-hidden
-    smup="true"
+    mdup="true"
   >
     <mock-box
       alignitems="center"
@@ -122,38 +122,6 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               variant="h4"
             >
               Alert
-                
-              <arrowupward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="depth-asc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Depth
-                
-              <arrowdownward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="depth-desc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Depth
                 
               <arrowupward
                 font-size="small"
@@ -256,134 +224,6 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
               />
             </mock-typography>
           </mock-menuitem>
-          <mock-menuitem
-            data-value="historicMax-asc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Historic Max
-                
-              <arrowdownward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="historicMax-desc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Historic Max
-                
-              <arrowupward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="sstAnomaly-asc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Sst Anomaly
-                
-              <arrowdownward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="sstAnomaly-desc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Sst Anomaly
-                
-              <arrowupward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="buoyTop-asc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Buoy Top
-                
-              <arrowdownward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="buoyTop-desc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Buoy Top
-                
-              <arrowupward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="buoyBottom-asc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Buoy Bottom
-                
-              <arrowdownward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
-          <mock-menuitem
-            data-value="buoyBottom-desc"
-            role="option"
-            selected="false"
-          >
-            <mock-typography
-              color="primary"
-              variant="h4"
-            >
-              Buoy Bottom
-                
-              <arrowupward
-                font-size="small"
-              />
-            </mock-typography>
-          </mock-menuitem>
         </mock-menu>
       </div>
     </mock-box>
@@ -400,7 +240,7 @@ exports[`ReefTable should render with given state from Redux store 1`] = `
         stickyheader="true"
       >
         <mock-hidden
-          xsdown="true"
+          smdown="true"
         >
           <mock-tablehead
             style="background-color: rgb(244, 244, 244);"

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -132,7 +132,7 @@ const ReefTableBody = ({
   const [selectedRow, setSelectedRow] = useState<number>();
 
   const theme = useTheme();
-  const isTablet = useMediaQuery(theme.breakpoints.only("sm"));
+  const isTablet = useMediaQuery(theme.breakpoints.down("sm"));
 
   const mapElement = document.getElementById("sites-map");
 

--- a/packages/website/src/routes/HomeMap/ReefTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/body.tsx
@@ -132,7 +132,7 @@ const ReefTableBody = ({
   const [selectedRow, setSelectedRow] = useState<number>();
 
   const theme = useTheme();
-  const isMobile = useMediaQuery(theme.breakpoints.only("xs"));
+  const isTablet = useMediaQuery(theme.breakpoints.only("sm"));
 
   const mapElement = document.getElementById("sites-map");
 
@@ -154,13 +154,13 @@ const ReefTableBody = ({
   useEffect(() => {
     const child = document.getElementById(`homepage-table-row-${selectedRow}`);
     // only scroll if not on mobile (info at the top is more useful than the reef row)
-    if (child && !isMobile && scrollTableOnSelection) {
+    if (child && !isTablet && scrollTableOnSelection) {
       setTimeout(
         () => child.scrollIntoView({ block: "center", behavior: "smooth" }),
         SCROLLT_TIMEOUT
       );
     }
-  }, [isMobile, scrollTableOnSelection, selectedRow]);
+  }, [isTablet, scrollTableOnSelection, selectedRow]);
 
   return (
     <TableBody>

--- a/packages/website/src/routes/HomeMap/ReefTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/ReefTable/index.tsx
@@ -38,28 +38,32 @@ import { Collection } from "../../Dashboard/collection";
 
 const SMALL_HEIGHT = 720;
 
-const MOBILE_SELECT_MENU_ITEMS = Object.values(OrderKeys).reduce<ReactNode[]>(
-  (elements, val) => [
-    ...elements,
-    ...times(2, (i) => {
-      const itemOrder: Order = i % 2 === 0 ? "asc" : "desc";
-      return (
-        <MenuItem value={`${val}-${itemOrder}`} key={val + i}>
-          <Typography color="primary" variant="h4">
-            {getOrderKeysFriendlyString(val)}
-            {"  "}
-            {itemOrder === "asc" ? (
-              <ArrowDownward fontSize="small" />
-            ) : (
-              <ArrowUpward fontSize="small" />
-            )}
-          </Typography>
-        </MenuItem>
-      );
-    }),
-  ],
-  []
-);
+const DEFAULT_ITEMS = ["alert", "dhw", "locationName", "sst"];
+
+const MOBILE_SELECT_MENU_ITEMS = Object.values(OrderKeys)
+  .filter((key) => DEFAULT_ITEMS.includes(key))
+  .reduce<ReactNode[]>(
+    (elements, val) => [
+      ...elements,
+      ...times(2, (i) => {
+        const itemOrder: Order = i % 2 === 0 ? "asc" : "desc";
+        return (
+          <MenuItem value={`${val}-${itemOrder}`} key={val + i}>
+            <Typography color="primary" variant="h4">
+              {getOrderKeysFriendlyString(val)}
+              {"  "}
+              {itemOrder === "asc" ? (
+                <ArrowDownward fontSize="small" />
+              ) : (
+                <ArrowUpward fontSize="small" />
+              )}
+            </Typography>
+          </MenuItem>
+        );
+      }),
+    ],
+    []
+  );
 
 const ReefTable = ({
   isDrawerOpen,
@@ -111,7 +115,7 @@ const ReefTable = ({
     <>
       {/* Holds drawer handle and reef name text on mobile */}
       {showCard && (
-        <Hidden smUp>
+        <Hidden mdUp>
           <Box
             width="100vw"
             display="flex"
@@ -152,7 +156,7 @@ const ReefTable = ({
       )}
       {/* Holds sort selector on mobile. Sorting on desktop uses table headers. */}
       {!isExtended && (
-        <Hidden smUp>
+        <Hidden mdUp>
           <Box
             paddingX={2}
             paddingY={3}
@@ -186,7 +190,7 @@ const ReefTable = ({
             stickyHeader
             className={isExtended ? classes.extendedTable : classes.table}
           >
-            <Hidden xsDown={!isExtended}>
+            <Hidden smDown={!isExtended}>
               <EnhancedTableHead
                 order={order}
                 orderBy={orderBy}

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`Homepage should render with given state from Redux store 1`] = `
       class="MuiGrid-root MuiGrid-container"
     >
       <div
-        class="MuiGrid-root Homepage-map-2 MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6"
+        class="MuiGrid-root Homepage-map-2 MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6"
       >
         <mock-map
           initialcenter="LatLng(0, 0)"
@@ -25,16 +25,16 @@ exports[`Homepage should render with given state from Redux store 1`] = `
         />
       </div>
       <mock-hidden
-        xsdown="true"
+        smdown="true"
       >
         <div
-          class="MuiGrid-root Homepage-reefTable-3 MuiGrid-item MuiGrid-grid-sm-6"
+          class="MuiGrid-root Homepage-reefTable-3 MuiGrid-item MuiGrid-grid-md-6"
         >
           <mock-reeftable />
         </div>
       </mock-hidden>
       <mock-hidden
-        smup="true"
+        mdup="true"
       >
         <div
           style="height: 60px; position: fixed; bottom: 0px; right: 0px; left: 0px;"

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -115,18 +115,18 @@ const Homepage = ({ classes }: HomepageProps) => {
       </div>
       <div className={classes.root}>
         <Grid container>
-          <Grid className={classes.map} item xs={12} sm={6}>
+          <Grid className={classes.map} item xs={12} md={6}>
             <HomepageMap
               initialZoom={initialZoom}
               initialCenter={initialCenter}
             />
           </Grid>
-          <Hidden xsDown>
-            <Grid className={classes.reefTable} item sm={6}>
+          <Hidden smDown>
+            <Grid className={classes.reefTable} item md={6}>
               <ReefTable />
             </Grid>
           </Hidden>
-          <Hidden smUp>
+          <Hidden mdUp>
             <SwipeableBottomSheet
               overflowHeight={60}
               bodyStyle={{


### PR DESCRIPTION
The purpose of this PR is to apply the mobile design of the `/map` page for screens < 960px.

Deployed [here](https://aqualink-app-programize.web.app/map).

Right now the designed is applied at < 600px which makes the iPad view a liitle squished.
Here's the difference of the previous and the current approach for iPad (768px):

| before | after |
|---|---|
| ![Screenshot_20210805_175012](https://user-images.githubusercontent.com/64922890/128371368-4e2b2c67-10d6-4275-b45c-347a1e5765b5.png) | ![Screenshot_20210805_175033](https://user-images.githubusercontent.com/64922890/128371404-b940432f-1865-457c-bc42-8c16ad8b7831.png) |
