### PR TITLE
OpenAPI doc fixes - explicitly mark a few fields as optional

### DIFF
--- a/packages/api/src/collections/dto/collection-data.dto.ts
+++ b/packages/api/src/collections/dto/collection-data.dto.ts
@@ -1,44 +1,44 @@
 /* eslint-disable camelcase */
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { Metric } from '../../time-series/metrics.entity';
 
 export class CollectionDataDto {
-  @ApiProperty({ example: 28.05 })
+  @ApiPropertyOptional({ example: 28.05 })
   [Metric.BOTTOM_TEMPERATURE]?: number;
 
-  @ApiProperty({ example: 29.05 })
+  @ApiPropertyOptional({ example: 29.05 })
   [Metric.TOP_TEMPERATURE]?: number;
 
-  @ApiProperty({ example: 29.13 })
+  @ApiPropertyOptional({ example: 29.13 })
   [Metric.SATELLITE_TEMPERATURE]?: number;
 
-  @ApiProperty({ example: 0 })
+  @ApiPropertyOptional({ example: 0 })
   [Metric.DHW]?: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiPropertyOptional({ example: 1 })
   [Metric.ALERT]?: number;
 
-  @ApiProperty({ example: 1 })
+  @ApiPropertyOptional({ example: 1 })
   [Metric.WEEKLY_ALERT]?: number;
 
-  @ApiProperty({ example: -0.101 })
+  @ApiPropertyOptional({ example: -0.101 })
   [Metric.SST_ANOMALY]?: number;
 
-  @ApiProperty({ example: 1.32 })
+  @ApiPropertyOptional({ example: 1.32 })
   [Metric.SIGNIFICANT_WAVE_HEIGHT]?: number;
 
-  @ApiProperty({ example: 2 })
+  @ApiPropertyOptional({ example: 2 })
   [Metric.WAVE_MEAN_DIRECTION]?: number;
 
-  @ApiProperty({ example: 12 })
+  @ApiPropertyOptional({ example: 12 })
   [Metric.WAVE_MEAN_PERIOD]?: number;
 
-  @ApiProperty({ example: 12 })
+  @ApiPropertyOptional({ example: 12 })
   [Metric.WAVE_PEAK_PERIOD]?: number;
 
-  @ApiProperty({ example: 153 })
+  @ApiPropertyOptional({ example: 153 })
   [Metric.WIND_DIRECTION]?: number;
 
-  @ApiProperty({ example: 10.4 })
+  @ApiPropertyOptional({ example: 10.4 })
   [Metric.WIND_SPEED]?: number;
 }

--- a/packages/api/src/sites/dto/live-data.dto.ts
+++ b/packages/api/src/sites/dto/live-data.dto.ts
@@ -1,3 +1,4 @@
+import { ApiPropertyOptional } from '@nestjs/swagger';
 import { TimeSeriesValueDto } from '../../time-series/dto/time-series-value.dto';
 import type { LatestData } from '../../time-series/latest-data.entity';
 import { SofarLiveData } from '../../utils/sofar.types';
