### PR TITLE
Do not return sources with no data

### DIFF
--- a/packages/api/src/sensors/sensors.spec.ts
+++ b/packages/api/src/sensors/sensors.spec.ts
@@ -2,11 +2,6 @@ import { INestApplication } from '@nestjs/common';
 import moment from 'moment';
 import request from 'supertest';
 import { californiaSite } from '../../test/mock/site.mock';
-import {
-  hoboMetrics,
-  NOAAMetrics,
-  spotterMetrics,
-} from '../../test/mock/time-series.mock';
 import { TestService } from '../../test/test.service';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { Metric } from '../time-series/metrics.entity';
@@ -36,20 +31,9 @@ export const sensorTests = () => {
       });
 
     expect(rsp.status).toBe(200);
-    const sources = [SourceType.HOBO, SourceType.NOAA, SourceType.SPOTTER];
+    const sources = [SourceType.SPOTTER];
     sources.forEach((source) => {
       expect(rsp.body).toHaveProperty(source);
-    });
-    hoboMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.HOBO]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.HOBO][metric].length).toBe(0);
-    });
-    NOAAMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.NOAA]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.NOAA][metric].length).toBe(0);
-    });
-    spotterMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.SPOTTER]).toHaveProperty(metric);
     });
     expect(rsp.body[SourceType.SPOTTER][Metric.TOP_TEMPERATURE].length).toBe(6);
   });

--- a/packages/api/src/time-series/time-series.spec.ts
+++ b/packages/api/src/time-series/time-series.spec.ts
@@ -36,7 +36,7 @@ export const timeSeriesTests = () => {
     );
 
     expect(rsp.status).toBe(200);
-    const sources = [SourceType.HOBO, SourceType.NOAA, SourceType.SPOTTER];
+    const sources = [SourceType.HOBO, SourceType.NOAA];
     sources.forEach((source) => {
       expect(rsp.body).toHaveProperty(source);
     });
@@ -60,10 +60,6 @@ export const timeSeriesTests = () => {
         max([maxDate, endDate]),
       ];
     });
-    spotterMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.SPOTTER]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.SPOTTER][metric].length).toBe(0);
-    });
   });
 
   it('GET /sites/:id/range fetch range of site data', async () => {
@@ -72,13 +68,9 @@ export const timeSeriesTests = () => {
     );
 
     expect(rsp.status).toBe(200);
-    const sources = [SourceType.HOBO, SourceType.NOAA, SourceType.SPOTTER];
+    const sources = [SourceType.NOAA, SourceType.SPOTTER];
     sources.forEach((source) => {
       expect(rsp.body).toHaveProperty(source);
-    });
-    hoboMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.HOBO]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.HOBO][metric].length).toBe(0);
     });
     NOAAMetrics.forEach((metric) => {
       expect(rsp.body[SourceType.NOAA]).toHaveProperty(metric);
@@ -111,7 +103,7 @@ export const timeSeriesTests = () => {
       });
 
     expect(rsp.status).toBe(200);
-    const sources = [SourceType.HOBO, SourceType.NOAA, SourceType.SPOTTER];
+    const sources = [SourceType.HOBO, SourceType.NOAA];
     sources.forEach((source) => {
       expect(rsp.body).toHaveProperty(source);
     });
@@ -122,10 +114,6 @@ export const timeSeriesTests = () => {
     NOAAMetrics.forEach((metric) => {
       expect(rsp.body[SourceType.NOAA]).toHaveProperty(metric);
       expect(rsp.body[SourceType.NOAA][metric].length).toBe(10);
-    });
-    spotterMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.SPOTTER]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.SPOTTER][metric].length).toBe(0);
     });
   });
 
@@ -142,13 +130,9 @@ export const timeSeriesTests = () => {
       });
 
     expect(rsp.status).toBe(200);
