### PR TITLE
Make live data request run only once

### DIFF
--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -21,6 +21,7 @@ import { getAxiosErrorMessage } from "../../helpers/errors";
 const selectedSiteInitialState: SelectedSiteState = {
   draft: null,
   loading: true,
+  loadingLiveData: 0,
   timeSeriesDataLoading: false,
   timeSeriesDataRangeLoading: false,
   latestOceanSenseDataLoading: false,
@@ -34,14 +35,21 @@ export const liveDataRequest = createAsyncThunk<
   SelectedSiteState["liveData"],
   string,
   CreateAsyncThunkTypes
->("selectedSite/requestLiveData", async (id: string, { rejectWithValue }) => {
-  try {
-    const { data } = await siteServices.getSiteLiveData(id);
-    return data;
-  } catch (err) {
-    return rejectWithValue(getAxiosErrorMessage(err));
+>(
+  "selectedSite/requestLiveData",
+  async (id: string, { rejectWithValue, getState }) => {
+    const state = getState();
+    if (state.selectedSite.loadingLiveData !== 1) {
+      return rejectWithValue("Request already loading");
+    }
+    try {
+      const { data } = await siteServices.getSiteLiveData(id);
+      return data;
+    } catch (err) {
+      return rejectWithValue(getAxiosErrorMessage(err));
+    }
   }
-});
+);
 
 export const latestDataRequest = createAsyncThunk<
   SelectedSiteState["latestData"],
@@ -302,6 +310,7 @@ const selectedSiteSlice = createSlice({
         return {
           ...state,
           liveData: action.payload,
+          loadingLiveData: state.loadingLiveData - 1,
         };
       }
     );
@@ -312,6 +321,7 @@ const selectedSiteSlice = createSlice({
         return {
           ...state,
           error: action.payload,
+          loadingLiveData: state.loadingLiveData - 1,
         };
       }
     );
@@ -320,6 +330,7 @@ const selectedSiteSlice = createSlice({
       return {
         ...state,
         error: null,
+        loadingLiveData: state.loadingLiveData + 1,
       };
     });
 

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -31,6 +31,8 @@ const selectedSiteInitialState: SelectedSiteState = {
   error: null,
 };
 
+const AlreadyLoadingErrorMessage = "Request already loading";
+
 export const liveDataRequest = createAsyncThunk<
   SelectedSiteState["liveData"],
   string,
@@ -40,7 +42,7 @@ export const liveDataRequest = createAsyncThunk<
   async (id: string, { rejectWithValue, getState }) => {
     const state = getState();
     if (state.selectedSite.loadingLiveData !== 1) {
-      return rejectWithValue("Request already loading");
+      return rejectWithValue(AlreadyLoadingErrorMessage);
     }
     try {
       const { data } = await siteServices.getSiteLiveData(id);
@@ -320,7 +322,10 @@ const selectedSiteSlice = createSlice({
       (state, action: PayloadAction<SelectedSiteState["error"]>) => {
         return {
           ...state,
-          error: action.payload,
+          error:
+            action.payload === AlreadyLoadingErrorMessage
+              ? null
+              : action.payload,
           loadingLiveData: state.loadingLiveData - 1,
         };
       }

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -366,5 +366,6 @@ export interface SelectedSiteState {
   timeSeriesMinRequestDate?: string;
   timeSeriesMaxRequestDate?: string;
   loading: boolean;
+  loadingLiveData: number;
   error?: string | null;
 }


### PR DESCRIPTION
This PR closes https://github.com/aqualinkorg/aqualink-app/issues/710

This is adding a counter so only one request of live data can run at a time. 