### PR TITLE
Run upload request in the background

### DIFF
--- a/packages/api/src/time-series/time-series.service.ts
+++ b/packages/api/src/time-series/time-series.service.ts
@@ -124,6 +124,8 @@ export class TimeSeriesService {
     files: Express.Multer.File[],
     failOnWarning?: boolean,
   ) {
+    // Remove before merge. Just adds a delay for better debugging
+    await new Promise((res) => setTimeout(res, 10000));
     if (!sensor || !Object.values(SourceType).includes(sensor)) {
       throw new BadRequestException(
         `Field 'sensor' is required and must have one of the following values: ${Object.values(

--- a/packages/website/src/common/InfoWithAction/index.tsx
+++ b/packages/website/src/common/InfoWithAction/index.tsx
@@ -1,0 +1,27 @@
+import { Button, Typography } from "@material-ui/core";
+import React from "react";
+
+interface InfoWithActionProps {
+  message: string;
+  actionText: string;
+  action: () => void;
+}
+
+const InfoWithAction = ({
+  message,
+  actionText,
+  action,
+}: InfoWithActionProps) => {
+  return (
+    <>
+      <Typography variant="h3" style={{ textAlign: "center" }} color="primary">
+        {message}
+      </Typography>
+      <Button color="primary" onClick={action}>
+        {actionText}
+      </Button>
+    </>
+  );
+};
+
+export default InfoWithAction;

--- a/packages/website/src/common/StatusSnackbar/index.tsx
+++ b/packages/website/src/common/StatusSnackbar/index.tsx
@@ -60,6 +60,7 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...(hasMessage ? { padding: 0 } : {}),
   }),
   button: {
+    backgroundColor: "#3d8a27",
     marginLeft: theme.spacing(1.5),
   },
 }));

--- a/packages/website/src/common/StatusSnackbar/index.tsx
+++ b/packages/website/src/common/StatusSnackbar/index.tsx
@@ -60,7 +60,6 @@ const useStyles = makeStyles((theme: Theme) => ({
     ...(hasMessage ? { padding: 0 } : {}),
   }),
   button: {
-    backgroundColor: "#3d8a27",
     marginLeft: theme.spacing(1.5),
   },
 }));

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -109,6 +109,7 @@ const Site = ({ match, classes }: SiteProps) => {
   const siteId = match.params.id;
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
   const querySurveyPointId = getQueryParam("surveyPoint");
+  const refresh = getQueryParam("refresh");
   const { id: selectedSurveyPointId } =
     findSurveyPointFromList(querySurveyPointId, surveyPoints) || {};
 
@@ -135,6 +136,19 @@ const Site = ({ match, classes }: SiteProps) => {
     : undefined;
 
   const isLoading = !siteWithFeaturedImage;
+
+  useEffect(() => {
+    if (refresh === "true") {
+      dispatch(clearTimeSeriesDataRange());
+      dispatch(clearTimeSeriesData());
+      dispatch(clearOceanSenseData());
+
+      dispatch(siteRequest(siteId));
+      dispatch(liveDataRequest(siteId));
+      dispatch(surveysRequest(siteId));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [refresh]);
 
   // Fetch site and surveys
   useEffect(() => {

--- a/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {
   Card,
   CardHeader,
+  CircularProgress,
   Grid,
   IconButton,
   makeStyles,
@@ -9,25 +10,42 @@ import {
   Tooltip,
   Typography,
 } from "@material-ui/core";
+import { Alert } from "@material-ui/lab";
+import { grey } from "@material-ui/core/colors";
 import CloseIcon from "@material-ui/icons/HighlightOffOutlined";
 import FileIcon from "@material-ui/icons/InsertDriveFileOutlined";
+import classNames from "classnames";
 
+import { useSelector } from "react-redux";
 import { pluralize } from "../../../helpers/stringUtils";
+import {
+  uploadsErrorSelector,
+  uploadsInProgressSelector,
+} from "../../../store/uploads/uploadsSlice";
+
+const CIRCULAR_PROGRESS_SIZE = 36;
 
 const FileList = ({ files, onFileDelete }: FileListProps) => {
   const classes = useStyles();
+  const errors = useSelector(uploadsErrorSelector) as Record<
+    string,
+    string | null
+  >;
+  const loading = useSelector(uploadsInProgressSelector);
 
   return (
     <Grid container spacing={2} className={classes.root}>
       <Grid item xs={12}>
         <Typography gutterBottom variant="h6">
           {files.length} {pluralize(files.length, "file")}{" "}
+          {loading ? "uploading" : "to be uploaded"}
         </Typography>
       </Grid>
       {files.map(({ name }) => (
         <Grid item key={name} lg={4} md={6} xs={12}>
           <Card className={classes.card} variant="outlined">
             <CardHeader
+              className={classNames({ [classes.loading]: loading })}
               classes={{ content: classes.cardContent }}
               title={
                 <Typography
@@ -41,14 +59,24 @@ const FileList = ({ files, onFileDelete }: FileListProps) => {
               }
               action={
                 <Tooltip title="Remove file" arrow placement="top">
-                  <IconButton onClick={() => onFileDelete(name)}>
+                  <IconButton
+                    disabled={loading}
+                    onClick={() => onFileDelete(name)}
+                  >
                     <CloseIcon />
                   </IconButton>
                 </Tooltip>
               }
               avatar={<FileIcon className={classes.fileIcon} />}
             />
+            {loading && (
+              <CircularProgress
+                size={CIRCULAR_PROGRESS_SIZE}
+                className={classes.circularProgress}
+              />
+            )}
           </Card>
+          {errors?.[name] && <Alert severity="error">{errors[name]}</Alert>}
         </Grid>
       ))}
     </Grid>
@@ -73,6 +101,19 @@ const useStyles = makeStyles((theme: Theme) => ({
   },
   fileIcon: {
     color: theme.palette.text.secondary,
+  },
+  loading: {
+    opacity: 0.5,
+    pointerEvents: "none",
+    cursor: "default",
+  },
+  circularProgress: {
+    position: "absolute",
+    top: "50%",
+    left: "50%",
+    marginTop: -CIRCULAR_PROGRESS_SIZE / 2,
+    marginLeft: -CIRCULAR_PROGRESS_SIZE / 2,
+    color: grey[500],
   },
 }));
 

--- a/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import {
   Card,
   CardHeader,
-  CircularProgress,
   Grid,
   IconButton,
   makeStyles,
@@ -10,17 +9,12 @@ import {
   Tooltip,
   Typography,
 } from "@material-ui/core";
-import { Alert } from "@material-ui/lab";
-import { grey } from "@material-ui/core/colors";
 import CloseIcon from "@material-ui/icons/HighlightOffOutlined";
 import FileIcon from "@material-ui/icons/InsertDriveFileOutlined";
-import classNames from "classnames";
 
 import { pluralize } from "../../../helpers/stringUtils";
 
-const CIRCULAR_PROGRESS_SIZE = 36;
-
-const FileList = ({ files, loading, errors, onFileDelete }: FileListProps) => {
+const FileList = ({ files, onFileDelete }: FileListProps) => {
   const classes = useStyles();
 
   return (
@@ -28,14 +22,12 @@ const FileList = ({ files, loading, errors, onFileDelete }: FileListProps) => {
       <Grid item xs={12}>
         <Typography gutterBottom variant="h6">
           {files.length} {pluralize(files.length, "file")}{" "}
-          {loading ? "uploading" : "to be uploaded"}
         </Typography>
       </Grid>
       {files.map(({ name }) => (
         <Grid item key={name} lg={4} md={6} xs={12}>
           <Card className={classes.card} variant="outlined">
             <CardHeader
-              className={classNames({ [classes.loading]: loading })}
               classes={{ content: classes.cardContent }}
               title={
                 <Typography
@@ -49,24 +41,14 @@ const FileList = ({ files, loading, errors, onFileDelete }: FileListProps) => {
               }
               action={
                 <Tooltip title="Remove file" arrow placement="top">
-                  <IconButton
-                    disabled={loading}
-                    onClick={() => onFileDelete(name)}
-                  >
+                  <IconButton onClick={() => onFileDelete(name)}>
                     <CloseIcon />
                   </IconButton>
                 </Tooltip>
               }
               avatar={<FileIcon className={classes.fileIcon} />}
             />
-            {loading && (
-              <CircularProgress
-                size={CIRCULAR_PROGRESS_SIZE}
-                className={classes.circularProgress}
-              />
-            )}
           </Card>
-          {errors?.[name] && <Alert severity="error">{errors[name]}</Alert>}
         </Grid>
       ))}
     </Grid>
@@ -92,25 +74,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   fileIcon: {
     color: theme.palette.text.secondary,
   },
-  loading: {
-    opacity: 0.5,
-    pointerEvents: "none",
-    cursor: "default",
-  },
-  circularProgress: {
-    position: "absolute",
-    top: "50%",
-    left: "50%",
-    marginTop: -CIRCULAR_PROGRESS_SIZE / 2,
-    marginLeft: -CIRCULAR_PROGRESS_SIZE / 2,
-    color: grey[500],
-  },
 }));
 
 interface FileListProps {
   files: File[];
-  errors: Record<string, string | null>;
-  loading: boolean;
   onFileDelete: (name: string) => void;
 }
 

--- a/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
@@ -21,6 +21,7 @@ import { pluralize } from "../../../helpers/stringUtils";
 import {
   uploadsErrorSelector,
   uploadsInProgressSelector,
+  uploadsResponseSelector,
 } from "../../../store/uploads/uploadsSlice";
 
 const CIRCULAR_PROGRESS_SIZE = 36;
@@ -32,6 +33,7 @@ const FileList = ({ files, onFileDelete }: FileListProps) => {
     string | null
   >;
   const loading = useSelector(uploadsInProgressSelector);
+  const uploadResponse = useSelector(uploadsResponseSelector);
 
   return (
     <Grid container spacing={2} className={classes.root}>
@@ -77,6 +79,10 @@ const FileList = ({ files, onFileDelete }: FileListProps) => {
             )}
           </Card>
           {errors?.[name] && <Alert severity="error">{errors[name]}</Alert>}
+          {!loading &&
+            !!uploadResponse?.some((x) => x.file === name && !x.error) && (
+              <Alert severity="success">File uploaded</Alert>
+            )}
         </Grid>
       ))}
     </Grid>

--- a/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Grid,
   makeStyles,
@@ -14,8 +14,10 @@ import {
 import AddIcon from "@material-ui/icons/Add";
 import { Link } from "react-router-dom";
 
+import { useSelector } from "react-redux";
 import { Site, Sources } from "../../../store/Sites/types";
 import NewSurveyPointDialog from "../../../common/NewSurveyPointDialog";
+import { uploadsTargetSelector } from "../../../store/uploads/uploadsSlice";
 
 interface SelectOption {
   id: number;
@@ -39,6 +41,7 @@ const Selectors = ({
   onPointChange,
 }: SelectorsProps) => {
   const classes = useStyles();
+  const uploadsTarget = useSelector(uploadsTargetSelector);
   const pointOptions = site.surveyPoints;
   const [selectedPointIndex, setSelectedPointIndex] = useState<number>();
   const [selectedSensorIndex, setSelectedSensorIndex] = useState<number>();
@@ -127,6 +130,18 @@ const Selectors = ({
   };
 
   const handleNewPointDialogClose = () => setIsNewPointDialogOpen(false);
+
+  useEffect(() => {
+    if (uploadsTarget) {
+      const newPointIndex = uploadsTarget.selectedPoint - 1;
+      const newSensorIndex = SENSOR_TYPES.findIndex(
+        (x) => x.name === uploadsTarget.selectedSensor
+      );
+      setSelectedPointIndex(newPointIndex);
+      setSelectedSensorIndex(newSensorIndex);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [uploadsTarget]);
 
   return (
     <>

--- a/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
@@ -139,6 +139,9 @@ const Selectors = ({
       );
       setSelectedPointIndex(newPointIndex);
       setSelectedSensorIndex(newSensorIndex);
+    } else {
+      setSelectedPointIndex(undefined);
+      setSelectedSensorIndex(undefined);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [uploadsTarget]);

--- a/packages/website/src/routes/SiteRoutes/UploadData/UploadButton.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/UploadButton.tsx
@@ -32,7 +32,7 @@ const useStyles = makeStyles(() => ({
 
 interface UploadButtonProps {
   loading: boolean;
-  onUpload: () => Promise<void>;
+  onUpload: () => any;
 }
 
 export default UploadButton;

--- a/packages/website/src/routes/SiteRoutes/UploadData/UploadWarnings.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/UploadWarnings.tsx
@@ -35,7 +35,7 @@ const DetailsDialog = ({ open, details, onClose }: DetailsDialogProps) => {
       <DialogContent>
         <List>
           {details.map(({ file, ignoredHeaders }, index) =>
-            ignoredHeaders.length ? (
+            ignoredHeaders?.length ? (
               // eslint-disable-next-line react/no-array-index-key
               <ListItem key={`${file}-${index}`}>
                 <ListItemAvatar>

--- a/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Container, makeStyles, Theme } from "@material-ui/core";
 import { RouteComponentProps, useHistory } from "react-router-dom";
 import { DropzoneProps } from "react-dropzone";
-import { uniqBy, reduce, mapValues } from "lodash";
+import { uniqBy } from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import NavBar from "../../../common/NavBar";
 import Header from "./Header";
@@ -10,7 +10,6 @@ import Selectors from "./Selectors";
 import DropZone from "./DropZone";
 import FileList from "./FileList";
 import HistoryTable from "./HistoryTable";
-import StatusSnackbar from "../../../common/StatusSnackbar";
 import UploadButton from "./UploadButton";
 import { useSiteRequest } from "../../../hooks/useSiteRequest";
 import { SiteUploadHistory, Sources } from "../../../store/Sites/types";
@@ -21,8 +20,14 @@ import { userInfoSelector } from "../../../store/User/userSlice";
 import siteServices from "../../../services/siteServices";
 import { setSelectedSite } from "../../../store/Sites/selectedSiteSlice";
 import { getAxiosErrorMessage } from "../../../helpers/errors";
+import StatusSnackbar from "../../../common/StatusSnackbar";
 
-const UploadData = ({ match, onSuccess }: MatchProps) => {
+const UploadData = ({
+  match,
+  onSuccess,
+  setUploadError,
+  setUploadLoading,
+}: MatchProps) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const history = useHistory();
@@ -32,15 +37,10 @@ const UploadData = ({ match, onSuccess }: MatchProps) => {
   const [selectedSensor, setSelectedSensor] = useState<Sources>();
   const [selectedPoint, setSelectedPoint] = useState<number>();
   const [files, setFiles] = useState<File[]>([]);
-  const [uploadLoading, setUploadLoading] = useState(false);
-  const [uploadError, setUploadError] = useState<string>();
-  const [deleteError, setDeleteError] = useState<string>();
-  const [uploadErrors, setUploadErrors] = useState<
-    Record<string, string | null>
-  >({});
+  const [isUploadHistoryErrored, setIsUploadHistoryErrored] = useState(false);
+  const [deleteError, setDeleteError] = useState<string | undefined>();
   const [uploadHistory, setUploadHistory] = useState<SiteUploadHistory>([]);
   const [isUploadHistoryLoading, setIsUploadHistoryLoading] = useState(false);
-  const [isUploadHistoryErrored, setIsUploadHistoryErrored] = useState(false);
   const loading = !site || siteLoading || isUploadHistoryLoading;
 
   const onCompletedSelection = () => setIsSelectionCompleted(true);
@@ -53,26 +53,16 @@ const UploadData = ({ match, onSuccess }: MatchProps) => {
   ) => {
     const newFiles = uniqBy([...files, ...acceptedFiles], "name");
     setFiles(newFiles);
-    setUploadErrors(
-      reduce(
-        newFiles,
-        (accum, { name }) => ({ ...accum, [name]: null }),
-        uploadErrors
-      )
-    );
   };
 
-  const clearUploadErrors = () =>
-    setUploadErrors(mapValues(uploadErrors, () => null));
-
-  const onStatusSnackbarClose = () => setUploadError(undefined);
   const onHistorySnackbarClose = () => setIsUploadHistoryErrored(false);
   const onDeleteSnackbarClose = () => setDeleteError(undefined);
 
   const onUpload = async () => {
     setUploadLoading(true);
     setUploadError(undefined);
-    clearUploadErrors();
+    // eslint-disable-next-line fp/no-mutating-methods
+    history.push(`/sites/${site?.id}`);
     try {
       if (
         typeof site?.id === "number" &&
@@ -90,23 +80,15 @@ const UploadData = ({ match, onSuccess }: MatchProps) => {
             token,
             false
           );
-        // Clear redux selected site before we land on the site page,
-        // so that we fetch the updated data.
-        dispatch(setSelectedSite());
-        // eslint-disable-next-line fp/no-mutating-methods
-        history.push(`/sites/${site.id}`);
-        onSuccess(uploadResponse);
+        setUploadLoading(false);
+        onSuccess(uploadResponse, site.id);
       }
     } catch (err) {
       setUploadLoading(false);
       const errorMessage = getAxiosErrorMessage(err);
       const [maybeFileName, ...maybeFileError] = errorMessage?.split(": ");
-      if (maybeFileName in uploadErrors) {
-        // File specific error
-        setUploadErrors({
-          ...uploadErrors,
-          [maybeFileName]: maybeFileError.join(": "),
-        });
+      if (maybeFileName) {
+        setUploadError(maybeFileError.join(": "));
       } else {
         // General error
         setUploadError(errorMessage || "Something went wrong");
@@ -162,12 +144,6 @@ const UploadData = ({ match, onSuccess }: MatchProps) => {
         severity="error"
       />
       <StatusSnackbar
-        open={!!uploadError}
-        message={uploadError}
-        handleClose={onStatusSnackbarClose}
-        severity="error"
-      />
-      <StatusSnackbar
         open={!!deleteError}
         message={deleteError}
         handleClose={onDeleteSnackbarClose}
@@ -184,17 +160,12 @@ const UploadData = ({ match, onSuccess }: MatchProps) => {
             onPointChange={setSelectedPoint}
           />
           {isSelectionCompleted && (
-            <DropZone disabled={uploadLoading} onFilesDrop={onFilesDrop} />
+            <DropZone disabled={false} onFilesDrop={onFilesDrop} />
           )}
           {files.length > 0 && (
             <>
-              <FileList
-                files={files}
-                errors={uploadErrors}
-                loading={uploadLoading}
-                onFileDelete={onFileDelete}
-              />
-              <UploadButton loading={uploadLoading} onUpload={onUpload} />
+              <FileList files={files} onFileDelete={onFileDelete} />
+              <UploadButton loading={false} onUpload={onUpload} />
             </>
           )}
           <HistoryTable
@@ -216,7 +187,9 @@ const useStyles = makeStyles((theme: Theme) => ({
 }));
 
 interface MatchProps extends RouteComponentProps<{ id: string }> {
-  onSuccess: (arg: UploadTimeSeriesResult[]) => void;
+  onSuccess: (arg: UploadTimeSeriesResult[], currSiteId?: number) => void;
+  setUploadError: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setUploadLoading: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default UploadData;

--- a/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
@@ -1,8 +1,13 @@
 import React, { useState, useEffect } from "react";
-import { Container, makeStyles, Theme } from "@material-ui/core";
+import {
+  Button,
+  Container,
+  makeStyles,
+  Theme,
+  Typography,
+} from "@material-ui/core";
 import { RouteComponentProps, useHistory } from "react-router-dom";
 import { DropzoneProps } from "react-dropzone";
-import { uniqBy } from "lodash";
 import { useDispatch, useSelector } from "react-redux";
 import NavBar from "../../../common/NavBar";
 import Header from "./Header";
@@ -13,87 +18,71 @@ import HistoryTable from "./HistoryTable";
 import UploadButton from "./UploadButton";
 import { useSiteRequest } from "../../../hooks/useSiteRequest";
 import { SiteUploadHistory, Sources } from "../../../store/Sites/types";
-import uploadServices, {
-  UploadTimeSeriesResult,
-} from "../../../services/uploadServices";
+import uploadServices from "../../../services/uploadServices";
 import { userInfoSelector } from "../../../store/User/userSlice";
 import siteServices from "../../../services/siteServices";
 import { setSelectedSite } from "../../../store/Sites/selectedSiteSlice";
 import { getAxiosErrorMessage } from "../../../helpers/errors";
 import StatusSnackbar from "../../../common/StatusSnackbar";
+import {
+  addUploadsFiles,
+  clearUploadsError,
+  clearUploadsFiles,
+  clearUploadsTarget,
+  removeUploadsFiles,
+  setUploadsTarget,
+  uploadFiles,
+  uploadsFilesSelector,
+  uploadsInProgressSelector,
+  uploadsTargetSelector,
+} from "../../../store/uploads/uploadsSlice";
 
-const UploadData = ({
-  match,
-  onSuccess,
-  setUploadError,
-  setUploadLoading,
-}: MatchProps) => {
+const UploadData = ({ match }: RouteComponentProps<{ id: string }>) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const history = useHistory();
   const { token } = useSelector(userInfoSelector) || {};
   const { site, siteLoading } = useSiteRequest(match.params.id);
-  const [isSelectionCompleted, setIsSelectionCompleted] = useState(false);
+  // const [isSelectionCompleted, setIsSelectionCompleted] = useState(false);
   const [selectedSensor, setSelectedSensor] = useState<Sources>();
   const [selectedPoint, setSelectedPoint] = useState<number>();
-  const [files, setFiles] = useState<File[]>([]);
+  // const [files, setFiles] = useState<File[]>([]);
+  const files = useSelector(uploadsFilesSelector);
+  const uploadTarget = useSelector(uploadsTargetSelector);
+  const uploadLoading = useSelector(uploadsInProgressSelector);
   const [isUploadHistoryErrored, setIsUploadHistoryErrored] = useState(false);
   const [deleteError, setDeleteError] = useState<string | undefined>();
   const [uploadHistory, setUploadHistory] = useState<SiteUploadHistory>([]);
   const [isUploadHistoryLoading, setIsUploadHistoryLoading] = useState(false);
+  const [shouldShowPage, setShouldShowPage] = useState(true);
   const loading = !site || siteLoading || isUploadHistoryLoading;
 
-  const onCompletedSelection = () => setIsSelectionCompleted(true);
+  const onCompletedSelection = () => {
+    if (site?.id && selectedPoint && selectedSensor) {
+      dispatch(
+        setUploadsTarget({ siteId: site?.id, selectedSensor, selectedPoint })
+      );
+    }
+  };
 
-  const onFileDelete = (name: string) =>
-    setFiles(files.filter((file) => file.name !== name));
+  const onFileDelete = (name: string) => {
+    dispatch(removeUploadsFiles(name));
+    // setFiles(files.filter((file) => file.name !== name));
+  };
 
   const onFilesDrop: DropzoneProps["onDropAccepted"] = (
     acceptedFiles: File[]
   ) => {
-    const newFiles = uniqBy([...files, ...acceptedFiles], "name");
-    setFiles(newFiles);
+    dispatch(addUploadsFiles(acceptedFiles));
+    // const newFiles = uniqBy([...files, ...acceptedFiles], "name");
+    // setFiles(newFiles);
   };
 
   const onHistorySnackbarClose = () => setIsUploadHistoryErrored(false);
   const onDeleteSnackbarClose = () => setDeleteError(undefined);
 
-  const onUpload = async () => {
-    setUploadLoading(true);
-    setUploadError(undefined);
-    // eslint-disable-next-line fp/no-mutating-methods
-    history.push(`/sites/${site?.id}`);
-    try {
-      if (
-        typeof site?.id === "number" &&
-        typeof selectedPoint === "number" &&
-        selectedSensor
-      ) {
-        const data = new FormData();
-        files.forEach((file) => data.append("files", file));
-        data.append("sensor", selectedSensor);
-        const { data: uploadResponse } =
-          await uploadServices.uploadTimeSeriesData(
-            data,
-            site.id,
-            selectedPoint,
-            token,
-            false
-          );
-        setUploadLoading(false);
-        onSuccess(uploadResponse, site.id);
-      }
-    } catch (err) {
-      setUploadLoading(false);
-      const errorMessage = getAxiosErrorMessage(err);
-      const [maybeFileName, ...maybeFileError] = errorMessage?.split(": ");
-      if (maybeFileName) {
-        setUploadError(maybeFileError.join(": "));
-      } else {
-        // General error
-        setUploadError(errorMessage || "Something went wrong");
-      }
-    }
+  const onUpload = () => {
+    dispatch(uploadFiles(token));
   };
 
   const onDelete = async (ids: number[]) => {
@@ -134,6 +123,37 @@ const UploadData = ({
     getUploadHistory();
   }, [site]);
 
+  useEffect(() => {
+    if (
+      !uploadLoading &&
+      site?.id &&
+      uploadTarget?.siteId &&
+      uploadTarget.siteId !== site.id
+    ) {
+      dispatch(clearUploadsFiles);
+      dispatch(clearUploadsTarget);
+      dispatch(clearUploadsError);
+    }
+  }, [dispatch, site, uploadTarget, uploadLoading]);
+
+  // on component mount
+  useEffect(() => {
+    if (
+      uploadLoading &&
+      site?.id &&
+      uploadTarget?.siteId &&
+      uploadTarget.siteId !== site.id
+    ) {
+      setShouldShowPage(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const onGoBackClick = () => {
+    // eslint-disable-next-line fp/no-mutating-methods
+    history.push(`/sites/${site?.id}`);
+  };
+
   return (
     <>
       <NavBar searchLocation={false} loading={loading} />
@@ -150,30 +170,45 @@ const UploadData = ({
         severity="error"
       />
 
-      {site && (
-        <Container className={classes.root}>
-          <Header site={site} />
-          <Selectors
-            site={site}
-            onCompletedSelection={onCompletedSelection}
-            onSensorChange={setSelectedSensor}
-            onPointChange={setSelectedPoint}
-          />
-          {isSelectionCompleted && (
-            <DropZone disabled={false} onFilesDrop={onFilesDrop} />
-          )}
-          {files.length > 0 && (
-            <>
-              <FileList files={files} onFileDelete={onFileDelete} />
-              <UploadButton loading={false} onUpload={onUpload} />
-            </>
-          )}
-          <HistoryTable
-            site={site}
-            uploadHistory={uploadHistory}
-            onDelete={onDelete}
-          />
-        </Container>
+      {shouldShowPage ? (
+        site && (
+          <Container className={classes.root}>
+            <Header site={site} />
+            <Selectors
+              site={site}
+              onCompletedSelection={onCompletedSelection}
+              onSensorChange={setSelectedSensor}
+              onPointChange={setSelectedPoint}
+            />
+            {!!uploadTarget && (
+              <DropZone disabled={uploadLoading} onFilesDrop={onFilesDrop} />
+            )}
+            {files.length > 0 && (
+              <>
+                <FileList files={files} onFileDelete={onFileDelete} />
+                <UploadButton loading={uploadLoading} onUpload={onUpload} />
+              </>
+            )}
+            <HistoryTable
+              site={site}
+              uploadHistory={uploadHistory}
+              onDelete={onDelete}
+            />
+          </Container>
+        )
+      ) : (
+        <>
+          <Typography
+            variant="h3"
+            style={{ textAlign: "center" }}
+            color="primary"
+          >
+            An upload is already loading. Please wait.
+          </Typography>
+          <Button color="primary" onClick={onGoBackClick}>
+            Go back!
+          </Button>
+        </>
       )}
     </>
   );
@@ -185,11 +220,5 @@ const useStyles = makeStyles((theme: Theme) => ({
     marginBottom: theme.spacing(3),
   },
 }));
-
-interface MatchProps extends RouteComponentProps<{ id: string }> {
-  onSuccess: (arg: UploadTimeSeriesResult[], currSiteId?: number) => void;
-  setUploadError: React.Dispatch<React.SetStateAction<string | undefined>>;
-  setUploadLoading: React.Dispatch<React.SetStateAction<boolean>>;
-}
 
 export default UploadData;

--- a/packages/website/src/routes/SiteRoutes/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/index.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Switch, Route, useHistory } from "react-router-dom";
-import { useDispatch } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import Site from "./Site";
 import SiteApplication from "./SiteApplication";
 import SitesList from "./SitesList";
@@ -11,6 +11,13 @@ import StatusSnackbar from "../../common/StatusSnackbar";
 import UploadWarnings from "./UploadData/UploadWarnings";
 import { UploadTimeSeriesResult } from "../../services/uploadServices";
 import { setSelectedSite } from "../../store/Sites/selectedSiteSlice";
+import {
+  clearUploadsError,
+  uploadsErrorSelector,
+  uploadsInProgressSelector,
+  uploadsResponseSelector,
+  uploadsTargetSelector,
+} from "../../store/uploads/uploadsSlice";
 
 const SiteRoutes = () => {
   const dispatch = useDispatch();
@@ -21,16 +28,23 @@ const SiteRoutes = () => {
   const [uploadDetails, setUploadDetails] = useState<UploadTimeSeriesResult[]>(
     []
   );
-  const [uploadError, setUploadError] = useState<string | undefined>();
-  const [uploadLoading, setUploadLoading] = useState(false);
+  const uploadLoading = useSelector(uploadsInProgressSelector);
+  const uploadError = useSelector(uploadsErrorSelector);
+  const uploadResult = useSelector(uploadsResponseSelector);
+  const uploadTarget = useSelector(uploadsTargetSelector);
 
   const hasWarnings = uploadDetails.some((data) => data.ignoredHeaders.length);
 
   const handleSnackbarClose = () => setIsUploadSnackbarOpen(false);
   const handleDetailsDialogOpen = () => setIsUploadDetailsDialogOpen(true);
   const handleDetailsDialogClose = () => setIsUploadDetailsDialogOpen(false);
-  const onStatusSnackbarClose = () => setUploadError(undefined);
+  const onStatusSnackbarClose = () => dispatch(clearUploadsError());
   const [siteId, setSiteId] = useState<number | undefined>(undefined);
+
+  const onHandleUploadError = () => {
+    // eslint-disable-next-line fp/no-mutating-methods
+    history.push(`/sites/${uploadTarget?.siteId}/upload_data`);
+  };
 
   const handleRefreshOnSuccessUpload = () => {
     dispatch(setSelectedSite());
@@ -48,6 +62,12 @@ const SiteRoutes = () => {
     setIsUploadSnackbarOpen(true);
   };
 
+  useEffect(() => {
+    if (uploadResult && !uploadLoading && !uploadError && uploadTarget) {
+      onUploadSuccess(uploadResult, uploadTarget.siteId);
+    }
+  }, [uploadResult, uploadLoading, uploadError, uploadTarget]);
+
   return (
     <>
       <StatusSnackbar
@@ -62,7 +82,9 @@ const SiteRoutes = () => {
       />
       <StatusSnackbar
         open={!!uploadError}
-        message={uploadError}
+        message="Something went wrong with the upload"
+        furtherActionLabel="View details"
+        onFurtherActionTake={onHandleUploadError}
         handleClose={onStatusSnackbarClose}
         severity="error"
       />
@@ -99,14 +121,7 @@ const SiteRoutes = () => {
         <Route
           exact
           path="/sites/:id/upload_data"
-          render={(props) => (
-            <UploadData
-              {...props}
-              onSuccess={onUploadSuccess}
-              setUploadError={setUploadError}
-              setUploadLoading={setUploadLoading}
-            />
-          )}
+          render={(props) => <UploadData {...props} />}
         />
       </Switch>
     </>

--- a/packages/website/src/services/uploadServices.ts
+++ b/packages/website/src/services/uploadServices.ts
@@ -2,7 +2,8 @@ import requests from "../helpers/requests";
 
 export interface UploadTimeSeriesResult {
   file: string;
-  ignoredHeaders: string[];
+  ignoredHeaders: string[] | null;
+  error: string | null;
 }
 
 const uploadMedia = (

--- a/packages/website/src/store/reducer.ts
+++ b/packages/website/src/store/reducer.ts
@@ -6,6 +6,7 @@ import user from "./User/userSlice";
 import survey from "./Survey/surveySlice";
 import surveyList from "./Survey/surveyListSlice";
 import collection from "./Collection/collectionSlice";
+import uploads from "./uploads/uploadsSlice";
 
 const appReducer = combineReducers({
   selectedSite,
@@ -15,6 +16,7 @@ const appReducer = combineReducers({
   collection,
   survey,
   surveyList,
+  uploads,
 });
 
 export default appReducer;

--- a/packages/website/src/store/uploads/types.ts
+++ b/packages/website/src/store/uploads/types.ts
@@ -1,0 +1,14 @@
+import { UploadTimeSeriesResult } from "../../services/uploadServices";
+import { Sources } from "../Sites/types";
+
+export interface UploadsSliceState {
+  files: File[];
+  target?: {
+    selectedSensor: Sources;
+    selectedPoint: number;
+    siteId: number;
+  };
+  uploadInProgress: boolean;
+  uploadResponse?: UploadTimeSeriesResult[];
+  error?: any;
+}

--- a/packages/website/src/store/uploads/uploadsSlice.ts
+++ b/packages/website/src/store/uploads/uploadsSlice.ts
@@ -1,0 +1,162 @@
+import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
+import { uniqBy } from "lodash";
+import { getAxiosErrorMessage } from "../../helpers/errors";
+import uploadServices from "../../services/uploadServices";
+import type { CreateAsyncThunkTypes, RootState } from "../configure";
+import { UploadsSliceState } from "./types";
+
+const uploadsSliceInitialState: UploadsSliceState = {
+  files: [],
+  target: undefined,
+  uploadInProgress: false,
+  uploadResponse: undefined,
+  error: undefined,
+};
+
+export const uploadFiles = createAsyncThunk<
+  UploadsSliceState["uploadResponse"],
+  string | null | undefined,
+  CreateAsyncThunkTypes
+>(
+  "uploads/uploadFiles",
+  async (token: string | null | undefined, { rejectWithValue, getState }) => {
+    const state = getState();
+    const selectedSensor = state.uploads.target?.selectedSensor;
+    const selectedPoint = state.uploads.target?.selectedPoint;
+    const siteId = state.uploads.target?.siteId;
+    try {
+      if (
+        typeof siteId === "number" &&
+        typeof selectedPoint === "number" &&
+        selectedSensor
+      ) {
+        const data = new FormData();
+        state.uploads.files.forEach((file) => data.append("files", file));
+        data.append("sensor", selectedSensor);
+        const { data: uploadResponse } =
+          await uploadServices.uploadTimeSeriesData(
+            data,
+            siteId,
+            selectedPoint,
+            token,
+            false
+          );
+        return uploadResponse;
+      }
+      return rejectWithValue("Invalid arguments");
+    } catch (err) {
+      const errorMessage = getAxiosErrorMessage(err);
+      return rejectWithValue(errorMessage);
+    }
+  }
+);
+
+const uploadsSlice = createSlice({
+  name: "uploads",
+  initialState: uploadsSliceInitialState,
+  reducers: {
+    addUploadsFiles: (
+      state,
+      action: PayloadAction<UploadsSliceState["files"]>
+    ) => {
+      const newFiles = uniqBy([...state.files, ...action.payload], "name");
+      return {
+        ...state,
+        files: newFiles,
+      };
+    },
+    removeUploadsFiles: (state, action: PayloadAction<string>) => {
+      const newFIles = state.files.filter(
+        (file) => file.name !== action.payload
+      );
+      return {
+        ...state,
+        files: newFIles,
+      };
+    },
+    clearUploadsFiles: (state) => ({
+      ...state,
+      files: [],
+    }),
+    setUploadsTarget: (
+      state,
+      action: PayloadAction<UploadsSliceState["target"]>
+    ) => ({
+      ...state,
+      target: action.payload,
+    }),
+    clearUploadsTarget: (state) => ({
+      ...state,
+      target: undefined,
+    }),
+    // Should this function exists?
+    clearUploadsError: (state) => ({
+      ...state,
+      error: undefined,
+    }),
+  },
+  extraReducers: (builder) => {
+    builder.addCase(uploadFiles.pending, (state) => {
+      return {
+        ...state,
+        error: undefined,
+        uploadInProgress: true,
+      };
+    });
+    builder.addCase(
+      uploadFiles.fulfilled,
+      (state, action: PayloadAction<UploadsSliceState["uploadResponse"]>) => {
+        return {
+          ...state,
+          uploadInProgress: false,
+          uploadResponse: action.payload,
+        };
+      }
+    );
+    builder.addCase(
+      uploadFiles.rejected,
+      (state, action: PayloadAction<UploadsSliceState["error"]>) => {
+        const errorMessage = action.payload;
+        const [maybeFileName, ...maybeFileError] = errorMessage?.split(": ");
+        return {
+          ...state,
+          error: {
+            [maybeFileName]: maybeFileError.join(": "),
+          },
+          uploadInProgress: false,
+        };
+      }
+    );
+  },
+});
+
+export const uploadsFilesSelector = (
+  state: RootState
+): UploadsSliceState["files"] => state.uploads.files;
+
+export const uploadsTargetSelector = (
+  state: RootState
+): UploadsSliceState["target"] => state.uploads.target;
+
+export const uploadsInProgressSelector = (
+  state: RootState
+): UploadsSliceState["uploadInProgress"] => state.uploads.uploadInProgress;
+
+export const uploadsResponseSelector = (
+  state: RootState
+): UploadsSliceState["uploadResponse"] => state.uploads.uploadResponse;
+
+export const uploadsErrorSelector = (
+  state: RootState
+): UploadsSliceState["error"] => state.uploads.error;
+
+export const {
+  addUploadsFiles,
+  removeUploadsFiles,
+  clearUploadsFiles,
+  setUploadsTarget,
+  clearUploadsTarget,
+  clearUploadsError,
+} = uploadsSlice.actions;
+
+export default uploadsSlice.reducer;


### PR DESCRIPTION
The purpose of this PR is to resolve https://github.com/aqualinkorg/aqualink-app/issues/699

This PR moves all upload logic to a redux slice, making it possible for the user to browse the application while waiting for the upload to finish. It also fixes an issue of not all files being processed in the backend, if one failed, and keeping them in local file system  

![Screenshot from 2022-05-26 15-59-56](https://user-images.githubusercontent.com/80451946/170493229-330ffcc5-ea0e-437f-bd17-4fa7872cd5b4.png)

![Screenshot from 2022-05-31 12-47-06](https://user-images.githubusercontent.com/80451946/171164270-a75f45ed-1ad7-426c-b3d8-487d84d48c26.png)


![Screenshot from 2022-05-31 12-47-19](https://user-images.githubusercontent.com/80451946/171164282-fd06730a-90a5-4b79-80d2-946fc249d8ac.png)


![Screenshot from 2022-05-31 14-28-56](https://user-images.githubusercontent.com/80451946/171164299-7efc7a6c-fd00-48a8-8b3f-5d4709e9f543.png)

![Screenshot from 2022-05-31 14-37-29](https://user-images.githubusercontent.com/80451946/171164629-f5173f73-8c3d-4519-842b-90d5f95510da.png)


![Screenshot from 2022-05-31 14-37-37](https://user-images.githubusercontent.com/80451946/171164641-1752280f-edf6-4cdd-9e28-8d830ff41cbf.png)

![Screenshot from 2022-05-31 14-38-47](https://user-images.githubusercontent.com/80451946/171164797-d07eb670-b059-46ef-b00d-e7a019b6d9e0.png)



