### PR TITLE
Add indexes to foreign keys

### DIFF
--- a/packages/api/migration/1654608487703-AddIndexes.ts
+++ b/packages/api/migration/1654608487703-AddIndexes.ts
@@ -1,0 +1,107 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddIndexes1654608487703 implements MigrationInterface {
+  name = 'AddIndexes1654608487703';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5ae17cee9e339b189cf3e220e5" ON "site_audit" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_4f925485b013b52e32f43d430f" ON "collection" ("user_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_1ed4a7be821c5819d382e4b72e" ON "data_uploads" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a0eaf4da731fb39079b1fbf9fb" ON "data_uploads" ("survey_point_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_2547f55866c0274d35fdd9a29c" ON "region" ("parent_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_dcc651c79d9b16e5a159ad4ded" ON "site_application" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_37fc9d09ff7c17d2338203829b" ON "site_application" ("user_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_6f7e22a9fea6ffe85ee8249bdc" ON "sketch_fab" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a77a30409a2905313e11d7685d" ON "site_survey_point" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_9a513eb5b403b175938dce4bf3" ON "daily_data" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_2e5de2284644a41979436d3820" ON "historical_monthly_mean" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_ff7a13fae129f15180a3e36f9e" ON "site" ("region_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_2d56028954ec00388e734fb266" ON "site" ("stream_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_687c94fe33408bad80672846e1" ON "survey_media" ("survey_point_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_a37da0d039df5145bd187a32e0" ON "survey" ("user_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_5ee3e3571f59efef147b4e6b1f" ON "survey" ("site_id") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5ee3e3571f59efef147b4e6b1f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a37da0d039df5145bd187a32e0"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_687c94fe33408bad80672846e1"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_2d56028954ec00388e734fb266"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_ff7a13fae129f15180a3e36f9e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_2e5de2284644a41979436d3820"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_9a513eb5b403b175938dce4bf3"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a77a30409a2905313e11d7685d"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_6f7e22a9fea6ffe85ee8249bdc"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_37fc9d09ff7c17d2338203829b"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_dcc651c79d9b16e5a159ad4ded"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_2547f55866c0274d35fdd9a29c"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_a0eaf4da731fb39079b1fbf9fb"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_1ed4a7be821c5819d382e4b72e"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_4f925485b013b52e32f43d430f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_5ae17cee9e339b189cf3e220e5"`,
+    );
+  }
+}

--- a/packages/api/scripts/hindcast-wind-wave-data.ts
+++ b/packages/api/scripts/hindcast-wind-wave-data.ts
@@ -3,7 +3,7 @@ import yargs from 'yargs';
 import { configService } from '../src/config/config.service';
 import { Site } from '../src/sites/sites.entity';
 import { addWindWaveData } from '../src/utils/hindcast-wind-wave';
-import { ForecastData } from '../src/wind-wave-data/wind-wave-data.entity';
+import { ForecastData } from '../src/wind-wave-data/forecast-data.entity';
 
 // Initialize command definition
 const { argv } = yargs

--- a/packages/api/src/audit/site-audit.entity.ts
+++ b/packages/api/src/audit/site-audit.entity.ts
@@ -34,6 +34,7 @@ export class SiteAudit {
   columnName: SiteColumn;
 
   @ManyToOne(() => Site, { nullable: false, onDelete: 'CASCADE' })
+  @Index()
   site: Site;
 
   @Index()

--- a/packages/api/src/collections/collections.entity.ts
+++ b/packages/api/src/collections/collections.entity.ts
@@ -3,6 +3,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   JoinTable,
   ManyToMany,
   ManyToOne,
@@ -32,6 +33,7 @@ export class Collection {
   isPublic: boolean;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @Index()
   user: User;
 
   @ApiProperty({ example: 1 })

--- a/packages/api/src/data-uploads/data-uploads.entity.ts
+++ b/packages/api/src/data-uploads/data-uploads.entity.ts
@@ -2,6 +2,7 @@ import {
   Column,
   CreateDateColumn,
   Entity,
+  Index,
   ManyToOne,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
@@ -21,9 +22,11 @@ export class DataUploads {
   id: number;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE', nullable: false })
+  @Index()
   site: Site;
 
   @ManyToOne(() => SiteSurveyPoint, { onDelete: 'CASCADE', nullable: false })
+  @Index()
   surveyPoint: SiteSurveyPoint;
 
   @Column({ type: 'enum', enum: SourceType })

--- a/packages/api/src/regions/regions.entity.ts
+++ b/packages/api/src/regions/regions.entity.ts
@@ -40,6 +40,7 @@ export class Region {
 
   @ApiProperty({ type: () => Region })
   @ManyToOne(() => Region, { onDelete: 'CASCADE', nullable: true })
+  @Index()
   parent: Region | null;
 
   @ApiProperty({ example: 1 })

--- a/packages/api/src/site-applications/site-applications.entity.ts
+++ b/packages/api/src/site-applications/site-applications.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
   OneToOne,
   JoinColumn,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Exclude, Expose } from 'class-transformer';
@@ -55,9 +56,11 @@ export class SiteApplication {
 
   @OneToOne(() => Site, { onDelete: 'CASCADE' })
   @JoinColumn()
+  @Index()
   site: Site;
 
   @ManyToOne(() => User, { onDelete: 'CASCADE' })
+  @Index()
   user: User;
 
   @Expose()

--- a/packages/api/src/site-sketchfab/site-sketchfab.entity.ts
+++ b/packages/api/src/site-sketchfab/site-sketchfab.entity.ts
@@ -6,6 +6,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   RelationId,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Site } from '../sites/sites.entity';
@@ -17,6 +18,7 @@ export class SketchFab {
   id: number;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE', nullable: false })
+  @Index()
   site: Site;
 
   @ApiProperty({ example: 1 })

--- a/packages/api/src/site-survey-points/site-survey-points.entity.ts
+++ b/packages/api/src/site-survey-points/site-survey-points.entity.ts
@@ -32,6 +32,7 @@ export class SiteSurveyPoint {
   name: string;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE', nullable: false })
+  @Index()
   site: Site;
 
   @ApiProperty({ example: 1 })

--- a/packages/api/src/sites/daily-data.entity.ts
+++ b/packages/api/src/sites/daily-data.entity.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   CreateDateColumn,
   UpdateDateColumn,
+  Index,
 } from 'typeorm';
 import { Site } from './sites.entity';
 
@@ -91,6 +92,7 @@ export class DailyData {
   weeklyAlertLevel: number | null;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE' })
+  @Index()
   site: Site;
 
   @CreateDateColumn()

--- a/packages/api/src/sites/historical-monthly-mean.entity.ts
+++ b/packages/api/src/sites/historical-monthly-mean.entity.ts
@@ -7,6 +7,7 @@ import {
   UpdateDateColumn,
   Unique,
   RelationId,
+  Index,
 } from 'typeorm';
 import { Site } from './sites.entity';
 
@@ -32,6 +33,7 @@ export class HistoricalMonthlyMean {
   siteId: number;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE' })
+  @Index()
   site: Site;
 
   @UpdateDateColumn()

--- a/packages/api/src/sites/sites.entity.ts
+++ b/packages/api/src/sites/sites.entity.ts
@@ -96,9 +96,11 @@ export class Site {
   updatedAt: Date;
 
   @ManyToOne(() => Region, { onDelete: 'SET NULL', nullable: true })
+  @Index()
   region: Region | null;
 
   @ManyToOne(() => VideoStream, { onDelete: 'SET NULL', nullable: true })
+  @Index()
   stream: VideoStream | null;
 
   @ManyToMany(() => User, (user) => user.administeredSites)

--- a/packages/api/src/surveys/survey-media.entity.ts
+++ b/packages/api/src/surveys/survey-media.entity.ts
@@ -7,6 +7,7 @@ import {
   CreateDateColumn,
   UpdateDateColumn,
   RelationId,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Survey } from './surveys.entity';
@@ -85,6 +86,7 @@ export class SurveyMedia {
     nullable: true,
   })
   @JoinColumn({ name: 'survey_point_id' })
+  @Index()
   surveyPoint: SiteSurveyPoint | null;
 
   @CreateDateColumn()

--- a/packages/api/src/surveys/surveys.entity.ts
+++ b/packages/api/src/surveys/surveys.entity.ts
@@ -9,6 +9,7 @@ import {
   OneToOne,
   OneToMany,
   RelationId,
+  Index,
 } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Site } from '../sites/sites.entity';
@@ -54,6 +55,7 @@ export class Survey {
 
   @ManyToOne(() => User, { onDelete: 'CASCADE', nullable: false })
   @JoinColumn({ name: 'user_id' })
+  @Index()
   user: User;
 
   @RelationId((survey: Survey) => survey.site)
@@ -61,6 +63,7 @@ export class Survey {
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE', nullable: false })
   @JoinColumn({ name: 'site_id' })
+  @Index()
   site: Site;
 
   @CreateDateColumn()

--- a/packages/api/src/utils/hindcast-wind-wave.ts
+++ b/packages/api/src/utils/hindcast-wind-wave.ts
@@ -6,7 +6,7 @@ import moment from 'moment';
 import { Repository } from 'typeorm';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { Site } from '../sites/sites.entity';
-import { ForecastData } from '../wind-wave-data/wind-wave-data.entity';
+import { ForecastData } from '../wind-wave-data/forecast-data.entity';
 import { WindWaveMetric } from '../wind-wave-data/wind-wave-data.types';
 import { SofarModels, sofarVariableIDs } from './constants';
 import { getWindDirection, getWindSpeed } from './math';

--- a/packages/api/src/wind-wave-data/forecast-data.entity.ts
+++ b/packages/api/src/wind-wave-data/forecast-data.entity.ts
@@ -15,13 +15,13 @@ import { WindWaveMetric } from './wind-wave-data.types';
 
 @Entity()
 @Unique('one_row_per_site_per_metric_per_source', ['site', 'metric', 'source'])
-@Index(['site'])
 export class ForecastData {
   @ApiProperty({ example: 1 })
   @PrimaryGeneratedColumn()
   id: number;
 
   @ManyToOne(() => Site, { onDelete: 'CASCADE', nullable: false })
+  @Index()
   site: Site;
 
   @Column({ nullable: false })

--- a/packages/api/src/wind-wave-data/wind-wave-data.module.ts
+++ b/packages/api/src/wind-wave-data/wind-wave-data.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { EntityExists } from '../validations/entity-exists.constraint';
 import { WindWaveController } from './wind-wave-data.controller';
-import { ForecastData } from './wind-wave-data.entity';
+import { ForecastData } from './forecast-data.entity';
 import { WindWaveService } from './wind-wave-data.service';
 
 @Module({

--- a/packages/api/src/wind-wave-data/wind-wave-data.service.ts
+++ b/packages/api/src/wind-wave-data/wind-wave-data.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ForecastData } from './wind-wave-data.entity';
+import { ForecastData } from './forecast-data.entity';
 
 @Injectable()
 export class WindWaveService {

--- a/packages/api/src/workers/spotterTimeSeries.ts
+++ b/packages/api/src/workers/spotterTimeSeries.ts
@@ -1,5 +1,5 @@
 import { Connection } from 'typeorm';
-import { ForecastData } from '../wind-wave-data/wind-wave-data.entity';
+import { ForecastData } from '../wind-wave-data/forecast-data.entity';
 import { ExclusionDates } from '../sites/exclusion-dates.entity';
 import { Site } from '../sites/sites.entity';
 import { Sources } from '../sites/sources.entity';


### PR DESCRIPTION
This PR adds indexes to a lot of foreign  key columns. It also renames `wind-wave-data.entity.ts` to `forecast-data.entity.ts`.
@ericboucher let me know if there is any to add or remove.

The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/753