### PR TITLE
Fix featured card data do not match table data

### DIFF
--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -241,12 +241,18 @@ export class SitesService {
 
     const videoStream = await this.checkVideoStream(site);
 
+    const mappedSiteData = await getCollectionData(
+      [site],
+      this.latestDataRepository,
+    );
+
     return {
       ...site,
       surveys,
       historicalMonthlyMean,
       videoStream,
       applied: site.applied,
+      collectionData: mappedSiteData[site.id],
     };
   }
 

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -18,9 +18,7 @@ import classNames from "classnames";
 import { Alert } from "@material-ui/lab";
 import Chart from "../../../../common/Chart";
 import { formatNumber } from "../../../../helpers/numberUtils";
-import { sortByDate } from "../../../../helpers/dates";
 import { Site } from "../../../../store/Sites/types";
-import { degreeHeatingWeeksCalculator } from "../../../../helpers/degreeHeatingWeeks";
 import { getSiteNameAndRegion } from "../../../../store/Sites/helpers";
 import { standardDailyDataDataset } from "../../../../common/Chart/MultipleSensorsCharts/helpers";
 import {
@@ -42,22 +40,8 @@ const SelectedSiteCardContent = ({
   const classes = useStyles({ imageUrl, loading });
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down("sm"));
-  const sortedDailyData = sortByDate(site?.dailyData || [], "date");
-  const dailyDataLen = sortedDailyData.length;
-  const {
-    maxBottomTemperature,
-    satelliteTemperature: dailyDataSatelliteTemperature,
-    degreeHeatingDays: dailyDataDegreeHeatingDays,
-  } = (dailyDataLen && sortedDailyData[dailyDataLen - 1]) || {};
-  const {
-    satelliteTemperature: collectionDataSatelliteTemperature,
-    dhw: collectionDataDegreeHeatingWeeks,
-  } = site?.collectionData || {};
-  const satelliteTemperature =
-    collectionDataSatelliteTemperature || dailyDataSatelliteTemperature;
-  const degreeHeatingWeeks =
-    collectionDataDegreeHeatingWeeks ||
-    degreeHeatingWeeksCalculator(dailyDataDegreeHeatingDays);
+  const { bottomTemperature, satelliteTemperature, dhw } =
+    site?.collectionData || {};
   const useCardWithImageLayout = Boolean(loading || imageUrl);
 
   const metrics = [
@@ -69,15 +53,15 @@ const SelectedSiteCardContent = ({
     },
     {
       label: "HEAT STRESS",
-      value: formatNumber(degreeHeatingWeeks, 1),
+      value: formatNumber(dhw, 1),
       unit: " DHW",
-      display: isNumber(degreeHeatingWeeks),
+      display: isNumber(dhw),
     },
     {
       label: `TEMP AT ${site?.depth}m`,
-      value: formatNumber(maxBottomTemperature, 1),
+      value: formatNumber(bottomTemperature, 1),
       unit: " °C",
-      display: isNumber(maxBottomTemperature) && isNumber(site?.depth),
+      display: isNumber(bottomTemperature) && isNumber(site?.depth),
     },
   ];
 

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -40,8 +40,11 @@ const SelectedSiteCardContent = ({
   const classes = useStyles({ imageUrl, loading });
   const theme = useTheme();
   const isTablet = useMediaQuery(theme.breakpoints.down("sm"));
-  const { bottomTemperature, satelliteTemperature, dhw } =
-    site?.collectionData || {};
+  const {
+    bottomTemperature,
+    satelliteTemperature,
+    dhw: degreeHeatingWeek,
+  } = site?.collectionData || {};
   const useCardWithImageLayout = Boolean(loading || imageUrl);
 
   const metrics = [
@@ -53,9 +56,9 @@ const SelectedSiteCardContent = ({
     },
     {
       label: "HEAT STRESS",
-      value: formatNumber(dhw, 1),
+      value: formatNumber(degreeHeatingWeek, 1),
       unit: " DHW",
-      display: isNumber(dhw),
+      display: isNumber(degreeHeatingWeek),
     },
     {
       label: `TEMP AT ${site?.depth}m`,

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -44,8 +44,20 @@ const SelectedSiteCardContent = ({
   const isTablet = useMediaQuery(theme.breakpoints.down("sm"));
   const sortedDailyData = sortByDate(site?.dailyData || [], "date");
   const dailyDataLen = sortedDailyData.length;
-  const { maxBottomTemperature, satelliteTemperature, degreeHeatingDays } =
-    (dailyDataLen && sortedDailyData[dailyDataLen - 1]) || {};
+  const {
+    maxBottomTemperature,
+    satelliteTemperature: dailyDataSatelliteTemperature,
+    degreeHeatingDays: dailyDataDegreeHeatingDays,
+  } = (dailyDataLen && sortedDailyData[dailyDataLen - 1]) || {};
+  const {
+    satelliteTemperature: collectionDataSatelliteTemperature,
+    dhw: collectionDataDegreeHeatingWeeks,
+  } = site?.collectionData || {};
+  const satelliteTemperature =
+    collectionDataSatelliteTemperature || dailyDataSatelliteTemperature;
+  const degreeHeatingWeeks =
+    collectionDataDegreeHeatingWeeks ||
+    degreeHeatingWeeksCalculator(dailyDataDegreeHeatingDays);
   const useCardWithImageLayout = Boolean(loading || imageUrl);
 
   const metrics = [
@@ -57,9 +69,9 @@ const SelectedSiteCardContent = ({
     },
     {
       label: "HEAT STRESS",
-      value: formatNumber(degreeHeatingWeeksCalculator(degreeHeatingDays), 1),
+      value: formatNumber(degreeHeatingWeeks, 1),
       unit: " DHW",
-      display: isNumber(degreeHeatingDays),
+      display: isNumber(degreeHeatingWeeks),
     },
     {
       label: `TEMP AT ${site?.depth}m`,

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
@@ -113,7 +113,7 @@ exports[`renders as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                23.0
+                15.9
                  
                 <mock-typography
                   component="span"
@@ -290,7 +290,7 @@ exports[`renders loading as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                23.0
+                15.9
                  
                 <mock-typography
                   component="span"

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
@@ -136,7 +136,7 @@ exports[`renders as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                4.9
+                0.0
                  
                 <mock-typography
                   component="span"
@@ -159,7 +159,7 @@ exports[`renders as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                39.0
+                10.7
                  
                 <mock-typography
                   component="span"
@@ -313,7 +313,7 @@ exports[`renders loading as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                4.9
+                0.0
                  
                 <mock-typography
                   component="span"
@@ -336,7 +336,7 @@ exports[`renders loading as expected 1`] = `
                 color="primary"
                 variant="h4"
               >
-                39.0
+                10.7
                  
                 <mock-typography
                   component="span"

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -17,6 +17,7 @@ import {
   timeSeriesRequest,
 } from "./helpers";
 import { getAxiosErrorMessage } from "../../helpers/errors";
+import { mapCollectionData } from "../Collection/utils";
 
 const selectedSiteInitialState: SelectedSiteState = {
   draft: null,
@@ -98,6 +99,7 @@ export const siteRequest = createAsyncThunk<
 
       return {
         ...data,
+        collectionData: mapCollectionData(data.collectionData || {}),
         dailyData,
         sketchFab,
         historicalMonthlyMean: sortBy(


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/776

Data in card where from `daily_data`, while in the table they are from `collectionData`, which in reality are `latest_data`.
To resolve the issue, we updated `sites/:id` endpoint to include the same `collectionData` as the `sites/` endpoint and use them instead of `daily_data`.

