### PR TITLE
Fix water sampling charts not being displayed on view upload button click

### DIFF
--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -91,8 +91,8 @@ const MultipleSensorsCharts = ({
   const timeSeriesDataRanges = useSelector(siteTimeSeriesDataRangeSelector);
   const { bottomTemperature: hoboBottomTemperatureRange } =
     timeSeriesDataRanges?.hobo || {};
-  const [pickerEndDate, setPickerEndDate] = useState(initialEnd);
-  const [pickerStartDate, setPickerStartDate] = useState(initialStart);
+  const [pickerEndDate, setPickerEndDate] = useState<string>();
+  const [pickerStartDate, setPickerStartDate] = useState<string>();
   const [endDate, setEndDate] = useState<string>();
   const [startDate, setStartDate] = useState<string>();
   const [pickerErrored, setPickerErrored] = useState(false);
@@ -148,19 +148,19 @@ const MultipleSensorsCharts = ({
         .tz(site.timezone || "UTC")
         .startOf("day")
         .toISOString();
-      if (!initialEnd) {
-        setPickerEndDate(
+
+      setPickerEndDate(
+        initialEnd ||
           utcToZonedTime(
             localizedMaxDate || today,
             site.timezone || "UTC"
           ).toISOString()
-        );
-      }
-      if (!initialStart) {
-        setPickerStartDate(
+      );
+
+      setPickerStartDate(
+        initialStart ||
           utcToZonedTime(pastThreeMonths, site.timezone || "UTC").toISOString()
-        );
-      }
+      );
     }
   }, [
     hoboBottomTemperatureRange,


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/652.
When providing an initial `start/end` date via url query params, a time series data request is being dispatched, with the following metrics:

```typescript
const DEFAULT_METRICS = [
  "bottom_temperature",
  "top_temperature",
  "wind_speed",
  "significant_wave_height",
];
```
This data is being cached, and the cache invalidation happens only when one from `start/end` dates is changed. However, the information of whether a site has sonde data comes only after the time series data range request is fulfilled, so when the flag `hasSondeData` changes, the 3rd `useEffect` on `/MultipleSensorsCharts/index.tsx` gets triggered again with the sonde metrics, but since the `start/end` dates have not changed, the cache does not get invalidated, and the time series request does not go through.

With this approach, we set the url query params for `start/end` dates only after the time series range request is fulfilled.