### PR TITLE
Flip wave directions

### DIFF
--- a/packages/api/src/utils/math.test.ts
+++ b/packages/api/src/utils/math.test.ts
@@ -11,4 +11,7 @@ test('It calculates direction properly from velocity.', () => {
 
   const northEastWindDirection = getWindDirection(-1, -1);
   expect(northEastWindDirection).toEqual(45);
+
+  const northWestWindDirection = getWindDirection(1, -1);
+  expect(northWestWindDirection).toEqual(315);
 });

--- a/packages/api/src/utils/math.test.ts
+++ b/packages/api/src/utils/math.test.ts
@@ -1,14 +1,14 @@
 import { getWindDirection } from './math';
 
 test('It calculates direction properly from velocity.', () => {
-  // For SOFAR windDirection represents the direction the wind is GOING TO.
+  // We use the meteorological convention - the direction the wind is "COMING FROM".
   // getWindDirection(windEastwardVelocity: number, windNorhwardVelocity)
   const eastWindDirection = getWindDirection(-1, 0);
-  expect(eastWindDirection).toEqual(270);
+  expect(eastWindDirection).toEqual(90);
 
   const northWindDirection = getWindDirection(0, -1);
-  expect(northWindDirection).toEqual(180);
+  expect(northWindDirection).toEqual(0);
 
   const northEastWindDirection = getWindDirection(-1, -1);
-  expect(northEastWindDirection).toEqual(225);
+  expect(northEastWindDirection).toEqual(45);
 });

--- a/packages/api/src/utils/math.ts
+++ b/packages/api/src/utils/math.ts
@@ -28,7 +28,7 @@ export const getWindDirection = (
   windNorhwardVelocity: number,
 ) => {
   const degree =
-    -(Math.atan2(windNorhwardVelocity, windEastwardVelocity) * 180) / Math.PI +
+    -(Math.atan2(windNorhwardVelocity, windEastwardVelocity) * 180) / Math.PI -
     90;
 
   return degree >= 0 ? degree : degree + 360;

--- a/packages/api/src/utils/sofar.test.ts
+++ b/packages/api/src/utils/sofar.test.ts
@@ -8,11 +8,11 @@ test('It processes Sofar API for daily data.', async () => {
     'analysedSeaSurfaceTemperature',
     -3.5976336810301888,
     -178.0000002552476,
-    new Date('2021-08-06'),
+    new Date('2021-12-06'),
   );
 
   expect(values).toEqual([
-    { timestamp: '2021-08-05T12:00:00.000Z', value: 28.8099994659424 },
+    { timestamp: '2021-12-05T12:00:00.000Z', value: 28.7399997711182 },
   ]);
 });
 

