### PR TITLE
Add nearest NOAA point column to sites and fill script

### DIFF
--- a/packages/api/migration/1666786316691-AddNOAAAvailabilityColumn.ts
+++ b/packages/api/migration/1666786316691-AddNOAAAvailabilityColumn.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddNOAAAvailabilityColumn1666786316691
+  implements MigrationInterface
+{
+  name = 'AddNOAAAvailabilityColumn1666786316691';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "site" ADD "nearest_noaa_location" geometry`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "site" DROP COLUMN "nearest_noaa_location"`,
+    );
+  }
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -61,7 +61,8 @@
     "upload-sonde-data": "ts-node -r dotenv/config scripts/upload-sonde-data.ts",
     "backfill-sofar-time-series": "ts-node -r dotenv/config scripts/backfill-sofar-time-series.ts",
     "update-wind-wave-data": "ts-node -r dotenv/config scripts/hindcast-wind-wave-data.ts",
-    "resize-survey-images": "ts-node -r dotenv/config scripts/resize-survey-images.ts"
+    "resize-survey-images": "ts-node -r dotenv/config scripts/resize-survey-images.ts",
+    "fill-noaa-nearest-point": "ts-node -r dotenv/config scripts/noaa-availability.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.3.0",
@@ -73,6 +74,7 @@
     "@nestjs/schedule": "^0.4.1",
     "@nestjs/swagger": "^4.8.0",
     "@nestjs/typeorm": "^7.0.0",
+    "@turf/boolean-point-in-polygon": "^6.5.0",
     "@turf/nearest-point": "^6.5.0",
     "@types/bluebird": "^3.5.32",
     "@types/node-xlsx": "^0.15.3",

