### PR TITLE
Retire daily data

### DIFF
--- a/packages/api/src/sensors/sensors.module.ts
+++ b/packages/api/src/sensors/sensors.module.ts
@@ -1,6 +1,5 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { DailyData } from '../reefs/daily-data.entity';
 import { Reef } from '../reefs/reefs.entity';
 import { Sources } from '../reefs/sources.entity';
 import { Survey } from '../surveys/surveys.entity';
@@ -11,8 +10,6 @@ import { SensorsService } from './sensors.service';
 @Module({
   controllers: [SensorsController],
   providers: [SensorsService],
-  imports: [
-    TypeOrmModule.forFeature([DailyData, Reef, Sources, Survey, TimeSeries]),
-  ],
+  imports: [TypeOrmModule.forFeature([Reef, Sources, Survey, TimeSeries])],
 })
 export class SensorsModule {}

--- a/packages/api/src/sensors/sensors.service.ts
+++ b/packages/api/src/sensors/sensors.service.ts
@@ -106,7 +106,6 @@ export class SensorsService {
       startDate,
       endDate,
       metrics as Metric[],
-      false,
       reef.id,
     );
 

--- a/packages/api/src/surveys/surveys.module.ts
+++ b/packages/api/src/surveys/surveys.module.ts
@@ -10,12 +10,21 @@ import { ReefPointOfInterest } from '../reef-pois/reef-pois.entity';
 import { GoogleCloudModule } from '../google-cloud/google-cloud.module';
 import { GoogleCloudService } from '../google-cloud/google-cloud.service';
 import { Reef } from '../reefs/reefs.entity';
+import { TimeSeries } from '../time-series/time-series.entity';
+import { Sources } from '../reefs/sources.entity';
 
 @Module({
   imports: [
     AuthModule,
     GoogleCloudModule,
-    TypeOrmModule.forFeature([Survey, SurveyMedia, ReefPointOfInterest, Reef]),
+    TypeOrmModule.forFeature([
+      Survey,
+      SurveyMedia,
+      ReefPointOfInterest,
+      Reef,
+      TimeSeries,
+      Sources,
+    ]),
   ],
   controllers: [SurveysController],
   providers: [EntityExists, SurveysService, GoogleCloudService],

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -1,11 +1,4 @@
-import {
-  Controller,
-  ParseArrayPipe,
-  Get,
-  Param,
-  Query,
-  ParseBoolPipe,
-} from '@nestjs/common';
+import { Controller, ParseArrayPipe, Get, Param, Query } from '@nestjs/common';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import { ParseDatePipe } from '../pipes/parse-date.pipe';
 import { ReefDataDto } from './dto/reef-data.dto';
@@ -18,6 +11,7 @@ import {
   ApiTimeSeriesRangeResponse,
   ApiTimeSeriesResponse,
 } from '../docs/api-time-series-response';
+import { TimeSeriesGrouping } from '../utils/time-series.utils';
 
 @ApiTags('Time Series')
 @Controller('time-series')
@@ -35,21 +29,21 @@ export class TimeSeriesController {
     name: 'metrics',
     example: [Metric.BOTTOM_TEMPERATURE, Metric.TOP_TEMPERATURE],
   })
-  @ApiQuery({ name: 'hourly', example: false })
+  @ApiQuery({ name: 'grouping', example: false, required: false })
   @Get('reefs/:reefId/pois/:poiId')
   findPoiData(
+    @Param() poiDataDto: PoiDataDto,
     @Query('start', ParseDatePipe) startDate: Date,
     @Query('end', ParseDatePipe) endDate: Date,
     @Query('metrics', ParseArrayPipe) metrics: Metric[],
-    @Query('hourly', ParseBoolPipe) hourly: boolean,
-    @Param() poiDataDto: PoiDataDto,
+    @Query('grouping') grouping?: TimeSeriesGrouping,
   ) {
     return this.timeSeriesService.findPoiData(
       startDate,
       endDate,
       metrics,
-      hourly,
       poiDataDto,
+      grouping,
     );
   }
 
@@ -63,21 +57,21 @@ export class TimeSeriesController {
     name: 'metrics',
     example: [Metric.BOTTOM_TEMPERATURE, Metric.TOP_TEMPERATURE],
   })
-  @ApiQuery({ name: 'hourly', example: false })
+  @ApiQuery({ name: 'grouping', example: false, required: false })
   @Get('reefs/:reefId')
   findReefData(
+    @Param() reefDataDto: ReefDataDto,
     @Query('start', ParseDatePipe) startDate: Date,
     @Query('end', ParseDatePipe) endDate: Date,
     @Query('metrics', ParseArrayPipe) metrics: Metric[],
-    @Query('hourly', ParseBoolPipe) hourly: boolean,
-    @Param() reefDataDto: ReefDataDto,
+    @Query('grouping') grouping?: TimeSeriesGrouping,
   ) {
     return this.timeSeriesService.findReefData(
       startDate,
       endDate,
       metrics,
-      hourly,
       reefDataDto,
+      grouping,
     );
   }
 

--- a/packages/api/src/time-series/time-series.service.ts
+++ b/packages/api/src/time-series/time-series.service.ts
@@ -12,6 +12,7 @@ import {
   getDataQuery,
   getDataRangeQuery,
   groupByMetricAndSource,
+  TimeSeriesGrouping,
 } from '../utils/time-series.utils';
 
 @Injectable()
