### PR TITLE
Fix issue with multiple source_id for latest_data

### DIFF
--- a/packages/api/migration/1642631169209-fixLatestDataMaterializedView.ts
+++ b/packages/api/migration/1642631169209-fixLatestDataMaterializedView.ts
@@ -13,11 +13,12 @@ export class fixLatestDataMaterializedView1642631169209 implements MigrationInte
                 timestamp,
                 value,
                 type AS "source",
-                site_id
+                site_id,
+                survey_point_id
             FROM "time_series" "time_series"
             INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id"
             ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`);
-        await queryRunner.query(`INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`, ["public","MATERIALIZED_VIEW","latest_data","SELECT DISTINCT ON (metric, type, site_id, survey_point_id) \"time_series\".\"id\", metric, timestamp, value, type AS \"source\", site_id FROM \"time_series\" \"time_series\" INNER JOIN \"sources\" \"sources\" ON \"sources\".\"id\" = \"time_series\".\"source_id\" ORDER BY metric, type, site_id, survey_point_id, timestamp DESC"]);
+        await queryRunner.query(`INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`, ["public","MATERIALIZED_VIEW","latest_data","SELECT DISTINCT ON (metric, type, site_id, survey_point_id) \"time_series\".\"id\", metric, timestamp, value, type AS \"source\", site_id, survey_point_id FROM \"time_series\" \"time_series\" INNER JOIN \"sources\" \"sources\" ON \"sources\".\"id\" = \"time_series\".\"source_id\" ORDER BY metric, type, site_id, survey_point_id, timestamp DESC"]);
     }
 
     public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/api/migration/1642631169209-fixLatestDataMaterializedView.ts
+++ b/packages/api/migration/1642631169209-fixLatestDataMaterializedView.ts
@@ -1,0 +1,28 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class fixLatestDataMaterializedView1642631169209 implements MigrationInterface {
+    name = 'fixLatestDataMaterializedView1642631169209'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DROP MATERIALIZED VIEW "latest_data";`);
+        await queryRunner.query(`
+            CREATE MATERIALIZED VIEW "latest_data" AS
+            SELECT DISTINCT ON (metric, type, site_id, survey_point_id)
+                "time_series"."id",
+                metric,
+                timestamp,
+                value,
+                type AS "source",
+                site_id
+            FROM "time_series" "time_series"
+            INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id"
+            ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`);
+        await queryRunner.query(`INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`, ["public","MATERIALIZED_VIEW","latest_data","SELECT DISTINCT ON (metric, type, site_id, survey_point_id) \"time_series\".\"id\", metric, timestamp, value, type AS \"source\", site_id FROM \"time_series\" \"time_series\" INNER JOIN \"sources\" \"sources\" ON \"sources\".\"id\" = \"time_series\".\"source_id\" ORDER BY metric, type, site_id, survey_point_id, timestamp DESC"]);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`, ["MATERIALIZED_VIEW","latest_data","public"]);
+        await queryRunner.query(`DROP MATERIALIZED VIEW "latest_data"`);
+    }
+
+}

--- a/packages/api/src/time-series/latest-data.entity.ts
+++ b/packages/api/src/time-series/latest-data.entity.ts
@@ -25,6 +25,7 @@ import { TimeSeries } from './time-series.entity';
       .addSelect('value')
       .addSelect('type', 'source')
       .addSelect('site_id')
+      .addSelect('survey_point_id')
       .from(TimeSeries, 'time_series')
       .innerJoin('sources', 'sources', 'sources.id = time_series.source_id')
       .orderBy('metric, type, site_id, survey_point_id, timestamp', 'DESC');

--- a/packages/api/src/time-series/latest-data.entity.ts
+++ b/packages/api/src/time-series/latest-data.entity.ts
@@ -15,22 +15,19 @@ import { TimeSeries } from './time-series.entity';
 
 @ViewEntity({
   expression: (connection: Connection) => {
-    const subQuery = connection
-      .createQueryBuilder()
-      .select('DISTINCT ON (metric, source_id) metric', 'metric')
-      .addSelect('id')
-      .addSelect('timestamp')
-      .addSelect('value')
-      .addSelect('source_id')
-      .from(TimeSeries, 'time_series')
-      .orderBy('metric, source_id, timestamp', 'DESC');
-
     return connection
       .createQueryBuilder()
-      .from(() => subQuery, 'time_series')
+      .select(
+        'DISTINCT ON (metric, type, site_id, survey_point_id) time_series.id',
+      )
+      .addSelect('metric')
+      .addSelect('timestamp')
+      .addSelect('value')
+      .addSelect('type', 'source')
       .addSelect('site_id')
-      .addSelect('survey_point_id')
-      .innerJoin('sources', 'source', 'source.id = time_series.source_id');
+      .from(TimeSeries, 'time_series')
+      .innerJoin('sources', 'sources', 'sources.id = time_series.source_id')
+      .orderBy('metric, type, site_id, survey_point_id, timestamp', 'DESC');
   },
   materialized: true,
 })


### PR DESCRIPTION
If a site had multiple sources with the same type (eg. a spotter was replaced), we ended up with two data points for a few metrics.

This new MV query fixes it but is a bit slower. We should investigate how to speed things up eventually.