--- a/packages/api/scripts/noaa-availability.ts
+++ b/packages/api/scripts/noaa-availability.ts
@@ -1,0 +1,180 @@
+/* eslint-disable fp/no-mutating-methods */
+/* eslint-disable no-plusplus */
+/* eslint-disable fp/no-mutation */
+import axios from 'axios';
+import { Logger } from '@nestjs/common';
+import fs from 'fs';
+import yargs from 'yargs';
+import { createConnection, In } from 'typeorm';
+import Bluebird from 'bluebird';
+import { Point } from 'geojson';
+import { Site } from '../src/sites/sites.entity';
+import { createPoint } from '../src/utils/coordinates';
+
+const dbConfig = require('../ormconfig');
+
+let netcdf4;
+try {
+  // eslint-disable-next-line global-require, fp/no-mutation, import/no-unresolved
+  netcdf4 = require('netcdf4');
+} catch {
+  Logger.error(
+    'NetCDF is not installed. Please install NetCDF before continuing',
+  );
+  process.exit();
+}
+
+function getFileUrl() {
+  const date = new Date();
+
+  // No data are available for last 2 days
+  date.setDate(date.getDate() - 2);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  // List of some available files https://www.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1_op/nc/v1.0/daily/sst/2022/
+  return `https://www.star.nesdis.noaa.gov/pub/sod/mecb/crw/data/5km/v3.1_op/nc/v1.0/daily/sst/${year}/coraltemp_v3.1_${year}${month}${day}.nc`;
+}
+
+const { argv } = yargs
+  .scriptName('fill-noaa-availability')
+  .usage('$0 <cmd> [args]')
+  .option('s', {
+    alias: 'sites',
+    describe:
+      'Specify the sites for which nearest noaa availability point will be filled',
+    type: 'array',
+  })
+  .help();
+
+async function getAvailabilityMapFromNetCDF4() {
+  Logger.log('Fetching NetCDF4 file...');
+
+  const tempFileName = './noaa_data.nc';
+
+  const response = await axios.get(getFileUrl(), {
+    responseType: 'arraybuffer',
+  });
+  const buff = Buffer.from(response.data);
+  fs.writeFileSync(tempFileName, buff);
+
+  const netcdfData = new netcdf4.File(tempFileName, 'r');
+
+  Logger.log('Creating world mask...');
+
+  // world[lon][lat]: world[7200][3600]. true means a value is invalid.
+  const world: number[][] = [];
+  const { fillvalue } = netcdfData.root.variables.analysed_sst;
+
+  for (let i = 0; i < 7200; i++) {
+    const row = netcdfData.root.variables.analysed_sst
+      .readSlice(0, 1, 0, 3600, i, 1)
+      .map((x: number) => x === fillvalue);
+    world[i] = row;
+  }
+
+  Logger.log(`Deleting temp file: ${tempFileName}`);
+  fs.unlink(tempFileName, (err) => {
+    if (err) console.error(err);
+  });
+
+  return world;
+}
+
+function BFS(
+  visited: Map<string, boolean>,
+  stack: { lon: number; lat: number }[],
+  worldMap: number[][],
+): [number, number] | null {
+  const head = stack.shift();
+
+  if (!head) return null;
+  if (visited.has(`${head.lon},${head.lat}`))
+    return BFS(visited, stack, worldMap);
+  if (Boolean(worldMap[head.lon][head.lat]) === false)
+    return [head.lon, head.lat];
+
+  visited.set(`${head.lon},${head.lat}`, true);
+
+  const up = { lon: (head.lon + 1) % 7200, lat: head.lat };
+  const down = { lon: (head.lon + 1) % 7200, lat: head.lat };
+  const right = { lon: head.lon, lat: (head.lat + 1) % 3200 };
+  const left = { lon: head.lon, lat: (head.lat - 1) % 3200 };
+
+  if (!visited.has(`${up.lon},${up.lat}`)) stack.push(up);
+  if (!visited.has(`${down.lon},${down.lat}`)) stack.push(down);
+  if (!visited.has(`${right.lon},${right.lat}`)) stack.push(right);
+  if (!visited.has(`${left.lon},${left.lat}`)) stack.push(left);
+
+  return BFS(visited, stack, worldMap);
+}
+// Points further than 175km away from a noaa available point will result in a maximum stack exited error.
+async function getNearestAvailablePoint(
+  longitude: number,
+  latitude: number,
+  worldMap: number[][],
+): Promise<[number, number]> {
+  const lonIndex = Math.round((180 + longitude) / 0.05);
+  const latIndex = Math.round((90 + latitude) / 0.05);
+
+  const visited = new Map<string, boolean>();
+  const stack = [{ lon: lonIndex, lat: latIndex }];
+  const result = BFS(visited, stack, worldMap);
+  if (result === null) throw new Error('Did not find nearest point!');
+
+  return [
+    Number((result[0] * 0.05 - 180).toFixed(3)),
+    Number((result[1] * 0.05 - 90).toFixed(3)),
+  ];
+}
+
+async function run() {
+  const { s: sites } = argv;
+  const siteIds = sites && sites.map((site) => parseInt(`${site}`, 10));
+  const availabilityArray = await getAvailabilityMapFromNetCDF4();
+  createConnection(dbConfig).then(async (connection) => {
+    Logger.log('Fetching sites');
+    const siteRepository = connection.getRepository(Site);
+    const allSites = await siteRepository.find(
+      siteIds && siteIds.length > 0
+        ? {
+            where: {
+              id: In(siteIds),
+            },
+          }
+        : {},
+    );
+
+    await Bluebird.map(
+      allSites,
+      async (site) => {
+        const { polygon, id } = site;
+        const [longitude, latitude] = (polygon as Point).coordinates;
+        try {
+          const [NOAALongitude, NOAALatitude] = await getNearestAvailablePoint(
+            longitude,
+            latitude,
+            availabilityArray,
+          );
+
+          await siteRepository.save({
+            id,
+            nearestNOAALocation: createPoint(NOAALongitude, NOAALatitude),
+          });
+          Logger.log(
+            `Updated site ${id} (${longitude}, ${latitude}) -> (${NOAALongitude}, ${NOAALatitude}) `,
+          );
+        } catch (error) {
+          console.error(error);
+          Logger.warn(
+            `Could not get nearest point for (lon, lat): (${longitude}, ${latitude})`,
+          );
+        }
+      },
+      { concurrency: 8 },
+    );
+  });
+}
+
+run();

