### PR TITLE
Add google tag manager

### DIFF
--- a/packages/website/.env.example
+++ b/packages/website/.env.example
@@ -15,3 +15,6 @@ REACT_APP_CARTO_API_KEY=
 
 # Mapbox token to access custom styles
 REACT_APP_MAPBOX_ACCESS_TOKEN=
+
+# Google Tag Manager
+REACT_APP_GA_TAG_MANAGER_ID=

--- a/packages/website/public/index.html
+++ b/packages/website/public/index.html
@@ -1,6 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
+    <!-- Google Tag Manager -->
+    <script>
+      (function (w, d, s, l, i) {
+        w[l] = w[l] || [];
+        w[l].push({"gtm.start": new Date().getTime(), event:"gtm.js"});
+        var f = d.getElementsByTagName(s)[0],
+          j = d.createElement(s),
+          dl = l != "dataLayer" ? "&l=" + l : "";
+        j.async = true;
+        j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl;
+        f.parentNode.insertBefore(j,f);
+      })(
+        window,
+        document,
+        "script",
+        "dataLayer",
+        "%REACT_APP_GA_TAG_MANAGER_ID%",
+      );
+    </script>
+  <!-- End Google Tag Manager -->
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta
@@ -34,7 +54,17 @@
   </head>
 
   <body>
-    <noscript>You need to enable JavaScript to run this app.</noscript>
+    <!-- Google Tag Manager (noscript) -->
+    <noscript>
+      <iframe
+        src="https://www.googletagmanager.com/ns.html?id=%REACT_APP_GA_TAG_MANAGER_ID%"
+        height="0"
+        width="0" 
+        style="display:none;visibility:hidden"
+      ></iframe>
+    </noscript>
+    <!-- End Google Tag Manager (noscript) -->
+    
     <div id="root"></div>
     <!--
       This HTML file is a template.


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/777

Adds google tag manager. Provide GTM ID in `REACT_APP_GA_TAG_MANAGER_ID` environment variable.