### PR TITLE
Delete deprecated reef-application endpoints

### DIFF
--- a/packages/api/src/main.ts
+++ b/packages/api/src/main.ts
@@ -27,7 +27,7 @@ async function bootstrap() {
   app.enableCors();
   app.setGlobalPrefix('api');
   app.useGlobalPipes(
-    new GlobalValidationPipe({ transform: true, skipTransformIds: ['hashId'] }),
+    new GlobalValidationPipe({ transform: true, skipTransformIds: ['appId'] }),
   );
   app.useGlobalFilters(
     new HttpExceptionFilter(),

--- a/packages/api/src/reef-applications/reef-application.spec.ts
+++ b/packages/api/src/reef-applications/reef-application.spec.ts
@@ -51,7 +51,7 @@ export const reefApplicationTests = () => {
     expect(rsp.status).toBe(404);
   });
 
-  it('PUT /:hashId/reefs/:id updates a reef application using reefId', async () => {
+  it('PUT /:appId/reefs/:id updates a reef application using reefId', async () => {
     const updatedReefApplicationFoundingSource = 'New found source';
     mockExtractAndVerifyToken(reefManagerFirebaseUserMock);
     const rsp = await request(app.getHttpServer())

--- a/packages/api/src/reef-applications/reef-application.spec.ts
+++ b/packages/api/src/reef-applications/reef-application.spec.ts
@@ -9,7 +9,6 @@ import {
   reefManagerFirebaseUserMock,
 } from '../../test/mock/user.mock';
 import { floridaReefApplication } from '../../test/mock/reef-application.mock';
-import { hashId } from '../utils/urls';
 
 export const reefApplicationTests = () => {
   const testService = TestService.getInstance();
@@ -40,6 +39,7 @@ export const reefApplicationTests = () => {
     });
     expect(rsp.body.reef).toBeDefined();
     expect(rsp.body.user).toBeDefined();
+    appId = rsp.body.appId;
   });
 
   it('GET /reefs/:id fetches a non-existing reef application', async () => {
@@ -49,46 +49,6 @@ export const reefApplicationTests = () => {
     );
 
     expect(rsp.status).toBe(404);
-  });
-
-  it('GET /:id fetches a reef application with id', async () => {
-    const rsp = await request(app.getHttpServer())
-      .get(`/reef-applications/${floridaReefApplication.id}`)
-      .query({ uid: floridaReefApplication.uid });
-
-    expect(rsp.status).toBe(200);
-    expect(rsp.body).toMatchObject({
-      ...omit(
-        floridaReefApplication,
-        'createdAt',
-        'updatedAt',
-        'user',
-        'reef',
-        'uid',
-        'id',
-      ),
-    });
-    expect(rsp.body.appId).toBeDefined();
-    appId = rsp.body.appId;
-  });
-
-  it('GET /:id fetches a reef application with appId', async () => {
-    const rsp = await request(app.getHttpServer())
-      .get(`/reef-applications/${appId}`)
-      .query({ uid: floridaReefApplication.uid });
-
-    expect(rsp.status).toBe(200);
-    expect(rsp.body).toMatchObject({
-      ...omit(
-        floridaReefApplication,
-        'createdAt',
-        'updatedAt',
-        'user',
-        'reef',
-        'uid',
-        'id',
-      ),
-    });
   });
 
   it('PUT /:hashId/reefs/:id updates a reef application using reefId', async () => {
@@ -115,30 +75,6 @@ export const reefApplicationTests = () => {
     });
   });
 
-  it('PUT /:hashId updates a reef application using hashId', async () => {
-    const rsp = await request(app.getHttpServer())
-      .put(`/reef-applications/${appId}`)
-      .send({
-        reefApplication: {
-          fundingSource: floridaReefApplication.fundingSource,
-        },
-        reef: {},
-      });
-
-    expect(rsp.status).toBe(200);
-    expect(rsp.body).toMatchObject({
-      ...omit(
-        floridaReefApplication,
-        'createdAt',
-        'updatedAt',
-        'user',
-        'reef',
-        'uid',
-        'id',
-      ),
-    });
-  });
-
   it('GET /:id fetches a non-existing reef application with id', async () => {
     const rsp = await request(app.getHttpServer())
       .get(`/reef-applications/0a0`)
@@ -151,32 +87,6 @@ export const reefApplicationTests = () => {
     const rsp = await request(app.getHttpServer())
       .get(`/reef-applications/${floridaReefApplication.id}`)
       .query({ uid: 'wrong' });
-
-    expect(rsp.status).toBe(404);
-  });
-
-  it('PUT /:hashId updates a reef application using an invalid hashId', async () => {
-    const rsp = await request(app.getHttpServer())
-      .put(`/reef-applications/0a0`)
-      .send({
-        reefApplication: {
-          fundingSource: floridaReefApplication.fundingSource,
-        },
-        reef: {},
-      });
-
-    expect(rsp.status).toBe(404);
-  });
-
-  it('PUT /:hashId updates a non-existing reef application using hashId', async () => {
-    const rsp = await request(app.getHttpServer())
-      .put(`/reef-applications/${hashId(0)}`)
-      .send({
-        reefApplication: {
-          fundingSource: floridaReefApplication.fundingSource,
-        },
-        reef: {},
-      });
 
     expect(rsp.status).toBe(404);
   });

--- a/packages/api/src/reef-applications/reef-applications.controller.ts
+++ b/packages/api/src/reef-applications/reef-applications.controller.ts
@@ -53,13 +53,13 @@ export class ReefApplicationsController {
   @ApiUpdateReefApplicationBody()
   @ApiOperation({
     summary:
-      'Updates reef application by providing its hashId. Needs authentication.',
+      'Updates reef application by providing its appId. Needs authentication.',
   })
-  @ApiParam({ name: 'hashId', example: 1 })
+  @ApiParam({ name: 'appId', example: 1 })
   @UseGuards(IsReefAdminGuard)
-  @Put(':hashId/reefs/:reef_id')
+  @Put(':appId/reefs/:reef_id')
   update(
-    @Param('hashId', new ParseHashedIdPipe()) id: number,
+    @Param('appId', new ParseHashedIdPipe()) id: number,
     @Body() reefApplication: UpdateReefApplicationDto,
   ) {
     return this.reefApplicationsService.update(id, reefApplication);

--- a/packages/api/src/reef-applications/reef-applications.module.ts
+++ b/packages/api/src/reef-applications/reef-applications.module.ts
@@ -3,12 +3,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ReefApplicationsController } from './reef-applications.controller';
 import { ReefApplicationsService } from './reef-applications.service';
 import { EntityExists } from '../validations/entity-exists.constraint';
-import { Reef } from '../reefs/reefs.entity';
 import { ReefApplication } from './reef-applications.entity';
 import { AuthModule } from '../auth/auth.module';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([Reef, ReefApplication])],
+  imports: [AuthModule, TypeOrmModule.forFeature([ReefApplication])],
   controllers: [ReefApplicationsController],
   providers: [ReefApplicationsService, EntityExists],
 })

--- a/packages/api/src/reef-applications/reef-applications.module.ts
+++ b/packages/api/src/reef-applications/reef-applications.module.ts
@@ -5,9 +5,10 @@ import { ReefApplicationsService } from './reef-applications.service';
 import { EntityExists } from '../validations/entity-exists.constraint';
 import { ReefApplication } from './reef-applications.entity';
 import { AuthModule } from '../auth/auth.module';
+import { Reef } from '../reefs/reefs.entity';
 
 @Module({
-  imports: [AuthModule, TypeOrmModule.forFeature([ReefApplication])],
+  imports: [AuthModule, TypeOrmModule.forFeature([Reef, ReefApplication])],
   controllers: [ReefApplicationsController],
   providers: [ReefApplicationsService, EntityExists],
 })

--- a/packages/api/src/reef-applications/reef-applications.service.ts
+++ b/packages/api/src/reef-applications/reef-applications.service.ts
@@ -3,8 +3,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { ReefApplication } from './reef-applications.entity';
 import { UpdateReefApplicationDto } from './dto/update-reef-application.dto';
-import { Reef } from '../reefs/reefs.entity';
-import { UpdateReefWithApplicationDto } from './dto/update-reef-with-application.dto';
 
 @Injectable()
 export class ReefApplicationsService {
@@ -12,8 +10,6 @@ export class ReefApplicationsService {
   constructor(
     @InjectRepository(ReefApplication)
     private reefApplicationRepository: Repository<ReefApplication>,
-    @InjectRepository(Reef)
-    private reefRepository: Repository<Reef>,
   ) {}
 
   async findOneFromReef(reefId: number): Promise<ReefApplication> {
@@ -33,23 +29,9 @@ export class ReefApplicationsService {
     return application;
   }
 
-  async findOne(id: number): Promise<ReefApplication> {
-    const reefApplication = await this.reefApplicationRepository.findOne({
-      where: { id },
-      relations: ['reef', 'user'],
-    });
-
-    if (!reefApplication) {
-      throw new NotFoundException(`Reef Application with ID ${id} not found.`);
-    }
-
-    return reefApplication;
-  }
-
   async update(
     id: number,
     appParams: UpdateReefApplicationDto,
-    reefParams: UpdateReefWithApplicationDto,
   ): Promise<ReefApplication> {
     const app = await this.reefApplicationRepository.findOne({
       where: { id },
@@ -60,7 +42,6 @@ export class ReefApplicationsService {
     }
 
     await this.reefApplicationRepository.update(app.id, appParams);
-    await this.reefRepository.update(app.reef.id, reefParams);
 
     const updatedApp = await this.reefApplicationRepository.findOne({
       where: { id },

--- a/packages/api/test/test.service.ts
+++ b/packages/api/test/test.service.ts
@@ -48,7 +48,7 @@ export class TestService {
     this.app.useGlobalPipes(
       new GlobalValidationPipe({
         transform: true,
-        skipTransformIds: ['hashId'],
+        skipTransformIds: ['appId'],
       }),
     );
 


### PR DESCRIPTION
Delete:
- GET /reef-applications/:id : Gets application based on a hashId and the uid
- PUT /reef-applications/:id : Update reefApplication based on a hashId

Also there was a functionality that allowed users to edit some reef column through the above PUT endpoint. This is no longer available and thus deleted. 