### PR TITLE
Replace live_data request with spotter_position

### DIFF
--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -110,10 +110,8 @@ export class SitesController {
   @ApiParam({ name: 'id', example: 1 })
   @Public()
   @Get(':id/spotter_position')
-  findSpotterPosition(
-    @Param('id', ParseIntPipe) id: number,
-  ): Promise<SofarLiveDataDto> {
-    return this.sitesService.findLiveData(id);
+  findSpotterPosition(@Param('id', ParseIntPipe) id: number) {
+    return this.sitesService.findSpotterPosition(id);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -106,6 +106,17 @@ export class SitesController {
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')
+  @ApiOperation({ summary: 'Returns spotter position for the specified site' })
+  @ApiParam({ name: 'id', example: 1 })
+  @Public()
+  @Get(':id/spotter_position')
+  findSpotterPosition(
+    @Param('id', ParseIntPipe) id: number,
+  ): Promise<SofarLiveDataDto> {
+    return this.sitesService.findLiveData(id);
+  }
+
+  @ApiNestNotFoundResponse('No site was found with the specified id')
   @ApiOperation({ summary: 'Returns latest data for the specified site' })
   @ApiParam({ name: 'id', example: 1 })
   @Public()

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -365,7 +365,7 @@ export class SitesService {
       return {
         timestamp: undefined,
         isDeployed,
-        spotterPosition: undefined,
+        position: undefined,
       };
 
     const spotterRaw = await getSpotterData(sensorId);
@@ -384,8 +384,8 @@ export class SitesService {
       ...(spotterData.longitude &&
         spotterData.latitude && {
           position: {
-            longitude: spotterData.longitude,
-            latitude: spotterData.latitude,
+            longitude: spotterData.longitude.value,
+            latitude: spotterData.latitude.value,
           },
         }),
     };

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -383,7 +383,7 @@ export class SitesService {
       timestamp: spotterData.latitude?.timestamp,
       ...(spotterData.longitude &&
         spotterData.latitude && {
-          spotterPosition: {
+          position: {
             longitude: spotterData.longitude,
             latitude: spotterData.latitude,
           },

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -45,6 +45,7 @@ export async function getDegreeHeatingDays(
   endOfDate: Date,
   maxMonthlyMean: number | null,
 ): Promise<ValueWithTimestamp | undefined> {
+  console.time(`--> getDegreeHeatingDays for ${latitude}, ${longitude}`);
   try {
     // TODO - Get data for the past 84 days.
     const seaSurfaceTemperatures = [] as number[];
@@ -65,6 +66,7 @@ export async function getDegreeHeatingDays(
     // Check if there are any data returned
     // Grab the last one and convert it to degreeHeatingDays
     const latestDegreeHeatingWeek = getLatestData(degreeHeatingWeek);
+    console.timeEnd(`--> getDegreeHeatingDays for ${latitude}, ${longitude}`);
     return (
       latestDegreeHeatingWeek && {
         value: latestDegreeHeatingWeek.value * 7,

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -45,7 +45,6 @@ export async function getDegreeHeatingDays(
   endOfDate: Date,
   maxMonthlyMean: number | null,
 ): Promise<ValueWithTimestamp | undefined> {
-  console.time(`--> getDegreeHeatingDays for ${latitude}, ${longitude}`);
   try {
     // TODO - Get data for the past 84 days.
     const seaSurfaceTemperatures = [] as number[];
@@ -66,7 +65,6 @@ export async function getDegreeHeatingDays(
     // Check if there are any data returned
     // Grab the last one and convert it to degreeHeatingDays
     const latestDegreeHeatingWeek = getLatestData(degreeHeatingWeek);
-    console.timeEnd(`--> getDegreeHeatingDays for ${latitude}, ${longitude}`);
     return (
       latestDegreeHeatingWeek && {
         value: latestDegreeHeatingWeek.value * 7,

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
@@ -2,8 +2,10 @@ import React, { useState } from "react";
 import downloadCsv from "download-csv";
 import { Button } from "@material-ui/core";
 import moment from "moment";
+import { useSelector } from "react-redux";
 import { ValueWithTimestamp } from "../../../store/Sites/types";
 import DownloadCSVDialog from "./DownloadCSVDialog";
+import { spotterPositionSelector } from "../../../store/Sites/selectedSiteSlice";
 
 type CSVDataColumn =
   | "spotterBottomTemp"
@@ -80,6 +82,7 @@ function DownloadCSVButton({
 }) {
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
+  const spotterData = useSelector(spotterPositionSelector);
 
   const onClose = (shouldDownload: boolean) => {
     if (!shouldDownload) {
@@ -125,6 +128,7 @@ function DownloadCSVButton({
         onClick={() => {
           setOpen(true);
         }}
+        style={{ marginBottom: spotterData?.isDeployed ? 0 : "2em" }}
       >
         {/* TODO update this component with LoadingButton from MUILab when newest version is released. */}
         {loading ? "Loading..." : "Download CSV"}

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -41,7 +41,7 @@ import {
 } from "../../store/Collection/collectionSlice";
 import {
   unsetLatestData,
-  unsetLiveData,
+  unsetSpotterPosition,
   unsetSelectedSite,
 } from "../../store/Sites/selectedSiteSlice";
 
@@ -84,7 +84,7 @@ const NavBar = ({
 
   const onSiteChange = () => {
     dispatch(unsetSelectedSite());
-    dispatch(unsetLiveData());
+    dispatch(unsetSpotterPosition());
     dispatch(unsetLatestData());
   };
 

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -25,7 +25,7 @@ import { getSiteNameAndRegion } from "../../store/Sites/helpers";
 import mapServices from "../../services/mapServices";
 import {
   unsetLatestData,
-  unsetLiveData,
+  unsetSpotterPosition,
   unsetSelectedSite,
 } from "../../store/Sites/selectedSiteSlice";
 
@@ -83,7 +83,7 @@ const Search = ({ geocodingEnabled, classes }: SearchProps) => {
       // - through the search
       // - through the admin side panel
       dispatch(unsetSelectedSite());
-      dispatch(unsetLiveData());
+      dispatch(unsetSpotterPosition());
       dispatch(unsetLatestData());
       if (!geocodingEnabled) {
         browserHistory.push(`/sites/${value.id}`);
@@ -96,7 +96,7 @@ const Search = ({ geocodingEnabled, classes }: SearchProps) => {
       if (!geocodingEnabled) {
         browserHistory.push(`/sites/${searchedSite.id}`);
       }
-      dispatch(unsetLiveData());
+      dispatch(unsetSpotterPosition());
       dispatch(unsetLatestData());
       dispatch(setSiteOnMap(searchedSite));
       setSearchedSite(null);

--- a/packages/website/src/common/SiteDetails/Map/index.tsx
+++ b/packages/website/src/common/SiteDetails/Map/index.tsx
@@ -239,10 +239,7 @@ const SiteMap = ({
       {!draftSite && spotterPosition && isManager(user) && (
         <Marker
           icon={buoyIcon}
-          position={[
-            spotterPosition.latitude.value,
-            spotterPosition.longitude.value,
-          ]}
+          position={[spotterPosition.latitude, spotterPosition.longitude]}
         />
       )}
     </Map>

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -39,11 +39,11 @@ import {
   forecastDataSelector,
   latestDataRequest,
   latestDataSelector,
-  liveDataRequest,
-  liveDataSelector,
+  spotterPositionRequest,
+  spotterPositionSelector,
   unsetForecastData,
   unsetLatestData,
-  unsetLiveData,
+  unsetSpotterPosition,
 } from "../../store/Sites/selectedSiteSlice";
 import { parseLatestData } from "../../store/Sites/helpers";
 
@@ -59,7 +59,7 @@ const SiteDetails = ({
   const classes = useStyles();
   const theme = useTheme();
   const dispatch = useDispatch();
-  const liveData = useSelector(liveDataSelector);
+  const spotterPosition = useSelector(spotterPositionSelector);
   const [latestDataAsSofarValues, setLatestDataAsSofarValues] =
     useState<LatestDataASSofarValue>({});
   const [hasSondeData, setHasSondeData] = useState<boolean>(false);
@@ -72,8 +72,8 @@ const SiteDetails = ({
   const isLoading = !site;
 
   useEffect(() => {
-    if (site && !liveData) {
-      dispatch(liveDataRequest(String(site.id)));
+    if (site && !spotterPosition) {
+      dispatch(spotterPositionRequest(String(site.id)));
     }
     if (site && !latestData) {
       dispatch(latestDataRequest(String(site.id)));
@@ -81,11 +81,11 @@ const SiteDetails = ({
     if (site && !forecastData) {
       dispatch(forecastDataRequest(String(site.id)));
     }
-  }, [dispatch, site, liveData, latestData, forecastData]);
+  }, [dispatch, site, spotterPosition, latestData, forecastData]);
 
   useEffect(() => {
     return () => {
-      dispatch(unsetLiveData());
+      dispatch(unsetSpotterPosition());
       dispatch(unsetLatestData());
       dispatch(unsetForecastData());
     };
@@ -228,7 +228,7 @@ const SiteDetails = ({
           {site && !isSketchFabView && (
             <Map
               siteId={site.id}
-              spotterPosition={liveData?.spotterPosition}
+              spotterPosition={spotterPosition}
               polygon={site.polygon}
               surveyPoints={site.surveyPoints}
             />

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -95,14 +95,18 @@ const SiteDetails = ({
     if (forecastData && latestData) {
       const combinedArray = [...forecastData, ...latestData];
       const parsedData = parseLatestData(combinedArray);
-      const hasSpotter = Boolean(parsedData.bottomTemperature);
       const hasSonde = Boolean(parsedData.salinity);
 
       setHasSondeData(hasSonde);
-      setHasSpotterData(hasSpotter);
       setLatestDataAsSofarValues(parsedData);
     }
   }, [forecastData, latestData]);
+
+  useEffect(() => {
+    if (spotterPosition) {
+      setHasSpotterData(spotterPosition.isDeployed);
+    }
+  }, [spotterPosition]);
 
   const { videoStream } = site || {};
 
@@ -228,7 +232,9 @@ const SiteDetails = ({
           {site && !isSketchFabView && (
             <Map
               siteId={site.id}
-              spotterPosition={spotterPosition}
+              spotterPosition={
+                hastSpotterData ? spotterPosition?.spotterPosition : null
+              }
               polygon={site.polygon}
               surveyPoints={site.surveyPoints}
             />

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -63,7 +63,7 @@ const SiteDetails = ({
   const [latestDataAsSofarValues, setLatestDataAsSofarValues] =
     useState<LatestDataASSofarValue>({});
   const [hasSondeData, setHasSondeData] = useState<boolean>(false);
-  const [hastSpotterData, setHasSpotterData] = useState<boolean>(false);
+  const [hasSpotterData, setHasSpotterData] = useState<boolean>(false);
   const [isSketchFabView, setIsSketchFabView] = useState<boolean>(false);
   const latestData = useSelector(latestDataSelector);
   const forecastData = useSelector(forecastDataSelector);
@@ -95,18 +95,14 @@ const SiteDetails = ({
     if (forecastData && latestData) {
       const combinedArray = [...forecastData, ...latestData];
       const parsedData = parseLatestData(combinedArray);
+      const hasSpotter = Boolean(parsedData.bottomTemperature);
       const hasSonde = Boolean(parsedData.salinity);
 
       setHasSondeData(hasSonde);
+      setHasSpotterData(hasSpotter);
       setLatestDataAsSofarValues(parsedData);
     }
   }, [forecastData, latestData]);
-
-  useEffect(() => {
-    if (spotterPosition) {
-      setHasSpotterData(spotterPosition.isDeployed);
-    }
-  }, [spotterPosition]);
 
   const { videoStream } = site || {};
 
@@ -129,7 +125,7 @@ const SiteDetails = ({
               dailyData={sortByDate(site.dailyData, "date", "asc").slice(-1)[0]}
             />
           ),
-          <Waves data={latestDataAsSofarValues} hasSpotter={hastSpotterData} />,
+          <Waves data={latestDataAsSofarValues} hasSpotter={hasSpotterData} />,
         ]
       : times(4, () => null);
 
@@ -233,7 +229,7 @@ const SiteDetails = ({
             <Map
               siteId={site.id}
               spotterPosition={
-                hastSpotterData ? spotterPosition?.spotterPosition : null
+                hasSpotterData ? spotterPosition?.position : null
               }
               polygon={site.polygon}
               surveyPoints={site.surveyPoints}

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/ExclusionDatesDialog/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/ExclusionDatesDialog/index.tsx
@@ -24,7 +24,6 @@ import siteServices from "../../../../../services/siteServices";
 import {
   clearTimeSeriesData,
   clearTimeSeriesDataRange,
-  liveDataRequest,
   setSelectedSite,
   siteRequest,
 } from "../../../../../store/Sites/selectedSiteSlice";
@@ -110,7 +109,6 @@ const ExclusionDatesDialog = ({
           setPickerError("");
           onDeployDialogClose();
           dispatch(siteRequest(`${siteId}`));
-          dispatch(liveDataRequest(`${siteId}`));
         })
         .catch((err) =>
           setDeployError(err?.response?.data?.message || "Something went wrong")
@@ -150,7 +148,6 @@ const ExclusionDatesDialog = ({
           dispatch(clearTimeSeriesDataRange());
           dispatch(setSelectedSite(undefined));
           dispatch(siteRequest(`${siteId}`));
-          dispatch(liveDataRequest(`${siteId}`));
         })
         .catch((err) =>
           setMaintainError(

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -23,8 +23,8 @@ import {
   clearTimeSeriesDataRange,
   siteOceanSenseDataRequest,
   clearOceanSenseData,
-  liveDataRequest,
-  liveDataSelector,
+  spotterPositionRequest,
+  spotterPositionSelector,
   siteLoadingSelector,
 } from "../../../store/Sites/selectedSiteSlice";
 import {
@@ -103,7 +103,7 @@ const Site = ({ match, classes }: SiteProps) => {
   const siteLoading = useSelector(siteLoadingSelector);
   const user = useSelector(userInfoSelector);
   const surveyList = useSelector(surveyListSelector);
-  const liveData = useSelector(liveDataSelector);
+  const spotterPosition = useSelector(spotterPositionSelector);
   const dispatch = useDispatch();
   const siteId = match.params.id;
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
@@ -124,7 +124,7 @@ const Site = ({ match, classes }: SiteProps) => {
   } = featuredMedia || {};
   const { surveyPoint: featuredSurveyPoint, url } = featuredSurveyMedia || {};
 
-  const hasSpotterData = Boolean(liveData?.topTemperature);
+  const hasSpotterData = Boolean(spotterPosition);
 
   const hasDailyData = Boolean(dailyData && dailyData.length > 0);
 
@@ -145,7 +145,7 @@ const Site = ({ match, classes }: SiteProps) => {
       dispatch(clearOceanSenseData());
 
       dispatch(siteRequest(siteId));
-      dispatch(liveDataRequest(siteId));
+      dispatch(spotterPositionRequest(siteId));
       dispatch(surveysRequest(siteId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -154,7 +154,7 @@ const Site = ({ match, classes }: SiteProps) => {
   // Fetch site and surveys
   useEffect(() => {
     dispatch(siteRequest(siteId));
-    dispatch(liveDataRequest(siteId));
+    dispatch(spotterPositionRequest(siteId));
     dispatch(surveysRequest(siteId));
 
     return () => {

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -124,7 +124,7 @@ const Site = ({ match, classes }: SiteProps) => {
   } = featuredMedia || {};
   const { surveyPoint: featuredSurveyPoint, url } = featuredSurveyMedia || {};
 
-  const hasSpotterData = Boolean(spotterPosition);
+  const hasSpotterData = Boolean(spotterPosition?.isDeployed);
 
   const hasDailyData = Boolean(dailyData && dailyData.length > 0);
 

--- a/packages/website/src/routes/SiteRoutes/SiteApplication/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SiteApplication/index.tsx
@@ -31,7 +31,6 @@ import {
   userLoadingSelector,
 } from "../../../store/User/userSlice";
 import {
-  liveDataRequest,
   siteDetailsSelector,
   siteLoadingSelector,
   siteRequest,
@@ -62,7 +61,6 @@ const Apply = ({ match, classes }: ApplyProps) => {
 
   useEffect(() => {
     dispatch(siteRequest(`${siteId}`));
-    dispatch(liveDataRequest(`${siteId}`));
   }, [dispatch, siteId]);
 
   useEffect(() => {

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
@@ -11,8 +11,8 @@ import SurveyHistory from "./SurveyHistory";
 import {
   clearTimeSeriesData,
   clearTimeSeriesDataRange,
-  liveDataRequest,
-  liveDataSelector,
+  spotterPositionRequest,
+  spotterPositionSelector,
   siteDetailsSelector,
   siteLoadingSelector,
   siteRequest,
@@ -34,7 +34,7 @@ const SurveyPoint = ({ match }: SurveyPointProps) => {
 
   const dispatch = useDispatch();
   const site = useSelector(siteDetailsSelector);
-  const liveData = useSelector(liveDataSelector);
+  const spotterPosition = useSelector(spotterPositionSelector);
   const siteLoading = useSelector(siteLoadingSelector);
   const surveysLoading = useSelector(surveyListLoadingSelector);
   const timeSeriesRangeLoading = useSelector(
@@ -44,7 +44,7 @@ const SurveyPoint = ({ match }: SurveyPointProps) => {
     useSelector(siteTimeSeriesDataRangeSelector)?.bottomTemperature || {};
   const loading = siteLoading || surveysLoading || timeSeriesRangeLoading;
 
-  const hasSpotterData = Boolean(liveData?.topTemperature);
+  const hasSpotterData = Boolean(spotterPosition);
   const hasRange = !!(
     hoboBottomTemperatureRange?.data &&
     hoboBottomTemperatureRange.data.length > 0
@@ -68,7 +68,7 @@ const SurveyPoint = ({ match }: SurveyPointProps) => {
   useEffect(() => {
     if (!site || site.id !== siteIdNumber) {
       dispatch(siteRequest(id));
-      dispatch(liveDataRequest(id));
+      dispatch(spotterPositionRequest(id));
       dispatch(surveysRequest(id));
     }
   }, [dispatch, id, pointId, site, siteIdNumber]);

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
@@ -44,7 +44,7 @@ const SurveyPoint = ({ match }: SurveyPointProps) => {
     useSelector(siteTimeSeriesDataRangeSelector)?.bottomTemperature || {};
   const loading = siteLoading || surveysLoading || timeSeriesRangeLoading;
 
-  const hasSpotterData = Boolean(spotterPosition);
+  const hasSpotterData = Boolean(spotterPosition?.isDeployed);
   const hasRange = !!(
     hoboBottomTemperatureRange?.data &&
     hoboBottomTemperatureRange.data.length > 0

--- a/packages/website/src/routes/Surveys/index.tsx
+++ b/packages/website/src/routes/Surveys/index.tsx
@@ -16,7 +16,6 @@ import {
   siteLoadingSelector,
   siteErrorSelector,
   siteRequest,
-  liveDataRequest,
 } from "../../store/Sites/selectedSiteSlice";
 import NavBar from "../../common/NavBar";
 import Footer from "../../common/Footer";
@@ -34,7 +33,6 @@ const Surveys = ({ match, isView, classes }: SurveysProps) => {
   useEffect(() => {
     if (!siteDetails || `${siteDetails.id}` !== siteId) {
       dispatch(siteRequest(siteId));
-      dispatch(liveDataRequest(siteId));
     }
   }, [dispatch, siteId, siteDetails]);
 

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -71,9 +71,11 @@ const getSiteLatestData = (id: string) =>
 const getSiteSpotterPosition = (id: string) =>
   requests.send<{
     spotterPosition?: {
-      latitude: ValueWithTimestamp;
       longitude: ValueWithTimestamp;
+      latitude: ValueWithTimestamp;
     };
+    isDeployed: boolean;
+    timestamp?: string;
   }>({
     url: `sites/${id}/spotter_position`,
     method: "GET",

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -24,7 +24,6 @@ import {
   LatestData,
   SiteSketchFab,
   ForecastData,
-  ValueWithTimestamp,
 } from "../store/Sites/types";
 
 const getSite = (id: string) =>
@@ -71,8 +70,8 @@ const getSiteLatestData = (id: string) =>
 const getSiteSpotterPosition = (id: string) =>
   requests.send<{
     position?: {
-      longitude: ValueWithTimestamp;
-      latitude: ValueWithTimestamp;
+      longitude: number;
+      latitude: number;
     };
     isDeployed: boolean;
     timestamp?: string;

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -24,6 +24,7 @@ import {
   LatestData,
   SiteSketchFab,
   ForecastData,
+  ValueWithTimestamp,
 } from "../store/Sites/types";
 
 const getSite = (id: string) =>
@@ -64,6 +65,17 @@ const getSiteForecastData = (id: string) =>
 const getSiteLatestData = (id: string) =>
   requests.send<{ latestData: LatestData[] }>({
     url: `sites/${id}/latest_data`,
+    method: "GET",
+  });
+
+const getSiteSpotterPosition = (id: string) =>
+  requests.send<{
+    spotterPosition?: {
+      latitude: ValueWithTimestamp;
+      longitude: ValueWithTimestamp;
+    };
+  }>({
+    url: `sites/${id}/spotter_position`,
     method: "GET",
   });
 
@@ -216,6 +228,7 @@ export default {
   getSiteLiveData,
   getSiteForecastData,
   getSiteLatestData,
+  getSiteSpotterPosition,
   getSiteTimeSeriesData,
   getSiteTimeSeriesDataRange,
   getSiteSurveyPoints,

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -70,7 +70,7 @@ const getSiteLatestData = (id: string) =>
 
 const getSiteSpotterPosition = (id: string) =>
   requests.send<{
-    spotterPosition?: {
+    position?: {
       longitude: ValueWithTimestamp;
       latitude: ValueWithTimestamp;
     };

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -63,7 +63,7 @@ export const spotterPositionRequest = createAsyncThunk<
     try {
       const { data: spotterPositionData } =
         await siteServices.getSiteSpotterPosition(id);
-      return spotterPositionData.spotterPosition;
+      return spotterPositionData;
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -370,8 +370,12 @@ export interface SelectedSiteState {
   draft: SiteUpdateParams | null;
   details?: Site | null;
   spotterPosition?: {
-    latitude: ValueWithTimestamp;
-    longitude: ValueWithTimestamp;
+    spotterPosition?: {
+      longitude: ValueWithTimestamp;
+      latitude: ValueWithTimestamp;
+    };
+    isDeployed: boolean;
+    timestamp?: string;
   } | null;
   latestData?: LatestData[] | null;
   forecastData?: ForecastData[] | null;

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -370,7 +370,7 @@ export interface SelectedSiteState {
   draft: SiteUpdateParams | null;
   details?: Site | null;
   spotterPosition?: {
-    spotterPosition?: {
+    position?: {
       longitude: ValueWithTimestamp;
       latitude: ValueWithTimestamp;
     };

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -22,14 +22,8 @@ export interface SurveyPoints {
 export type Range = "day" | "week" | "month" | "year";
 
 export interface SpotterPosition {
-  latitude: {
-    timestamp: string;
-    value: number;
-  };
-  longitude: {
-    timestamp: string;
-    value: number;
-  };
+  latitude: number;
+  longitude: number;
 }
 
 export interface UpdateSiteNameFromListArgs {
@@ -371,8 +365,8 @@ export interface SelectedSiteState {
   details?: Site | null;
   spotterPosition?: {
     position?: {
-      longitude: ValueWithTimestamp;
-      latitude: ValueWithTimestamp;
+      longitude: number;
+      latitude: number;
     };
     isDeployed: boolean;
     timestamp?: string;

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -369,7 +369,10 @@ export interface SitesListState {
 export interface SelectedSiteState {
   draft: SiteUpdateParams | null;
   details?: Site | null;
-  liveData?: LiveData | null;
+  spotterPosition?: {
+    latitude: ValueWithTimestamp;
+    longitude: ValueWithTimestamp;
+  } | null;
   latestData?: LatestData[] | null;
   forecastData?: ForecastData[] | null;
   latestOceanSenseData?: OceanSenseData;
@@ -386,6 +389,6 @@ export interface SelectedSiteState {
   timeSeriesMinRequestDate?: string;
   timeSeriesMaxRequestDate?: string;
   loading: boolean;
-  loadingLiveData: number;
+  loadingSpotterPosition: number;
   error?: string | null;
 }


### PR DESCRIPTION
The purpose of this PR is to close https://github.com/aqualinkorg/aqualink-app/issues/711

This PR removes unnecessary FE request to `live_data` endpoint. It also creates a new `spotter_position` endpoint for getting the latest spotter coordinates and Deployed status. 