### PR TITLE
Use site.dailyData for survey observation

### DIFF
--- a/packages/website/src/routes/Surveys/View/SurveyDetails.tsx
+++ b/packages/website/src/routes/Surveys/View/SurveyDetails.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   Typography,
 } from "@material-ui/core";
-import { useSelector } from "react-redux";
 
 import {
   getNumberOfImages,
@@ -17,10 +16,8 @@ import type { Site } from "../../../store/Sites/types";
 import type { SurveyState } from "../../../store/Survey/types";
 import { getSiteNameAndRegion } from "../../../store/Sites/helpers";
 import ObservationBox from "./ObservationBox";
-import { siteGranularDailyDataSelector } from "../../../store/Sites/selectedSiteSlice";
 
 const SurveyDetails = ({ site, survey, classes }: SurveyDetailsProps) => {
-  const dailyData = useSelector(siteGranularDailyDataSelector);
   const nSurveyPoints = getNumberOfSurveyPoints(survey?.surveyMedia || []);
   const nImages = getNumberOfImages(survey?.surveyMedia || []);
   const { region: regionName } = getSiteNameAndRegion(site);
@@ -93,7 +90,7 @@ const SurveyDetails = ({ site, survey, classes }: SurveyDetailsProps) => {
         <ObservationBox
           depth={site.depth}
           date={survey?.diveDate}
-          dailyData={dailyData || []}
+          dailyData={site.dailyData || []}
         />
       </Grid>
     </Grid>

--- a/packages/website/src/routes/Surveys/View/utils.ts
+++ b/packages/website/src/routes/Surveys/View/utils.ts
@@ -25,8 +25,12 @@ export const getCardTemperatureValues = (
 
   return {
     satelliteTemperature: surfaceData?.satelliteTemperature,
-    spotterBottom: getSensorValue(bottomTemperature?.spotter?.data, date),
-    spotterTop: getSensorValue(topTemperature?.spotter?.data, date),
+    spotterBottom:
+      getSensorValue(bottomTemperature?.spotter?.data, date) ||
+      surfaceData?.avgBottomTemperature,
+    spotterTop:
+      getSensorValue(topTemperature?.spotter?.data, date) ||
+      surfaceData?.topTemperature,
     hoboBottom: getSensorValue(bottomTemperature?.hobo?.data, date),
     hoboSurface: getSensorValue(topTemperature?.hobo?.data, date),
   };

--- a/packages/website/src/routes/Surveys/View/utils.ts
+++ b/packages/website/src/routes/Surveys/View/utils.ts
@@ -26,10 +26,10 @@ export const getCardTemperatureValues = (
   return {
     satelliteTemperature: surfaceData?.satelliteTemperature,
     spotterBottom:
-      getSensorValue(bottomTemperature?.spotter?.data, date) ||
+      getSensorValue(bottomTemperature?.spotter?.data, date) ??
       surfaceData?.avgBottomTemperature,
     spotterTop:
-      getSensorValue(topTemperature?.spotter?.data, date) ||
+      getSensorValue(topTemperature?.spotter?.data, date) ??
       surfaceData?.topTemperature,
     hoboBottom: getSensorValue(bottomTemperature?.hobo?.data, date),
     hoboSurface: getSensorValue(topTemperature?.hobo?.data, date),


### PR DESCRIPTION
Fixes #785 

Some of the data selectors we were using are not getting triggered properly so I switched to using site.dailyData instead.
And fall back to average values in dailyData when the spotter timeseries are not available.

https://aqualink.org/sites/2943/survey_details/401

<img width="1336" alt="Screen Shot 2022-10-30 at 10 48 51 AM" src="https://user-images.githubusercontent.com/16843267/198872661-aad70905-a5e2-4b8c-93c1-2d00fc505bbf.png">