-    const sources = [SourceType.HOBO, SourceType.NOAA, SourceType.SPOTTER];
+    const sources = [SourceType.NOAA, SourceType.SPOTTER];
     sources.forEach((source) => {
       expect(rsp.body).toHaveProperty(source);
-    });
-    hoboMetrics.forEach((metric) => {
-      expect(rsp.body[SourceType.HOBO]).toHaveProperty(metric);
-      expect(rsp.body[SourceType.HOBO][metric].length).toBe(0);
     });
     NOAAMetrics.forEach((metric) => {
       expect(rsp.body[SourceType.NOAA]).toHaveProperty(metric);

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -27,16 +27,13 @@ interface TimeSeriesGroupable {
   source: SourceType;
 }
 
-type TimeSeriesResponse<T> = Record<SourceType, Record<Metric, T[]>>;
+type TimeSeriesResponse<T> = Record<SourceType, Partial<Record<Metric, T[]>>>;
 
 // TODO: Revisit the response structure and simplify when we have more metrics and sources available
 export const emptyMetricsSourcesObject = Object.values(SourceType).reduce(
   (root, key) => ({
     ...root,
-    [key]: Object.values(Metric).reduce(
-      (sources, source) => ({ ...sources, [source]: [] }),
-      {},
-    ),
+    [key]: {},
   }),
   {},
 ) as TimeSeriesResponse<TimeSeriesGroupable>;

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -27,17 +27,11 @@ interface TimeSeriesGroupable {
   source: SourceType;
 }
 
-type TimeSeriesResponse<T> = Record<SourceType, Partial<Record<Metric, T[]>>>;
+type TimeSeriesResponse<T> = Partial<
+  Record<SourceType, Partial<Record<Metric, T[]>>>
+>;
 
 // TODO: Revisit the response structure and simplify when we have more metrics and sources available
-export const emptyMetricsSourcesObject = Object.values(SourceType).reduce(
-  (root, key) => ({
-    ...root,
-    [key]: {},
-  }),
-  {},
-) as TimeSeriesResponse<TimeSeriesGroupable>;
-
 export const groupByMetricAndSource = <T extends TimeSeriesGroupable>(
   data: T[],
 ): TimeSeriesResponse<Pick<T, 'metric' | 'source'>> => {
@@ -51,7 +45,6 @@ export const groupByMetricAndSource = <T extends TimeSeriesGroupable>(
         )
         .toJSON();
     })
-    .merge(emptyMetricsSourcesObject)
     .toJSON();
 };
 

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -10,6 +10,7 @@ import {
   siteGranularDailyDataSelector,
   siteOceanSenseDataRequest,
   siteOceanSenseDataSelector,
+  siteTimeSeriesDataRangeLoadingSelector,
   siteTimeSeriesDataRangeSelector,
   siteTimeSeriesDataRequest,
   siteTimeSeriesDataSelector,
@@ -31,7 +32,6 @@ import { RangeValue } from "./types";
 import { oceanSenseConfig } from "../../../constants/oceanSenseConfig";
 import { getSondeConfig } from "../../../constants/sondeConfig";
 import { useQueryParams } from "../../../hooks/useQueryParams";
-import { siteHasSondeData } from "../../../store/Sites/helpers";
 import ChartWithCard from "./ChartWithCard";
 
 const DEFAULT_METRICS: MetricsKeys[] = [
@@ -91,6 +91,7 @@ const MultipleSensorsCharts = ({
   const timeSeriesDataRanges = useSelector(siteTimeSeriesDataRangeSelector);
   const { bottomTemperature: hoboBottomTemperatureRange } =
     timeSeriesDataRanges?.hobo || {};
+  const rangesLoading = useSelector(siteTimeSeriesDataRangeLoadingSelector);
   const [pickerEndDate, setPickerEndDate] = useState<string>();
   const [pickerStartDate, setPickerStartDate] = useState<string>();
   const [endDate, setEndDate] = useState<string>();
@@ -111,7 +112,9 @@ const MultipleSensorsCharts = ({
     spotterData?.bottomTemperature?.[1] || spotterData?.topTemperature?.[1]
   );
 
-  const hasSondeData = siteHasSondeData(timeSeriesDataRanges?.sonde);
+  const hasSondeData = Boolean(
+    site.liveData?.latestData?.some((data) => data.source === "sonde")
+  );
 
   const hasHoboData = Boolean(hoboBottomTemperature?.[1]);
 
@@ -139,7 +142,7 @@ const MultipleSensorsCharts = ({
 
   // Set pickers initial values once the range request is completed
   useEffect(() => {
-    if (hoboBottomTemperatureRange) {
+    if (!rangesLoading && !pickerStartDate && !pickerEndDate) {
       const { maxDate } = hoboBottomTemperatureRange?.[0] || {};
       const localizedMaxDate = localizedEndOfDay(maxDate, site.timezone);
       const pastThreeMonths = moment(
@@ -166,6 +169,9 @@ const MultipleSensorsCharts = ({
     hoboBottomTemperatureRange,
     initialEnd,
     initialStart,
+    pickerEndDate,
+    pickerStartDate,
+    rangesLoading,
     site.timezone,
     today,
   ]);

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -215,17 +215,11 @@ exports[`renders as expected 1`] = `
             <mock-button
               classname="makeStyles-button-21"
             >
-              <a
-                class="makeStyles-link-19"
-                href="/sites/1"
-                target="_blank"
+              <mock-typography
+                classname="makeStyles-chipText-17"
               >
-                <mock-typography
-                  classname="makeStyles-chipText-17"
-                >
-                  VIEW UPLOAD
-                </mock-typography>
-              </a>
+                VIEW UPLOAD
+              </mock-typography>
             </mock-button>
           </div>
         </div>

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -200,11 +200,8 @@ exports[`renders as expected 1`] = `
               >
                 <mock-typography
                   classname="makeStyles-updateInfoText-12"
-                  title="Survey point: Random Point"
                   variant="caption"
-                >
-                  Survey point: Random Point
-                </mock-typography>
+                />
               </mock-box>
             </div>
           </div>
@@ -220,7 +217,7 @@ exports[`renders as expected 1`] = `
             >
               <a
                 class="makeStyles-link-19"
-                href="/sites/1?surveyPoint=1"
+                href="/sites/1"
                 target="_blank"
               >
                 <mock-typography

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -215,11 +215,17 @@ exports[`renders as expected 1`] = `
             <mock-button
               classname="makeStyles-button-21"
             >
-              <mock-typography
-                classname="makeStyles-chipText-17"
+              <a
+                class="makeStyles-link-19"
+                href="/sites/1"
+                target="_blank"
               >
-                VIEW UPLOAD
-              </mock-typography>
+                <mock-typography
+                  classname="makeStyles-chipText-17"
+                >
+                  VIEW UPLOAD
+                </mock-typography>
+              </a>
             </mock-button>
           </div>
         </div>

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.test.tsx
@@ -3,17 +3,11 @@ import { render } from "@testing-library/react";
 import { BrowserRouter as Router } from "react-router-dom";
 
 import WaterSamplingCard from ".";
-import { mockHoboDataRange } from "../../../mocks/mockHoboDataRange";
 
 test("renders as expected", () => {
   const { container } = render(
     <Router>
-      <WaterSamplingCard
-        siteId="1"
-        pointId="1"
-        pointName="Random Point"
-        sondeDataRange={mockHoboDataRange.sonde}
-      />
+      <WaterSamplingCard siteId="1" />
     </Router>
   );
   expect(container).toMatchSnapshot();

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -91,14 +91,13 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
     point?.name || isPointIdValid
       ? `${isPointNameLong ? "" : " Survey point:"} ${point?.name || point?.id}`
       : undefined;
-  const viewUploadButtonLink =
-    minDate && maxDate && isPointIdValid
-      ? `/sites/${siteId}${requests.generateUrlQueryParams({
-          start: minDate,
-          end: maxDate,
-          surveyPoint: point?.id,
-        })}`
-      : undefined;
+  const viewUploadButtonLink = `/sites/${siteId}${requests.generateUrlQueryParams(
+    {
+      start: minDate,
+      end: maxDate,
+      surveyPoint: point?.id,
+    }
+  )}`;
   const lastUpload = maxDate ? moment(maxDate).format("MM/DD/YYYY") : undefined;
 
   useEffect(() => {

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -86,11 +86,9 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
   const [sondeData, setSondeData] = useState<TimeSeriesData["sonde"]>();
   const meanValues = calculateSondeDataMeanValues(sondeData);
   const isPointNameLong = (point?.name?.length || 0) > 24;
-  const isPointIdValid = typeof point?.id === "number";
-  const surveyPointDisplayName =
-    point?.name || isPointIdValid
-      ? `${isPointNameLong ? "" : " Survey point:"} ${point?.name || point?.id}`
-      : undefined;
+  const surveyPointDisplayName = `${isPointNameLong ? "" : " Survey point:"} ${
+    point?.name || point?.id
+  }`;
   const viewUploadButtonLink = `/sites/${siteId}${requests.generateUrlQueryParams(
     {
       start: minDate,
@@ -185,7 +183,7 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
           timeText="Last data uploaded"
           imageText="VIEW UPLOAD"
           href={viewUploadButtonLink}
-          subtitle={surveyPointDisplayName}
+          subtitle={point && surveyPointDisplayName}
         />
       </CardContent>
     </Card>

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -85,7 +85,21 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
   const [point, setPoint] = useState<SurveyPoint>();
   const [sondeData, setSondeData] = useState<TimeSeriesData["sonde"]>();
   const meanValues = calculateSondeDataMeanValues(sondeData);
-  const isPointNameLong = point?.name ? point.name.length > 24 : false;
+  const isPointNameLong = (point?.name?.length || 0) > 24;
+  const isPointIdValid = typeof point?.id === "number";
+  const surveyPointDisplayName =
+    point?.name || isPointIdValid
+      ? `${isPointNameLong ? "" : " Survey point:"} ${point?.name || point?.id}`
+      : undefined;
+  const viewUploadButtonLink =
+    minDate && maxDate && isPointIdValid
+      ? `/sites/${siteId}${requests.generateUrlQueryParams({
+          start: minDate,
+          end: maxDate,
+          surveyPoint: point?.id,
+        })}`
+      : undefined;
+  const lastUpload = maxDate ? moment(maxDate).format("MM/DD/YYYY") : undefined;
 
   useEffect(() => {
     const getCardData = async () => {
@@ -167,22 +181,12 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
           </Grid>
         </Box>
         <UpdateInfo
-          relativeTime={
-            maxDate ? moment(maxDate).format("MM/DD/YYYY") : undefined
-          }
+          relativeTime={lastUpload}
           chipWidth={64}
           timeText="Last data uploaded"
           imageText="VIEW UPLOAD"
-          href={`/sites/${siteId}${requests.generateUrlQueryParams({
-            start: minDate,
-            end: maxDate,
-            surveyPoint: point?.id,
-          })}`}
-          subtitle={
-            point?.name
-              ? `${isPointNameLong ? "" : "Survey point:"} ${point.name}`
-              : undefined
-          }
+          href={viewUploadButtonLink}
+          subtitle={surveyPointDisplayName}
         />
       </CardContent>
     </Card>

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -38,6 +38,11 @@ interface Metric {
   xs: GridProps["xs"];
 }
 
+interface SurveyPoint {
+  id: number;
+  name: string;
+}
+
 const metrics = (
   data: ReturnType<typeof calculateSondeDataMeanValues>
 ): Metric[] => [
@@ -77,11 +82,10 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
   const classes = useStyles();
   const [minDate, setMinDate] = useState<string>();
   const [maxDate, setMaxDate] = useState<string>();
-  const [pointId, setPointId] = useState<number>();
-  const [pointName, setPointName] = useState<string>();
+  const [point, setPoint] = useState<SurveyPoint>();
   const [sondeData, setSondeData] = useState<TimeSeriesData["sonde"]>();
   const meanValues = calculateSondeDataMeanValues(sondeData);
-  const isPointNameLong = pointName ? pointName.length > 24 : false;
+  const isPointNameLong = point?.name ? point.name.length > 24 : false;
 
   useEffect(() => {
     const getCardData = async () => {
@@ -96,7 +100,7 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
           maxDate: to,
           surveyPoint,
         } = head(uploadHistory) || {};
-        if (from && to && typeof surveyPoint?.id === "number") {
+        if (typeof surveyPoint?.id === "number") {
           const [data] = await timeSeriesRequest({
             siteId,
             pointId: surveyPoint.id.toString(),
@@ -107,8 +111,7 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
           });
           setMinDate(from);
           setMaxDate(to);
-          setPointName(surveyPoint.name);
-          setPointId(surveyPoint.id);
+          setPoint(surveyPoint);
           setSondeData(data?.sonde);
         }
       } catch (err) {
@@ -173,11 +176,11 @@ const WaterSamplingCard = ({ siteId }: WaterSamplingCardProps) => {
           href={`/sites/${siteId}${requests.generateUrlQueryParams({
             start: minDate,
             end: maxDate,
-            surveyPoint: pointId,
+            surveyPoint: point?.id,
           })}`}
           subtitle={
-            pointName
-              ? `${isPointNameLong ? "" : "Survey point:"} ${pointName}`
+            point?.name
+              ? `${isPointNameLong ? "" : "Survey point:"} ${point.name}`
               : undefined
           }
         />

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -35,7 +35,6 @@ const SiteDetails = ({
   classes,
   site,
   selectedSurveyPointId,
-  selectedSurveyPointName,
   featuredSurveyId,
   hasDailyData,
   surveys,
@@ -56,11 +55,7 @@ const SiteDetails = ({
     <Satellite liveData={liveData} maxMonthlyMean={maxMonthlyMean} />,
     <Sensor site={site} />,
     hasSondeData ? (
-      <WaterSamplingCard
-        siteId={`${site.id}`}
-        pointId={selectedSurveyPointId}
-        pointName={selectedSurveyPointName}
-      />
+      <WaterSamplingCard siteId={site.id.toString()} />
     ) : (
       <CoralBleaching dailyData={sortByDate(dailyData, "date").slice(-1)[0]} />
     ),
@@ -217,7 +212,6 @@ const styles = (theme: Theme) =>
 interface SiteDetailsIncomingProps {
   site: Site;
   selectedSurveyPointId?: string;
-  selectedSurveyPointName?: string;
   featuredSurveyId?: number | null;
   hasDailyData: boolean;
   surveys: SurveyListItem[];
@@ -230,7 +224,6 @@ SiteDetails.defaultProps = {
   featuredSurveyPoint: null,
   surveyDiveDate: null,
   featuredSurveyId: null,
-  selectedSurveyPointName: undefined,
 };
 
 type SiteDetailsProps = SiteDetailsIncomingProps & WithStyles<typeof styles>;

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -112,7 +112,7 @@ const Site = ({ match, classes }: SiteProps) => {
   const { id, liveData, dailyData, surveyPoints, polygon, timezone } =
     siteDetails || {};
   const querySurveyPointId = getQueryParam("surveyPoint");
-  const { id: selectedSurveyPointId, name: selectedSurveyPointName } =
+  const { id: selectedSurveyPointId } =
     findSurveyPointFromList(querySurveyPointId, surveyPoints) ||
     findClosestSurveyPoint(polygon, surveyPoints) ||
     {};
@@ -207,7 +207,6 @@ const Site = ({ match, classes }: SiteProps) => {
                 featuredImage: url,
               }}
               selectedSurveyPointId={selectedSurveyPointId}
-              selectedSurveyPointName={selectedSurveyPointName}
               featuredSurveyId={featuredSurveyId}
               hasDailyData={hasDailyData}
               surveys={surveyList}

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -112,8 +112,10 @@ const Site = ({ match, classes }: SiteProps) => {
   const { id, liveData, dailyData, surveyPoints, polygon, timezone } =
     siteDetails || {};
   const querySurveyPointId = getQueryParam("surveyPoint");
-  const { id: initialSurveyPointId, name: initialSurveyPointName } =
-    findSurveyPointFromList(querySurveyPointId, surveyPoints) || {};
+  const { id: selectedSurveyPointId, name: selectedSurveyPointName } =
+    findSurveyPointFromList(querySurveyPointId, surveyPoints) ||
+    findClosestSurveyPoint(polygon, surveyPoints) ||
+    {};
 
   const featuredMedia = sortByDate(surveyList, "diveDate", "desc").find(
     (survey) =>
@@ -126,9 +128,6 @@ const Site = ({ match, classes }: SiteProps) => {
     diveDate,
   } = featuredMedia || {};
   const { surveyPoint: featuredSurveyPoint, url } = featuredSurveyMedia || {};
-
-  const { id: closestSurveyPointId, name: closestSurveyPointName } =
-    findClosestSurveyPoint(polygon, surveyPoints) || {};
 
   const hasSpotterData = Boolean(liveData?.topTemperature);
 
@@ -155,11 +154,11 @@ const Site = ({ match, classes }: SiteProps) => {
       dispatch(
         siteTimeSeriesDataRangeRequest({
           siteId,
-          pointId: closestSurveyPointId ? `${closestSurveyPointId}` : undefined,
+          pointId: selectedSurveyPointId,
         })
       );
     }
-  }, [closestSurveyPointId, dispatch, id, siteId]);
+  }, [dispatch, id, selectedSurveyPointId, siteId]);
 
   useEffect(() => {
     if (id && oceanSenseConfig?.[id] && siteId === id.toString()) {
@@ -207,12 +206,8 @@ const Site = ({ match, classes }: SiteProps) => {
                 ...siteDetails,
                 featuredImage: url,
               }}
-              selectedSurveyPointId={
-                initialSurveyPointId || closestSurveyPointId
-              }
-              selectedSurveyPointName={
-                initialSurveyPointName || closestSurveyPointName
-              }
+              selectedSurveyPointId={selectedSurveyPointId}
+              selectedSurveyPointName={selectedSurveyPointName}
               featuredSurveyId={featuredSurveyId}
               hasDailyData={hasDailyData}
               surveys={surveyList}

--- a/packages/website/src/store/Sites/helpers.ts
+++ b/packages/website/src/store/Sites/helpers.ts
@@ -7,7 +7,6 @@ import {
   keyBy,
   pick,
   union,
-  some,
 } from "lodash";
 import { isBefore } from "../../helpers/dates";
 import { longDHW } from "../../helpers/siteUtils";
@@ -30,17 +29,12 @@ import {
   TimeSeriesDataRangeResponse,
   TimeSeriesDataRequestParams,
   TimeSeriesDataResponse,
-  TimeSeriesRange,
 } from "./types";
 
 export function getSiteNameAndRegion(site: Site) {
   const name = site.name || site.region?.name || null;
   const region = site.name ? site.region?.name : null;
   return { name, region };
-}
-
-export function siteHasSondeData(sondeDataRange?: TimeSeriesRange) {
-  return some(sondeDataRange, (range) => Boolean(range?.length));
 }
 
 export const constructTableData = (list: Site[]): TableRow[] => {

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -173,14 +173,14 @@ export type TimeSeriesRange = Partial<Record<Metrics, DataRange[]>>;
 
 export type TimeSeriesDataResponse = Record<
   Sources,
-  Record<MetricsKeys, SofarValue[]>
+  Partial<Record<MetricsKeys, SofarValue[]>>
 >;
 
 export type TimeSeriesData = Record<Sources, TimeSeries>;
 
 export type TimeSeriesDataRangeResponse = Record<
   Sources,
-  Record<MetricsKeys, DataRange[]>
+  Partial<Record<MetricsKeys, DataRange[]>>
 >;
 
 export type TimeSeriesDataRange = Partial<Record<Sources, TimeSeriesRange>>;

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -171,16 +171,14 @@ export type TimeSeries = Partial<Record<Metrics, SofarValue[]>>;
 
 export type TimeSeriesRange = Partial<Record<Metrics, DataRange[]>>;
 
-export type TimeSeriesDataResponse = Record<
-  Sources,
-  Partial<Record<MetricsKeys, SofarValue[]>>
+export type TimeSeriesDataResponse = Partial<
+  Record<Sources, Partial<Record<MetricsKeys, SofarValue[]>>>
 >;
 
-export type TimeSeriesData = Record<Sources, TimeSeries>;
+export type TimeSeriesData = Partial<Record<Sources, TimeSeries>>;
 
-export type TimeSeriesDataRangeResponse = Record<
-  Sources,
-  Partial<Record<MetricsKeys, DataRange[]>>
+export type TimeSeriesDataRangeResponse = Partial<
+  Record<Sources, Partial<Record<MetricsKeys, DataRange[]>>>
 >;
 
 export type TimeSeriesDataRange = Partial<Record<Sources, TimeSeriesRange>>;


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/638.
This PR is a prework for https://github.com/aqualinkorg/aqualink-app/issues/639.
If a source metric has no data, we simply do not return it instead of an empty array. Likewise, if we have a source with no data for each metric, then we do not return the source at all.

## TODOs
 - [x] Do not return sources with no data
 - [x] Fix API tests