@@ -27,8 +28,8 @@ export class TimeSeriesService {
     startDate: Date,
     endDate: Date,
     metrics: Metric[],
-    hourly: boolean,
     poiDataDto: PoiDataDto,
+    grouping?: TimeSeriesGrouping,
   ) {
     const { reefId, poiId } = poiDataDto;
 
@@ -37,8 +38,8 @@ export class TimeSeriesService {
       startDate,
       endDate,
       metrics,
-      hourly,
       reefId,
+      grouping,
       poiId,
     );
 
@@ -49,8 +50,8 @@ export class TimeSeriesService {
     startDate: Date,
     endDate: Date,
     metrics: Metric[],
-    hourly: boolean,
     reefDataDto: ReefDataDto,
+    grouping?: TimeSeriesGrouping,
   ) {
     const { reefId } = reefDataDto;
 
@@ -59,8 +60,8 @@ export class TimeSeriesService {
       startDate,
       endDate,
       metrics,
-      hourly,
       reefId,
+      grouping,
     );
 
     return groupByMetricAndSource(data);

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -1,8 +1,9 @@
-import _, { omit } from 'lodash';
+import _, { groupBy, keyBy, mapValues, omit } from 'lodash';
 import { IsNull, Repository } from 'typeorm';
 import { Reef } from '../reefs/reefs.entity';
 import { SourceType } from '../reefs/schemas/source-type.enum';
 import { Sources } from '../reefs/sources.entity';
+import { SensorDataDto } from '../sensors/dto/sensor-data.dto';
 import { TimeSeriesValueDto } from '../time-series/dto/time-series-value.dto';
 import { Metric } from '../time-series/metrics.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
@@ -180,4 +181,72 @@ export const insertReefDataToTimeSeries = (
     )
     .onConflict('ON CONSTRAINT "no_duplicate_data" DO NOTHING')
     .execute();
+};
+
+export const getClosestTimeSeriesData = async (
+  date: Date,
+  reefId: number,
+  metrics: Metric[],
+  sourceTypes: SourceType[],
+  timeSeriesRepository: Repository<TimeSeries>,
+  sourcesRepository: Repository<Sources>,
+  poiId?: number,
+) => {
+  const poiCondition = poiId
+    ? `source.poi_id = ${poiId}`
+    : 'source.poi_id IS NULL';
+  // We will use this many times in our query, so we declare it as constant
+  const diff = `(time_series.timestamp::timestamp - '${date.toISOString()}'::timestamp)`;
+
+  // First get all sources needed to avoid inner join later
+  const sources = await sourcesRepository
+    .createQueryBuilder('source')
+    .where('source.type IN (:...sourceTypes)', { sourceTypes })
+    .andWhere('source.reef_id = :reefId', { reefId })
+    .andWhere(poiCondition)
+    .getMany();
+
+  if (!sources.length) {
+    return {};
+  }
+
+  // Create map from source_id to source entity
+  const sourceMap = keyBy(sources, (source) => source.id);
+
+  // Grab all data at an interval of +/- 24 hours around the diveDate
+  // Order (descending) those data by the absolute time distance between the data and the survey diveDate
+  // This way the closest data point for each metric for each source type will be the last row
+  const timeSeriesData: TimeSeriesData[] = await timeSeriesRepository
+    .createQueryBuilder('time_series')
+    .select('time_series.timestamp', 'timestamp')
+    .addSelect('time_series.value', 'value')
+    .addSelect('time_series.metric', 'metric')
+    .addSelect('time_series.source_id', 'source')
+    .where(`${diff} < INTERVAL '1 d'`)
+    .andWhere(`${diff} > INTERVAL '-1 d'`)
+    .andWhere('time_series.metric IN (:...metrics)', { metrics })
+    .andWhere('time_series.source_id IN (:...sourceIds)', {
+      sourceIds: Object.keys(sourceMap),
+    })
+    .orderBy(
+      `time_series.source_id, metric, (CASE WHEN ${diff} < INTERVAL '0' THEN (-${diff}) ELSE ${diff} END)`,
+      'DESC',
+    )
+    .getRawMany();
+
+  // Group the data by source id
+  const groupedData = groupBy(timeSeriesData, (o) => o.source);
+
+  return Object.keys(groupedData).reduce<SensorDataDto>((data, key) => {
+    return {
+      ...data,
+      // Replace source id by source using the mapped source object
+      // Keep only timestamps and value from the resulting objects
+      [sourceMap[key].type]: mapValues(
+        // Use key by to group the data by metric and keep only the last entry, i.e. the closest one
+        keyBy(groupedData[key], (grouped) => grouped.metric),
+        (v) => ({ timestamp: v.timestamp, value: v.value }),
+      ),
+    };
+  }, {});
 };


### PR DESCRIPTION
Remove daily data usage from the backend
- findDailyData endpoint GET /reefs/:id/daily_data
- liveDailyData endpoint GET /reefs/:id/live_data : used to calculate the live weeklyAlert
- findSensorSurveys endpoint GET /sensors/:id/surveys : used to fetch the sst for the surveys
- findSurveys endpoint GET /reefs/:reef_id/surveys : used to fetch bottomTemperature and sst as fallback for the surveys temperature