### PR TITLE
Data upload history table tweaks

### DIFF
--- a/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
@@ -28,7 +28,7 @@ const tableHeaderTitles = [
   "SURVEY POINT",
   "SENSOR TYPE",
   "UPLOAD DATE",
-  "",
+  "DATA RANGE",
 ];
 
 const tableCellTypographyProps: TypographyProps = {

--- a/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
@@ -27,6 +27,7 @@ const tableHeaderTitles = [
   "SITE",
   "SURVEY POINT",
   "SENSOR TYPE",
+  "UPLOAD DATE",
   "",
 ];
 
@@ -42,6 +43,7 @@ const HistoryTable = ({ site, uploadHistory }: HistoryTableProps) => {
   const timezoneAbbreviation = timezone
     ? moment().tz(timezone).zoneAbbr()
     : undefined;
+  const dateFormat = "MM/DD/YYYY";
 
   const dataVizualizationButtonLink = (
     start: string,
@@ -76,7 +78,15 @@ const HistoryTable = ({ site, uploadHistory }: HistoryTableProps) => {
           </TableHead>
           <TableBody>
             {uploadHistory.map(
-              ({ id, file, surveyPoint, sensorType, minDate, maxDate }) => (
+              ({
+                id,
+                file,
+                surveyPoint,
+                sensorType,
+                minDate,
+                maxDate,
+                createdAt,
+              }) => (
                 <TableRow key={id}>
                   <TableCell component="th" scope="row">
                     <Typography {...tableCellTypographyProps}>
@@ -104,6 +114,11 @@ const HistoryTable = ({ site, uploadHistory }: HistoryTableProps) => {
                     </Typography>
                   </TableCell>
                   <TableCell>
+                    <Typography {...tableCellTypographyProps}>
+                      {moment(createdAt).format(dateFormat)}
+                    </Typography>
+                  </TableCell>
+                  <TableCell>
                     <Button
                       component={Link}
                       to={dataVizualizationButtonLink(
@@ -115,7 +130,8 @@ const HistoryTable = ({ site, uploadHistory }: HistoryTableProps) => {
                       variant="outlined"
                       color="primary"
                     >
-                      SEE DATA VISUALIZATION
+                      {moment(minDate).format(dateFormat)} -{" "}
+                      {moment(maxDate).format(dateFormat)}
                     </Button>
                   </TableCell>
                 </TableRow>


### PR DESCRIPTION
The purpose of this PR is to:
  - [x] Add an upload date column on the data upload history table
  - [x] Change visualization button label to `minDate - maxDate`
  - [x] Add `DATE RANGE` column name

### Screenshots
![Screenshot_20220207_113624](https://user-images.githubusercontent.com/64922890/152762713-9488deda-1ddd-426b-bb88-2907f024209f.png)