--- a/packages/api/src/workers/dailyData.test.ts
+++ b/packages/api/src/workers/dailyData.test.ts
@@ -4,7 +4,7 @@ import { Site } from '../sites/sites.entity';
 test('It processes Sofar API for daily data.', async () => {
   jest.setTimeout(60000);
 
-  const date = new Date('2021-08-01');
+  const date = new Date('2021-12-01');
   date.setUTCHours(23, 59, 59, 999);
   const site = {
     id: 1,
@@ -33,16 +33,16 @@ test('It processes Sofar API for daily data.', async () => {
     maxBottomTemperature: undefined,
     avgBottomTemperature: undefined,
     topTemperature: undefined,
-    satelliteTemperature: 16.0400009155273,
-    degreeHeatingDays: 14.13999986648557,
-    minWaveHeight: 0.826433181762695,
-    maxWaveHeight: 0.902798652648926,
-    avgWaveHeight: 0.8645887772242228,
-    waveMeanDirection: 275,
-    waveMeanPeriod: 6,
-    minWindSpeed: 1.3851696423913313,
-    maxWindSpeed: 3.1935656540742148,
-    avgWindSpeed: 2.093633046123507,
-    windDirection: 34,
+    satelliteTemperature: 13.5900001525879,
+    degreeHeatingDays: 54.66999959945678,
+    minWaveHeight: 1.40074372291565,
+    maxWaveHeight: 1.88541984558105,
+    avgWaveHeight: 1.6570496062437696,
+    waveMeanDirection: 280,
+    waveMeanPeriod: 9,
+    minWindSpeed: 0.7573268278485021,
+    maxWindSpeed: 3.369370754458181,
+    avgWindSpeed: 2.037785290559487,
+    windDirection: 98,
   });
 });

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -185,7 +185,7 @@ exports[`renders as expected 1`] = `
                 color="textSecondary"
                 variant="h3"
               >
-                316°
+                136°
               </mock-typography>
             </div>
           </div>

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -81,7 +81,7 @@ exports[`renders as expected 1`] = `
                 color="textSecondary"
                 variant="h3"
               >
-                276°
+                96°
               </mock-typography>
             </div>
           </div>

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -13,7 +13,7 @@ import { isNil } from "lodash";
 
 import UpdateInfo from "../../UpdateInfo";
 import type { LiveData } from "../../../store/Sites/types";
-import { formatNumber, invertDirection } from "../../../helpers/numberUtils";
+import { formatNumber } from "../../../helpers/numberUtils";
 import { toRelativeTime } from "../../../helpers/dates";
 import waves from "../../../assets/waves.svg";
 import arrow from "../../../assets/directioncircle.svg";

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -31,7 +31,8 @@ const Waves = ({ liveData }: WavesProps) => {
     windDirection,
   } = liveData;
 
-  // Make sure to getthe direction the wind is COMING FROM.
+  // Make sure to get the direction the wind is COMING FROM.
+  // use `numberUtils.invertDirection` if needed.
   const windDirectionFrom = windDirection?.value;
   const waveDirectionFrom = waveMeanDirection?.value;
   const classes = useStyles({

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -31,9 +31,10 @@ const Waves = ({ liveData }: WavesProps) => {
     windDirection,
   } = liveData;
 
-  // SOFAR uses direction GOING TO, but we want to disply direction COMING FROM.
+  // SOFAR uses direction GOING TO, but we want to display direction COMING FROM.
   const windDirectionFrom = invertDirection(windDirection?.value);
-  const waveDirectionFrom = invertDirection(waveMeanDirection?.value);
+  // Wave data seems to be using the COMING FROM convention. Ask eric@ovio.org for questions.
+  const waveDirectionFrom = waveMeanDirection?.value;
   const classes = useStyles({
     windDirection: windDirectionFrom,
     wavesDirection: waveDirectionFrom,

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -31,9 +31,8 @@ const Waves = ({ liveData }: WavesProps) => {
     windDirection,
   } = liveData;
 
-  // SOFAR uses direction GOING TO, but we want to display direction COMING FROM.
-  const windDirectionFrom = invertDirection(windDirection?.value);
-  // Wave data seems to be using the COMING FROM convention. Ask eric@ovio.org for questions.
+  // Make sure to getthe direction the wind is COMING FROM.
+  const windDirectionFrom = windDirection?.value;
   const waveDirectionFrom = waveMeanDirection?.value;
   const classes = useStyles({
     windDirection: windDirectionFrom,

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -1972,7 +1972,7 @@ exports[`Site Detail Page should render with given state from Redux store: snaps
                         color="textSecondary"
                         variant="h3"
                       >
-                        270°
+                        90°
                       </mock-typography>
                     </div>
                   </div>

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -1868,7 +1868,7 @@ exports[`Site Detail Page should render with given state from Redux store: snaps
                         color="textSecondary"
                         variant="h3"
                       >
-                        0°
+                        180°
                       </mock-typography>
                     </div>
                   </div>


### PR DESCRIPTION
Following a conversation with Sofar, we realized that there had been a misunderstanding on conventions used to represent wave directions.

We are switching back to using the meteorological convention for all metrics.