### PR TITLE
Add bottom pressure metric and line graphs

### DIFF
--- a/packages/api/migration/1667483794322-AddSpotterBottomPressure.ts
+++ b/packages/api/migration/1667483794322-AddSpotterBottomPressure.ts
@@ -1,0 +1,60 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSpotterBottomPressure1667483794322
+  implements MigrationInterface
+{
+  name = 'AddSpotterBottomPressure1667483794322';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum" ADD VALUE IF NOT EXISTS 'barometric_pressure_bottom'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum" RENAME VALUE 'barometric_pressure' TO 'barometric_pressure_top'`,
+    );
+
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum" RENAME VALUE 'barometric_pressure_diff' TO 'barometric_pressure_top_diff'`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP MATERIALIZED VIEW "latest_data"`);
+
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum" RENAME VALUE 'barometric_pressure_top_diff' TO 'barometric_pressure_diff'`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum" RENAME VALUE 'barometric_pressure_top' TO 'barometric_pressure'`,
+    );
+
+    await queryRunner.query(
+      `CREATE TYPE "public"."metrics_metric_enum_old" AS ENUM('temp_alert', 'temp_weekly_alert', 'dhw', 'air_temperature', 'satellite_temperature', 'top_temperature', 'bottom_temperature', 'sst_anomaly', 'significant_wave_height', 'wave_mean_period', 'wave_peak_period', 'wave_mean_direction', 'wind_speed', 'wind_direction', 'cholorophyll_rfu', 'cholorophyll_concentration', 'conductivity', 'water_depth', 'odo_saturation', 'odo_concentration', 'salinity', 'specific_conductance', 'tds', 'turbidity', 'total_suspended_solids', 'sonde_wiper_position', 'ph', 'ph_mv', 'sonde_battery_voltage', 'sonde_cable_power_voltage', 'pressure', 'precipitation', 'rh', 'wind_gust_speed', 'barometric_pressure', 'barometric_pressure_diff')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "metrics" ALTER COLUMN "metric" TYPE "public"."metrics_metric_enum_old" USING "metric"::"text"::"public"."metrics_metric_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ALTER COLUMN "metric" TYPE "public"."metrics_metric_enum_old" USING "metric"::"text"::"public"."metrics_metric_enum_old"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "forecast_data" ALTER COLUMN "metric" TYPE "public"."metrics_metric_enum_old" USING "metric"::"text"::"public"."metrics_metric_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."metrics_metric_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."metrics_metric_enum_old" RENAME TO "metrics_metric_enum"`,
+    );
+
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "latest_data"
+                AS SELECT
+                    DISTINCT ON (metric, type, site_id, survey_point_id)
+                    "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id
+                FROM "time_series" "time_series"
+                INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id"
+                WHERE timestamp >= current_date - INTERVAL '7 days'
+                OR type IN ('sonde') AND (timestamp >= current_date - INTERVAL '90 days')
+                ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`,
+    );
+  }
+}

--- a/packages/api/scripts/noaa-availability.ts
+++ b/packages/api/scripts/noaa-availability.ts
@@ -170,7 +170,7 @@ async function run() {
         } catch (error) {
           console.error(error);
           Logger.warn(
-            `Could not get nearest point for (lon, lat): (${longitude}, ${latitude})`,
+            `Could not get nearest point for site id: ${site.id}, (lon, lat): (${longitude}, ${latitude})`,
           );
         }
       },

--- a/packages/api/src/time-series/metrics.entity.ts
+++ b/packages/api/src/time-series/metrics.entity.ts
@@ -38,8 +38,9 @@ export enum Metric {
   PRECIPITATION = 'precipitation',
   RH = 'rh',
   WIND_GUST_SPEED = 'wind_gust_speed',
-  BAROMETRIC_PRESSURE = 'barometric_pressure',
-  BAROMETRIC_PRESSURE_DIFF = 'barometric_pressure_diff',
+  BAROMETRIC_PRESSURE_TOP = 'barometric_pressure_top',
+  BAROMETRIC_PRESSURE_TOP_DIFF = 'barometric_pressure_top_diff',
+  BAROMETRIC_PRESSURE_BOTTOM = 'barometric_pressure_bottom',
 }
 
 export enum Units {

--- a/packages/api/src/utils/sofar.ts
+++ b/packages/api/src/utils/sofar.ts
@@ -257,44 +257,60 @@ export async function getSpotterData(
     [[], []],
   );
 
-  const spotterBarometer: ValueWithTimestamp[] = barometerData.map((data) => ({
-    timestamp: data.timestamp,
-    value: data.value,
-  }));
+  const spotterBarometerTop: ValueWithTimestamp[] = barometerData.map(
+    (data) => ({
+      timestamp: data.timestamp,
+      value: data.value,
+    }),
+  );
 
-  const spotterBarometricDiff = getBarometricDiff(spotterBarometer);
+  const spotterBarometricTopDiff = getBarometricDiff(spotterBarometerTop);
 
   // Sofar increments sensors by distance to the spotter.
-  // Sensor 1 -> topTemp and Sensor 2 -> bottomTemp
-  const [sofarTopTemperature, sofarBottomTemperature]: [
+  // Sensor 1 -> top and Sensor 2 -> bottom
+  const [sofarTopTemperature, sofarBottomTemperature, sofarBottomPressure]: [
+    ValueWithTimestamp[],
     ValueWithTimestamp[],
     ValueWithTimestamp[],
   ] = smartMooringData.reduce(
-    ([sensor1Data, sensor2Data], data) => {
+    ([topTemp, bottomTemp, bottomPressure], data) => {
       const { sensorPosition, unit_type: unitType } = data;
 
       if (sensorPosition === 1 && unitType === 'temperature') {
         return [
-          sensor1Data.concat({
+          topTemp.concat({
             timestamp: data.timestamp,
             value: data.value,
           }),
-          sensor2Data,
+          bottomTemp,
+          bottomPressure,
         ];
       }
       if (sensorPosition === 2 && unitType === 'temperature') {
         return [
-          sensor1Data,
-          sensor2Data.concat({
+          topTemp,
+          bottomTemp.concat({
             timestamp: data.timestamp,
             value: data.value,
+          }),
+          bottomPressure,
+        ];
+      }
+      if (sensorPosition === 2 && unitType === 'pressure') {
+        return [
+          topTemp,
+          bottomTemp,
+          bottomPressure.concat({
+            timestamp: data.timestamp,
+            // convert micro bar to hPa
+            value: data.value / 1000,
           }),
         ];
       }
 
-      return [sensor1Data, sensor2Data];
+      return [topTemp, bottomTemp, bottomPressure];
     },
-    [[], []],
+    [[], [], []],
   );
 
   console.timeEnd(`getSpotterData for sensor ${sensorId}`);
@@ -309,8 +325,11 @@ export async function getSpotterData(
     waveMeanDirection: sofarMeanDirection,
     windSpeed: sofarWindSpeed,
     windDirection: sofarWindDirection,
-    barometer: spotterBarometer,
-    barometricDiff: spotterBarometricDiff ? [spotterBarometricDiff] : [],
+    barometerTop: spotterBarometerTop,
+    barometerBottom: sofarBottomPressure.filter((data) => !isNil(data.value)),
+    barometricTopDiff: spotterBarometricTopDiff
+      ? [spotterBarometricTopDiff]
+      : [],
     latitude: spotterLatitude,
     longitude: spotterLongitude,
   };

--- a/packages/api/src/utils/sofar.ts
+++ b/packages/api/src/utils/sofar.ts
@@ -151,7 +151,7 @@ export async function getSofarHindcastData(
 ) {
   const [start, end] = getStartEndDate(endDate, hours);
   // Get data for model and return values
-  console.time(`getSofarHindcast for ${modelId}-${variableID}`);
+  console.time(`getSofarHindcast ${modelId}-${variableID} for lat ${latitude}`);
   const hindcastVariables = await sofarHindcast(
     modelId,
     variableID,
@@ -160,7 +160,9 @@ export async function getSofarHindcastData(
     start,
     end,
   );
-  console.timeEnd(`getSofarHindcast for ${modelId}-${variableID}`);
+  console.timeEnd(
+    `getSofarHindcast ${modelId}-${variableID} for lat ${latitude}`,
+  );
 
   // Filter out unknown values
   return filterSofarResponse(hindcastVariables);

--- a/packages/api/src/utils/sofar.types.ts
+++ b/packages/api/src/utils/sofar.types.ts
@@ -56,8 +56,9 @@ export interface SpotterData {
   waveMeanDirection: ValueWithTimestamp[];
   windSpeed: ValueWithTimestamp[];
   windDirection: ValueWithTimestamp[];
-  barometer: ValueWithTimestamp[];
-  barometricDiff: ValueWithTimestamp[];
+  barometerTop: ValueWithTimestamp[];
+  barometerBottom: ValueWithTimestamp[];
+  barometricTopDiff: ValueWithTimestamp[];
   latitude?: ValueWithTimestamp[];
   longitude?: ValueWithTimestamp[];
 }
@@ -70,6 +71,7 @@ export const DEFAULT_SPOTTER_DATA_VALUE: SpotterData = {
   waveMeanDirection: [],
   windSpeed: [],
   windDirection: [],
-  barometer: [],
-  barometricDiff: [],
+  barometerTop: [],
+  barometerBottom: [],
+  barometricTopDiff: [],
 };

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -169,8 +169,9 @@ export const addSpotterData = async (
             ['waveMeanPeriod', Metric.WAVE_MEAN_PERIOD],
             ['windDirection', Metric.WIND_DIRECTION],
             ['windSpeed', Metric.WIND_SPEED],
-            ['barometer', Metric.BAROMETRIC_PRESSURE],
-            ['barometricDiff', Metric.BAROMETRIC_PRESSURE_DIFF],
+            ['barometerTop', Metric.BAROMETRIC_PRESSURE_TOP],
+            ['barometerBottom', Metric.BAROMETRIC_PRESSURE_BOTTOM],
+            ['barometricTopDiff', Metric.BAROMETRIC_PRESSURE_TOP_DIFF],
           ];
 
           // Save data to time_series

--- a/packages/api/src/utils/uploads/upload-sheet-data.ts
+++ b/packages/api/src/utils/uploads/upload-sheet-data.ts
@@ -473,7 +473,7 @@ export const uploadTimeSeriesData = async (
     });
 
     const barometricPressures = dataAsTimeSeriesNoDiffs.filter(
-      (x) => x.metric === Metric.BAROMETRIC_PRESSURE,
+      (x) => x.metric === Metric.BAROMETRIC_PRESSURE_TOP,
     );
     const pressuresBySource = groupBy(barometricPressures, 'source.site.id');
 
@@ -491,7 +491,7 @@ export const uploadTimeSeriesData = async (
           ? {
               timestamp: valueDiff.timestamp,
               value: valueDiff.value,
-              metric: Metric.BAROMETRIC_PRESSURE_DIFF,
+              metric: Metric.BAROMETRIC_PRESSURE_TOP_DIFF,
               source: sortedPressures[1].source,
               dataUpload: dataUploadsFile,
             }

--- a/packages/api/test/mock/daily-data.mock.ts
+++ b/packages/api/test/mock/daily-data.mock.ts
@@ -130,11 +130,15 @@ export const getMockSpotterData = (
       timestamp: start.clone().add(i, 'days').toISOString(),
       value: random(-180, 180, true),
     })),
-    barometer: times(diffDays, (i) => ({
+    barometerTop: times(diffDays, (i) => ({
       timestamp: start.clone().add(i, 'days').toISOString(),
       value: random(900, 1100, true),
     })),
-    barometricDiff: [],
+    barometerBottom: times(diffDays, (i) => ({
+      timestamp: start.clone().add(i, 'days').toISOString(),
+      value: random(900, 1100, true),
+    })),
+    barometricTopDiff: [],
   };
 };
 

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -54,7 +54,8 @@ const DEFAULT_METRICS: MetricsKeys[] = [
   "top_temperature",
   "wind_speed",
   "significant_wave_height",
-  "barometric_pressure",
+  "barometric_pressure_top",
+  "barometric_pressure_bottom",
 ];
 
 interface SpotterConfig {
@@ -70,9 +71,13 @@ const spotterConfig: Partial<Record<Metrics, SpotterConfig>> = {
     // convert from m/s to to km/h
     convert: 3.6,
   },
-  barometricPressure: {
+  barometricPressureTop: {
     unit: "hPa",
-    title: "Barometric Pressure",
+    title: "Surface Barometric Pressure",
+  },
+  barometricPressureBottom: {
+    unit: "hPa",
+    title: "Bottom Barometric Pressure",
   },
   significantWaveHeight: {
     unit: "m",
@@ -540,11 +545,13 @@ const MultipleSensorsCharts = ({
       {hasSpotterData &&
         Object.entries(spotterConfig).map(([key, { title }]) => {
           const datasets = [spotterMetricDataset(key as Metrics)];
-          // Since the data will only be available for a few sites,
+          // Since barometric data will only be available for a few sites,
           // we don’t want to display the warning message for all the others.
           if (
             !datasets[0] ||
-            (datasets[0].metric === "barometricPressure" &&
+            (datasets[0].metric === "barometricPressureTop" &&
+              !datasets[0].displayData) ||
+            (datasets[0].metric === "barometricPressureBottom" &&
               !datasets[0].displayData)
           ) {
             return <></>;

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -69,8 +69,8 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
   const {
     topTemperature,
     bottomTemperature,
-    barometricPressure,
-    barometricPressureDiff,
+    barometricPressureTop,
+    barometricPressureTopDiff,
   } = data;
 
   const relativeTime =
@@ -113,7 +113,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
       <CardContent className={classes.content}>
         <div className={classes.gridContainer}>
           {metrics.map(({ label, value }, index) => (
-            <div style={{ gridArea: `value${index}` }}>
+            <div style={{ gridArea: `value${index}` }} key={label}>
               <Typography
                 className={classes.contentTextTitles}
                 variant="subtitle2"
@@ -125,7 +125,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
               </Typography>
             </div>
           ))}
-          {barometricPressure && (
+          {barometricPressureTop && (
             <div style={{ gridArea: "value2" }}>
               <Typography
                 className={classes.contentTextTitles}
@@ -140,7 +140,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                 }}
               >
                 <Typography className={classes.contentTextValues} variant="h3">
-                  {formatNumber(barometricPressure?.value, 1)}
+                  {formatNumber(barometricPressureTop?.value, 1)}
                 </Typography>
                 <Typography className={classes.contentUnits} variant="h6">
                   hPa
@@ -152,7 +152,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
             <img
               alt="sensor"
               src={sensor}
-              height={barometricPressure ? "135" : "150"}
+              height={barometricPressureTop ? "135" : "150"}
               width="auto"
             />
           </div>
@@ -163,7 +163,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
               alignItems: "flex-end",
             }}
           >
-            {barometricPressure && (
+            {barometricPressureTopDiff && (
               <div>
                 <Box
                   style={{
@@ -171,11 +171,13 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                     alignItems: "flex-end",
                   }}
                 >
-                  {(barometricPressureDiff?.value || 0) === 0 && <RemoveIcon />}
-                  {(barometricPressureDiff?.value || 0) <= 0 && (
+                  {(barometricPressureTopDiff?.value || 0) === 0 && (
+                    <RemoveIcon />
+                  )}
+                  {(barometricPressureTopDiff?.value || 0) <= 0 && (
                     <ArrowDownwardIcon />
                   )}
-                  {(barometricPressureDiff?.value || 0) >= 0 && (
+                  {(barometricPressureTopDiff?.value || 0) >= 0 && (
                     <ArrowUpwardIcon />
                   )}
 
@@ -183,7 +185,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                     className={classes.contentTextValues}
                     variant="h3"
                   >
-                    {formatNumber(barometricPressureDiff?.value, 1)}
+                    {formatNumber(barometricPressureTopDiff?.value, 1)}
                   </Typography>
                   <Typography className={classes.contentUnits} variant="h6">
                     hPa

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -171,13 +171,13 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                     alignItems: "flex-end",
                   }}
                 >
-                  {(barometricPressureTopDiff?.value || 0) === 0 && (
+                  {(barometricPressureTopDiff.value || 0) === 0 && (
                     <RemoveIcon />
                   )}
-                  {(barometricPressureTopDiff?.value || 0) <= 0 && (
+                  {(barometricPressureTopDiff.value || 0) <= 0 && (
                     <ArrowDownwardIcon />
                   )}
-                  {(barometricPressureTopDiff?.value || 0) >= 0 && (
+                  {(barometricPressureTopDiff.value || 0) >= 0 && (
                     <ArrowUpwardIcon />
                   )}
 
@@ -185,7 +185,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                     className={classes.contentTextValues}
                     variant="h3"
                   >
-                    {formatNumber(barometricPressureTopDiff?.value, 1)}
+                    {formatNumber(barometricPressureTopDiff.value, 1)}
                   </Typography>
                   <Typography className={classes.contentUnits} variant="h6">
                     hPa

--- a/packages/website/src/store/Sites/helpers.ts
+++ b/packages/website/src/store/Sites/helpers.ts
@@ -339,8 +339,8 @@ export const parseLatestData = (
   const spotterTempWhitelist = new Set([
     "bottom_temperature",
     "top_temperature",
-    "barometric_pressure",
-    "barometric_pressure_diff",
+    "barometric_pressure_top",
+    "barometric_pressure_top_diff",
   ]);
 
   const filtered = copy.filter(

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -84,8 +84,9 @@ export const metricsKeysList = [
   "precipitation",
   "rh",
   "wind_gust_speed",
-  "barometric_pressure",
-  "barometric_pressure_diff",
+  "barometric_pressure_top",
+  "barometric_pressure_bottom",
+  "barometric_pressure_top_diff",
 ] as const;
 
 export type MetricsKeys = typeof metricsKeysList[number];


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/790

- adds new metric `barometric_pressure_bottom`
- renames metrics `barometric_pressure` and `barometric_pressure_diff` to `barometric_pressure_top` and `barometric_pressure_top_diff`
- adds bottom barometric pressure line graph if data are available

![image](https://user-images.githubusercontent.com/80451946/199758592-05d677e2-bd82-4aac-a00d-ca59ccbccfd3.png)
