### PR TITLE
Fix firebase spotter backfill error

### DIFF
--- a/packages/api/src/utils/site.utils.ts
+++ b/packages/api/src/utils/site.utils.ts
@@ -157,10 +157,15 @@ export const filterMetricDataByDate = (
 export const excludeSpotterData = (
   data: SpotterData,
   exclusionDates: ExclusionDates[],
-) =>
-  mapValues(data, (metricData) =>
+) => {
+  if (exclusionDates.length === 0) {
+    return data;
+  }
+
+  return mapValues(data, (metricData) =>
     filterMetricDataByDate(exclusionDates, metricData),
   );
+};
 
 export const getSite = async (
   siteId: number,

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -1,5 +1,5 @@
 import { Logger } from '@nestjs/common';
-import { has, times } from 'lodash';
+import { get, times } from 'lodash';
 import moment from 'moment';
 import { Connection, In, IsNull, Not, Repository } from 'typeorm';
 import Bluebird from 'bluebird';
@@ -179,19 +179,15 @@ export const addSpotterData = async (
             return DEFAULT_SPOTTER_DATA_VALUE;
           }
 
-          const sensorExclusionDates = has(
+          const sensorExclusionDates = get(
             sensorToExclusionDates,
             site.sensorId,
-          )
-            ? sensorToExclusionDates[site.sensorId]
-            : undefined;
+            [],
+          );
 
           // Fetch spotter and wave data from sofar
           return getSpotterData(site.sensorId, endDate, startDate).then(
-            (data) =>
-              sensorExclusionDates
-                ? excludeSpotterData(data, sensorExclusionDates)
-                : data,
+            (data) => excludeSpotterData(data, sensorExclusionDates),
           );
         },
         { concurrency: 100 },


### PR DESCRIPTION
The purpose of this PR is to fix the following error that occured on the spotter data backfill function on firebase:

```
A firebase error has occurred on firebase function scheduledSpotterTimeSeriesUpdate:
TypeError: Cannot read properties of undefined (reading 'sensorId')
```

This error occurs because there might be spotters with no exclusion dates, thus the

```typescript
exclusionDatesRepository.find({ where: { sensorId: source.sensorId } })
```
will return `[]`.
With the following approach, if a spotter has no exclusion dates, we simply return its data, otherwise we exclude the data that should be excluded.