--- a/packages/api/scripts/noaa-availability.ts
+++ b/packages/api/scripts/noaa-availability.ts
@@ -19,7 +19,7 @@ try {
   netcdf4 = require('netcdf4');
 } catch {
   Logger.error(
-    'NetCDF is not installed. Please install NetCDF before continuing',
+    'NetCDF is not installed. Please install NetCDF before continuing.',
   );
   process.exit();
 }
@@ -27,7 +27,7 @@ try {
 function getFileUrl() {
   const date = new Date();
 
-  // No data are available for last 2 days
+  // NOAA data is usually available with a 2-day lag.
   date.setDate(date.getDate() - 2);
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, '0');

--- a/packages/api/src/sites/sites.entity.ts
+++ b/packages/api/src/sites/sites.entity.ts
@@ -61,6 +61,14 @@ export class Site {
   @Index({ spatial: true })
   polygon: GeoJSON | null;
 
+  @ApiPointProperty()
+  @Column({
+    type: 'geometry',
+    srid: 4326,
+    nullable: true,
+  })
+  nearestNOAALocation: GeoJSON | null;
+
   @ApiProperty({ example: 23 })
   @Column({ nullable: true, type: 'integer' })
   depth: number | null;

--- a/packages/api/src/utils/liveData.ts
+++ b/packages/api/src/utils/liveData.ts
@@ -15,22 +15,24 @@ export const getLiveData = async (
   isDeployed: boolean,
 ): Promise<SofarLiveData> => {
   console.time(`getLiveData for site ${site.id}`);
-  const { polygon, sensorId, maxMonthlyMean } = site;
+  const { polygon, sensorId, maxMonthlyMean, nearestNOAALocation } = site;
   // TODO - Accept Polygon option
-  const [longitude, latitude] = (polygon as Point).coordinates;
+  const [NOAALongitude, NOAALatitude] = nearestNOAALocation
+    ? (nearestNOAALocation as Point).coordinates
+    : (polygon as Point).coordinates;
 
   const now = new Date();
 
   const [spotterRawData, degreeHeatingDays, satelliteTemperature] =
     await Promise.all([
       sensorId && isDeployed ? getSpotterData(sensorId) : undefined,
-      getDegreeHeatingDays(latitude, longitude, now, maxMonthlyMean),
+      getDegreeHeatingDays(NOAALatitude, NOAALongitude, now, maxMonthlyMean),
       getSofarHindcastData(
         SofarModels.NOAACoralReefWatch,
         sofarVariableIDs[SofarModels.NOAACoralReefWatch]
           .analysedSeaSurfaceTemperature,
-        latitude,
-        longitude,
+        NOAALatitude,
+        NOAALongitude,
         now,
         96,
       ),

--- a/packages/api/src/utils/sofar-availability.test.ts
+++ b/packages/api/src/utils/sofar-availability.test.ts
@@ -1,3 +1,4 @@
+import { createPoint } from './coordinates';
 import {
   AVAILABLE_POINTS,
   getSofarNearestAvailablePoint,
@@ -9,13 +10,13 @@ test('getting Sofar Wave Model availability zones', () => {
 });
 
 test('snapping point to availability zones', () => {
-  const point: [number, number] = [150.091, -5.432];
+  const point = createPoint(150.091, -5.432);
   const validPoint = getSofarNearestAvailablePoint(point);
   expect(validPoint).toEqual([150, -5]);
 });
 
 test('null island', () => {
-  const point: [number, number] = [0, 0];
+  const point = createPoint(0, 0);
   const validPoint = getSofarNearestAvailablePoint(point);
   expect(validPoint).toEqual([0, 0]);
 });

--- a/packages/api/src/utils/sofar-availability.ts
+++ b/packages/api/src/utils/sofar-availability.ts
@@ -1,6 +1,7 @@
 import type { Coord } from '@turf/helpers';
-import type { FeatureCollection, Point } from 'geojson';
+import type { FeatureCollection, Point, Polygon } from 'geojson';
 import nearestPoint from '@turf/nearest-point';
+import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
 import availabilityPoints from './sofar-availability-points';
 
 export const AVAILABLE_POINTS: FeatureCollection<Point> = {
@@ -18,5 +19,40 @@ export function getSofarNearestAvailablePoint(point: Coord): [number, number] {
   // deconstructing number[] into [number, number] in order to make typescript compiler happy
   const [longitude, latitude] = nearestPoint(point, AVAILABLE_POINTS).geometry
     .coordinates;
-  return [longitude, latitude];
+
+  const poly: Polygon = {
+    type: 'Polygon',
+    coordinates: [
+      [
+        [
+          ((180 + longitude - 0.25) % 360) - 180,
+          ((90 + latitude + 0.25) % 180) - 90,
+        ],
+        [
+          ((180 + longitude - 0.25) % 360) - 180,
+          ((90 + latitude - 0.25) % 180) - 90,
+        ],
+        [
+          ((180 + longitude + 0.25) % 360) - 180,
+          ((90 + latitude - 0.25) % 180) - 90,
+        ],
+        [
+          ((180 + longitude + 0.25) % 360) - 180,
+          ((90 + latitude + 0.25) % 180) - 90,
+        ],
+
+        // first again
+        [
+          ((180 + longitude - 0.25) % 360) - 180,
+          ((90 + latitude + 0.25) % 180) - 90,
+        ],
+      ],
+    ],
+  };
+
+  const pointCoordinates = (point as Point)?.coordinates || point;
+
+  return booleanPointInPolygon(point, poly)
+    ? (pointCoordinates as [number, number])
+    : [longitude, latitude];
 }

--- a/packages/api/src/utils/sofar-availability.ts
+++ b/packages/api/src/utils/sofar-availability.ts
@@ -1,4 +1,3 @@
-import type { Coord } from '@turf/helpers';
 import type { FeatureCollection, Point, Polygon } from 'geojson';
 import nearestPoint from '@turf/nearest-point';
 import booleanPointInPolygon from '@turf/boolean-point-in-polygon';
@@ -15,7 +14,7 @@ export const AVAILABLE_POINTS: FeatureCollection<Point> = {
   })),
 };
 
-export function getSofarNearestAvailablePoint(point: Coord): [number, number] {
+export function getSofarNearestAvailablePoint(point: Point): [number, number] {
   // deconstructing number[] into [number, number] in order to make typescript compiler happy
   const [longitude, latitude] = nearestPoint(point, AVAILABLE_POINTS).geometry
     .coordinates;
@@ -50,7 +49,7 @@ export function getSofarNearestAvailablePoint(point: Coord): [number, number] {
     ],
   };
 
-  const pointCoordinates = (point as Point).coordinates;
+  const pointCoordinates = point.coordinates;
 
   return booleanPointInPolygon(point, poly)
     ? (pointCoordinates as [number, number])

--- a/packages/api/src/utils/sofar-availability.ts
+++ b/packages/api/src/utils/sofar-availability.ts
@@ -50,7 +50,7 @@ export function getSofarNearestAvailablePoint(point: Coord): [number, number] {
     ],
   };
 
-  const pointCoordinates = (point as Point)?.coordinates || point;
+  const pointCoordinates = (point as Point).coordinates;
 
   return booleanPointInPolygon(point, poly)
     ? (pointCoordinates as [number, number])

--- a/packages/api/src/utils/sst-time-series.ts
+++ b/packages/api/src/utils/sst-time-series.ts
@@ -72,9 +72,11 @@ export const updateSST = async (
     sources,
     async (source) => {
       const { site } = source;
-      const point = site.polygon as Point;
+      const { polygon, nearestNOAALocation } = site;
       // Extract site coordinates
-      const [longitude, latitude] = point.coordinates;
+      const [NOAALongitude, NOAALatitude] = nearestNOAALocation
+        ? (nearestNOAALocation as Point).coordinates
+        : (polygon as Point).coordinates;
 
       logger.log(`Back-filling site with id ${site.id}.`);
 
@@ -97,8 +99,8 @@ export const updateSST = async (
               SofarModels.NOAACoralReefWatch,
               sofarVariableIDs[SofarModels.NOAACoralReefWatch]
                 .analysedSeaSurfaceTemperature,
-              latitude,
-              longitude,
+              NOAALatitude,
+              NOAALongitude,
               startDate,
               endDate,
             ),
@@ -107,8 +109,8 @@ export const updateSST = async (
               SofarModels.NOAACoralReefWatch,
               sofarVariableIDs[SofarModels.NOAACoralReefWatch]
                 .degreeHeatingWeek,
-              latitude,
-              longitude,
+              NOAALatitude,
+              NOAALongitude,
               startDate,
               endDate,
             ),

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -79,9 +79,12 @@ export async function getDailyData(
   endOfDate: Date,
   excludedDates: ExclusionDates[],
 ): Promise<SofarDailyData> {
-  const { polygon, sensorId, maxMonthlyMean } = site;
+  const { polygon, sensorId, maxMonthlyMean, nearestNOAALocation } = site;
   // TODO - Accept Polygon option
   const [longitude, latitude] = (polygon as Point).coordinates;
+  const [NOAALongitude, NOAALatitude] = nearestNOAALocation
+    ? (nearestNOAALocation as Point).coordinates
+    : (polygon as Point).coordinates;
 
   const [
     spotterRawData,
@@ -101,8 +104,8 @@ export async function getDailyData(
       SofarModels.NOAACoralReefWatch,
       sofarVariableIDs[SofarModels.NOAACoralReefWatch]
         .analysedSeaSurfaceTemperature,
-      latitude,
-      longitude,
+      NOAALatitude,
+      NOAALongitude,
       endOfDate,
       96,
     ),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3711,6 +3711,14 @@
     "@turf/helpers" "6.x"
     "@turf/invariant" "6.x"
 
+"@turf/boolean-point-in-polygon@^6.5.0":
+  version "6.5.0"
+  resolved "https://registry.yarnpkg.com/@turf/boolean-point-in-polygon/-/boolean-point-in-polygon-6.5.0.tgz#6d2e9c89de4cd2e4365004c1e51490b7795a63cf"
+  integrity sha512-DtSuVFB26SI+hj0SjrvXowGTUCHlgevPAIsukssW6BG5MlNSBQAo70wpICBNJL6RjukXg8d2eXaAWuD/CqL00A==
+  dependencies:
+    "@turf/helpers" "^6.5.0"
+    "@turf/invariant" "^6.5.0"
+
 "@turf/clone@^6.5.0":
   version "6.5.0"
   resolved "https://registry.yarnpkg.com/@turf/clone/-/clone-6.5.0.tgz#895860573881ae10a02dfff95f274388b1cda51a"


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/784

- adds column `nearest_noaa_location` of type `geometry` to `sites` table
- adds script `yarn fill-noaa-nearest-point` to fill the above column at existing sites

Nearest available NOAA point is calculated, using netcdf files from https://coralreefwatch.noaa.gov/, which contain world wide data for single dates. Then running a breadth first search on the world 2x2 grid we calculate the nearest point.

This PR is a second attempt of it's [original](https://github.com/aqualinkorg/aqualink-app/pull/788), since we had issues deploying to cloud. It would be nice though if, in the future, we could automate the process instead of running the script manually.