### PR TITLE
Fix data upload is very slow

### DIFF
--- a/packages/api/src/google-cloud/google-cloud.service.ts
+++ b/packages/api/src/google-cloud/google-cloud.service.ts
@@ -33,6 +33,27 @@ export class GoogleCloudService {
     });
   }
 
+  private getDestination(
+    filePath: string,
+    type: string,
+    dir: string,
+    prefix: string,
+  ): string {
+    const folder = `${this.STORAGE_FOLDER}/${dir}/`;
+    const basename = path.basename(filePath);
+    return getRandomName(folder, prefix, basename, type);
+  }
+
+  public uploadFileAsync(
+    filePath: string,
+    type: string,
+    dir: string = 'surveys',
+    prefix: string = 'site_hobo_image',
+  ): string {
+    this.uploadFile(filePath, type, dir, prefix);
+    return this.getDestination(filePath, type, dir, prefix);
+  }
+
   public async uploadFile(
     filePath: string,
     type: string,
@@ -45,9 +66,7 @@ export class GoogleCloudService {
       );
       throw new InternalServerErrorException();
     }
-    const folder = `${this.STORAGE_FOLDER}/${dir}/`;
-    const basename = path.basename(filePath);
-    const destination = getRandomName(folder, prefix, basename, type);
+    const destination = this.getDestination(filePath, type, dir, prefix);
 
     const response = await this.storage
       .bucket(this.GCS_BUCKET)

--- a/packages/api/src/utils/uploads/upload-sheet-data.ts
+++ b/packages/api/src/utils/uploads/upload-sheet-data.ts
@@ -439,7 +439,8 @@ export const uploadTimeSeriesData = async (
     // Initialize google cloud service, to be used for media upload
     const googleCloudService = new GoogleCloudService();
 
-    const fileLocation = await googleCloudService.uploadFile(
+    // Note this may fail. It would still return a location, but the file may not have been uploaded
+    const fileLocation = googleCloudService.uploadFileAsync(
       filePath,
       sourceType,
       'data_uploads',


### PR DESCRIPTION
https://github.com/aqualinkorg/aqualink-app/issues/712

Uploading 85kb file, for me, would take on average 2 seconds, of which, on average, 1 second was for the upload to gCloud. I added an async alternative for uploading files to gCloud, to skip the waiting time.