@@ -5,18 +6,31 @@ import { SofarLiveData } from '../../utils/sofar.types';
 export class SofarLiveDataDto implements SofarLiveData {
   site: { id: number };
   latestData?: LatestData[];
+  @ApiPropertyOptional({ example: 1 })
   dailyAlertLevel?: number;
+  @ApiPropertyOptional({ example: 1 })
   weeklyAlertLevel?: number;
+  @ApiPropertyOptional({ example: 1 })
   bottomTemperature?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   topTemperature?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   satelliteTemperature?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   degreeHeatingDays?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   waveHeight?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   waveMeanDirection?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   waveMeanPeriod?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   windSpeed?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   windDirection?: TimeSeriesValueDto;
+  @ApiPropertyOptional({ example: 1 })
   sstAnomaly?: number;
+  @ApiPropertyOptional({ example: 1 })
   spotterPosition?: {
     latitude: TimeSeriesValueDto;
     longitude: TimeSeriesValueDto;

--- a/packages/api/src/sites/sites.entity.ts
+++ b/packages/api/src/sites/sites.entity.ts
@@ -12,7 +12,7 @@ import {
   ManyToMany,
 } from 'typeorm';
 import { Expose } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { Region } from '../regions/regions.entity';
 import { VideoStream } from './video-streams.entity';
 import { Survey } from '../surveys/surveys.entity';
@@ -104,12 +104,14 @@ export class Site {
   @ManyToMany(() => User, (user) => user.administeredSites)
   admins: User[];
 
+  @ApiPropertyOptional()
   @OneToMany(() => Survey, (survey) => survey.site)
   surveys: Survey[];
 
   @OneToOne(() => SiteApplication, (siteApplication) => siteApplication.site)
   siteApplication?: SiteApplication;
 
+  @ApiPropertyOptional()
   @OneToMany(
     () => HistoricalMonthlyMean,
     (historicalMonthlyMean) => historicalMonthlyMean.site,

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -220,9 +220,20 @@ export class SitesService {
       'siteApplication',
     ]);
 
+    // Typeorm returns undefined instead of [] for
+    // OneToMany relations, so we fix it to match OpenAPI specs:
+    const surveys = site.surveys || [];
+    const historicalMonthlyMean = site.historicalMonthlyMean || [];
+
     const videoStream = await this.checkVideoStream(site);
 
-    return { ...site, videoStream, applied: site.applied };
+    return {
+      ...site,
+      surveys,
+      historicalMonthlyMean,
+      videoStream,
+      applied: site.applied,
+    };
   }
 
   async update(id: number, updateSiteDto: UpdateSiteDto): Promise<Site> {

--- a/packages/api/src/users/users.entity.ts
+++ b/packages/api/src/users/users.entity.ts
@@ -9,7 +9,11 @@ import {
   ManyToMany,
   JoinTable,
 } from 'typeorm';
-import { ApiHideProperty, ApiProperty } from '@nestjs/swagger';
+import {
+  ApiHideProperty,
+  ApiProperty,
+  ApiPropertyOptional,
+} from '@nestjs/swagger';
 import { Exclude } from 'class-transformer';
 import { Site } from '../sites/sites.entity';
 import { ApiPointProperty } from '../docs/api-properties';
@@ -74,6 +78,7 @@ export class User {
   @Column({ nullable: true, type: 'character varying' })
   imageUrl: string | null;
 
+  @ApiPropertyOptional()
   @ManyToMany(() => Site, (site) => site.admins, { cascade: true })
   @JoinTable()
   administeredSites: Site[];

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -104,13 +104,15 @@ export class UsersService {
       .where('users.id = :id', { id: req.user.id })
       .getOne();
 
-    return user!.administeredSites.map((site) => {
-      return {
-        ...site,
-        siteApplication: undefined,
-        applied: site.applied,
-      };
-    });
+    return (
+      user!.administeredSites.map((site) => {
+        return {
+          ...site,
+          siteApplication: undefined,
+          applied: site.applied,
+        };
+      }) || []
+    );
   }
 
   async findByEmail(email: string): Promise<User | undefined> {

--- a/packages/api/src/workers/dailyData.test.ts
+++ b/packages/api/src/workers/dailyData.test.ts
@@ -33,7 +33,7 @@ test('It processes Sofar API for daily data.', async () => {
     maxBottomTemperature: undefined,
     avgBottomTemperature: undefined,
     topTemperature: undefined,
-    satelliteTemperature: 10.7700004577637,
+    satelliteTemperature: 11,
     degreeHeatingDays: 0,
     minWaveHeight: 1.18205952644348,
     maxWaveHeight: 1.98118472099304,


### PR DESCRIPTION
While building the aqualink-sdk, we realized that the OpenAPI documentation was marking fields as required when they are not.

This is a first pass at resolving required fields mismatch 