### PR TITLE
Add deploy_website to ci actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,14 @@ jobs:
       - run: yarn build
       - run: cd packages/api && yarn build:cloud-functions
 
+  deploy_website:
+    working_directory: *working_directory
+    executor: default
+
+    steps:
+      - run: cd packages/website && yarn build
+      - run: surge --project ./build --domain aqualink-app-test.surge.sh
+
 workflows:
   version: 2.1
   build:
@@ -143,3 +151,8 @@ workflows:
       - build_app:
           requires:
             - build_dependencies
+
+      - deploy_website:
+          requires:
+            - build_dependencies
+            - test_website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,8 +139,8 @@ jobs:
       
       - run: |
           cd packages/api
-          export MY_MESSAGE=$(echo -e 'Build succeeded and deployed at https://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n(hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')')
-          yarn github-pr-comment -m "$MY_MESSAGE"
+          export PR_MESSAGE=$(echo -e 'Build succeeded and deployed at https://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n(hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')')
+          yarn github-pr-comment -m "$PR_MESSAGE"
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
   
   base:
     docker:
-      - image: cimg/base:stable
+      - image: cimg/base:current-22.04
 
 commands:
   install_psql:
@@ -154,7 +154,7 @@ jobs:
           curl --location --request POST "$pr_comment_url" \
           -u $GH_USER:$GH_TOKEN \
           --header 'Content-Type: application/json' \
-          --data-raw '{ "body": "Build succeeded and deployed at http://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n (hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')" }'
+          --data-raw '{ "body": "Build succeeded and deployed at https://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n (hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')" }'
 
 workflows:
   version: 2.1

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,10 @@ executors:
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: "CHANGE-ME"
         name: postgres
+  
+  base:
+    docker:
+      - image: cimg/base:stable
 
 commands:
   install_psql:
@@ -127,8 +131,30 @@ jobs:
     executor: default
 
     steps:
-      - run: cd packages/website && yarn build
-      - run: surge --project ./build --domain aqualink-app-test.surge.sh
+      - checkout_and_restore_dependencies
+
+      - run: cd packages/website && yarn build && yarn surge --project ./build --domain aqualink-app-${CIRCLE_PULL_REQUEST##*/}.surge.sh
+  
+  deploy_website_notification:
+    working_directory: *working_directory
+    executor: base
+    steps:
+      - run: |
+          sudo apt-get install jq
+
+          pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
+          -u $GH_USER:$GH_TOKEN)
+
+          if [ $(echo $pr_response | jq length) -eq 0 ]; then
+            echo "No PR found to update"
+          else
+            pr_comment_url=$(echo $pr_response | jq -r ".[]._links.comments.href")
+          fi
+
+          curl --location --request POST "$pr_comment_url" \
+          -u $GH_USER:$GH_TOKEN \
+          --header 'Content-Type: application/json' \
+          --data-raw '{ "body": "Build succeeded and deployed at http://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n (hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')" }'
 
 workflows:
   version: 2.1
@@ -154,5 +180,8 @@ workflows:
 
       - deploy_website:
           requires:
-            - build_dependencies
             - test_website
+
+      - deploy_website_notification:
+          requires:
+            - deploy_website

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,10 +19,6 @@ executors:
           POSTGRES_DB: postgres
           POSTGRES_PASSWORD: "CHANGE-ME"
         name: postgres
-  
-  base:
-    docker:
-      - image: cimg/base:current-22.04
 
 commands:
   install_psql:
@@ -137,7 +133,7 @@ jobs:
   
   deploy_website_notification:
     working_directory: *working_directory
-    executor: base
+    executor: default
     steps:
       - checkout_and_restore_dependencies
       

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -139,22 +139,13 @@ jobs:
     working_directory: *working_directory
     executor: base
     steps:
+      - checkout_and_restore_dependencies
+      
       - run: |
-          sudo apt-get install jq
+          cd packages/api
+          export MY_MESSAGE=$(echo -e 'Build succeeded and deployed at https://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n(hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')')
+          yarn github-pr-comment -m "$MY_MESSAGE"
 
-          pr_response=$(curl --location --request GET "https://api.github.com/repos/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/pulls?head=$CIRCLE_PROJECT_USERNAME:$CIRCLE_BRANCH&state=open" \
-          -u $GH_USER:$GH_TOKEN)
-
-          if [ $(echo $pr_response | jq length) -eq 0 ]; then
-            echo "No PR found to update"
-          else
-            pr_comment_url=$(echo $pr_response | jq -r ".[]._links.comments.href")
-          fi
-
-          curl --location --request POST "$pr_comment_url" \
-          -u $GH_USER:$GH_TOKEN \
-          --header 'Content-Type: application/json' \
-          --data-raw '{ "body": "Build succeeded and deployed at https://aqualink-app-'"${CIRCLE_PULL_REQUEST##*/}"'.surge.sh \n (hash `'"${CIRCLE_SHA1:0:7}"'` deployed at '"$( date '+%Y/%m/%d %H:%M:%S' )"')" }'
 
 workflows:
   version: 2.1

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -62,7 +62,8 @@
     "backfill-sofar-time-series": "ts-node -r dotenv/config scripts/backfill-sofar-time-series.ts",
     "update-wind-wave-data": "ts-node -r dotenv/config scripts/hindcast-wind-wave-data.ts",
     "resize-survey-images": "ts-node -r dotenv/config scripts/resize-survey-images.ts",
-    "fill-noaa-nearest-point": "ts-node -r dotenv/config scripts/noaa-availability.ts"
+    "fill-noaa-nearest-point": "ts-node -r dotenv/config scripts/noaa-availability.ts",
+    "github-pr-comment": "ts-node -r dotenv/config scripts/comment-github.ts"
   },
   "dependencies": {
     "@google-cloud/storage": "^5.3.0",
@@ -125,6 +126,7 @@
     "@types/passport-strategy": "^0.2.35",
     "@types/sharp": "^0.30.4",
     "@types/supertest": "^2.0.8",
+    "circleci-pr-commenter": "^0.1.2",
     "faker": "^4.1.0",
     "firebase-admin": "^9.0.0",
     "firebase-functions": "^3.8.0",

--- a/packages/api/scripts/comment-github.ts
+++ b/packages/api/scripts/comment-github.ts
@@ -1,0 +1,35 @@
+import yargs from 'yargs';
+import Commenter from 'circleci-pr-commenter';
+
+// Initialize command definition
+const { argv } = yargs
+  .scriptName('github-pr-comment')
+  .usage('$0 <cmd> [args]')
+  .example(
+    '$0 -f data/file.xml -s 1006 -p 3 -t sonde',
+    'This command will create or update a comment on github. It is used for automated comments.',
+  )
+  .option('m', {
+    alias: 'message',
+    describe: 'Message of the comment',
+    demandOption: true,
+    type: 'string',
+  })
+  .wrap(yargs.terminalWidth());
+
+const SURGE_COMMENT_KEY = 'SURGE_COMMENT_KEY';
+
+async function run() {
+  const { m: message } = argv;
+
+  const commenter = new Commenter();
+
+  // eslint-disable-next-line fp/no-mutation
+  commenter.env.token = process.env.GH_TOKEN || '';
+  // eslint-disable-next-line fp/no-mutation
+  commenter.env.tokenUserName = process.env.GH_USER || '';
+
+  await commenter.createOrUpdateComment(SURGE_COMMENT_KEY, message);
+}
+
+run();

--- a/packages/api/scripts/comment-github.ts
+++ b/packages/api/scripts/comment-github.ts
@@ -21,13 +21,12 @@ const SURGE_COMMENT_KEY = 'SURGE_COMMENT_KEY';
 
 async function run() {
   const { m: message } = argv;
+  // eslint-disable-next-line fp/no-mutation
+  process.env.GITHUB_TOKEN = process.env.GH_TOKEN;
+  // eslint-disable-next-line fp/no-mutation
+  process.env.GITHUB_TOKEN_USERNAME = process.env.GH_USER;
 
   const commenter = new Commenter();
-
-  // eslint-disable-next-line fp/no-mutation
-  commenter.env.token = process.env.GH_TOKEN || '';
-  // eslint-disable-next-line fp/no-mutation
-  commenter.env.tokenUserName = process.env.GH_USER || '';
 
   await commenter.createOrUpdateComment(SURGE_COMMENT_KEY, message);
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -104,6 +104,7 @@
     "@types/validator": "^13.1.0",
     "canvas": "^2.8.0",
     "cross-env": "^7.0.2",
-    "dotenv-cli": "^4.0.0"
+    "dotenv-cli": "^4.0.0",
+    "surge": "^0.23.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5824,6 +5824,13 @@ blakejs@^1.1.0:
   resolved "https://registry.yarnpkg.com/blakejs/-/blakejs-1.1.0.tgz#69df92ef953aa88ca51a32df6ab1c54a155fc7a5"
   integrity sha1-ad+S75U6qIylGjLfarHFShVfx6U=
 
+block-stream@*:
+  version "0.0.9"
+  resolved "https://registry.yarnpkg.com/block-stream/-/block-stream-0.0.9.tgz#13ebfe778a03205cfe03751481ebb4b3300c126a"
+  integrity sha512-OorbnJVPII4DuUKbjARAe8u8EfqOmkEEaSFIyoQ7OjTHn6kafxWl0wLgoZ2rXaYd7MyLcDaU4TmhfxtwgcccMQ==
+  dependencies:
+    inherits "~2.0.0"
+
 bluebird@^3.5.1, bluebird@^3.5.3, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -6721,7 +6728,7 @@ cli-spinners@^2.0.0, cli-spinners@^2.2.0, cli-spinners@^2.4.0:
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.4.0.tgz#c6256db216b878cfba4720e719cec7cf72685d7f"
   integrity sha512-sJAofoarcm76ZGpuooaO0eDy8saEy+YoZBLjC4h8srt4jeBnkYeOgqxgsJQTpyt2LjI5PTfLJHSL+41Yu4fEJA==
 
-cli-table3@0.5.1:
+cli-table3@0.5.1, cli-table3@^0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/cli-table3/-/cli-table3-0.5.1.tgz#0252372d94dfc40dbd8df06005f48f31f656f202"
   integrity sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==
@@ -6932,7 +6939,7 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-colors@^1.1.2, colors@^1.2.1:
+colors@1.4.0, colors@^1.1.2, colors@^1.2.1:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
@@ -10154,7 +10161,7 @@ fsevents@~2.1.2:
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
   integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
-fstream@^1.0.12:
+fstream@>=1.0.12, fstream@^1.0.12:
   version "1.0.12"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.12.tgz#4e8ba8ee2d48be4f7d0de505455548eae5932045"
   integrity sha512-WvJ193OHa0GHPEL+AycEJgxvBEwyfRkN1vhjca23OaPVMCaLCXTd5qAu82AjTcgP1UJmytkOKb63Ypde7raDIg==
@@ -11568,7 +11575,7 @@ inquirer@7.3.3:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
-inquirer@^6.2.0:
+inquirer@^6.2.0, inquirer@^6.2.2:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-6.5.2.tgz#ad50942375d036d327ff528c08bd5fab089928ca"
   integrity sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==
@@ -11811,6 +11818,11 @@ is-docker@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-docker/-/is-docker-2.1.1.tgz#4125a88e44e450d384e09047ede71adc2d144156"
   integrity sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
+
+is-domain@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/is-domain/-/is-domain-0.0.1.tgz#7ffb288d5cced6b07c4f2df91c9be9153511348e"
+  integrity sha512-hLm9uZUDm/sk0+xZgxyJluSf4B37sg3ivzv4ndTxNCAMnWFUUsHh1u4eh2maEcEvQl3mc65a9pJ/KURGItbLIg==
 
 is-extendable@^0.1.0, is-extendable@^0.1.1:
   version "0.1.1"
@@ -14131,6 +14143,13 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimatch@^3.0.0:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
+  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+  dependencies:
+    brace-expansion "^1.1.7"
+
 minimist-options@4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/minimist-options/-/minimist-options-4.1.0.tgz#c0655713c53a8a2ebd77ffa247d342c40f010619"
@@ -14147,6 +14166,11 @@ minimist-options@^3.0.1:
   dependencies:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
+
+minimist@1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.3.tgz#3db5c0765545ab8637be71f333a104a965a9ca3f"
+  integrity sha512-+bMdgqjMN/Z77a6NlY/I3U5LlRDbnmaAk6lDveAPKwSpcPM4tKAuYsvYF8xjhOPXhOYGe/73vVLVez5PW+jqhw==
 
 minimist@1.2.5, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
@@ -14296,6 +14320,11 @@ moment-timezone@*, moment-timezone@^0.5.31, moment-timezone@^0.5.x:
   version "2.29.4"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.4.tgz#3dbe052889fe7c1b2ed966fcb3a77328964ef108"
   integrity sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==
+
+moniker@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/moniker/-/moniker-0.1.2.tgz#872dfba575dcea8fa04a5135b13d5f24beccc97e"
+  integrity sha512-Uj9iV0QYr6281G+o0TvqhKwHHWB2Q/qUTT4LPQ3qDGc0r8cbMuqQjRXPZuVZ+gcL7APx+iQgE8lcfWPrj1LsLA==
 
 moo@^0.5.0:
   version "0.5.1"
@@ -14494,6 +14523,11 @@ netmask@^2.0.1:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
+netrc@0.1.4:
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/netrc/-/netrc-0.1.4.tgz#6be94fcaca8d77ade0a9670dc460914c94472444"
+  integrity sha512-ye8AIYWQcP9MvoM1i0Z2jV0qed31Z8EWXYnyGNkiUAd+Fo8J+7uy90xTV8g/oAbhtjkY7iZbNTizQaXdKUuwpQ==
 
 next-tick@1:
   version "1.1.0"
@@ -16729,6 +16763,11 @@ process@^0.11.10:
   resolved "https://registry.yarnpkg.com/process/-/process-0.11.10.tgz#7332300e840161bda3e69a1d1d91a7d4bc16f182"
   integrity sha1-czIwDoQBYb2j5podHZGn1LwW8YI=
 
+progress@1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
+  integrity sha512-UdA8mJ4weIkUBO224tIarHzuHs4HuYiJvsuGT7j/SPQiUJVjYvNDBIPa0hAorduOfjGohB/qHWRa/lrrWX/mXw==
+
 progress@^2.0.0, progress@^2.0.3:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
@@ -17624,6 +17663,13 @@ read@1, read@~1.0.1:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/read/-/read-1.0.7.tgz#b3da19bd052431a97671d44a42634adf710b40c4"
   integrity sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=
+  dependencies:
+    mute-stream "~0.0.4"
+
+read@1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/read/-/read-1.0.5.tgz#007a3d169478aa710a491727e453effb92e76203"
+  integrity sha512-hDLATrzYLoMu23c/69pMC6u3fO3Y0qLTIygJkEZHLOn+AO2gSapu6QgrgwX9ehyVtaRoZVZbF4IuiZPPRdGgdg==
   dependencies:
     mute-stream "~0.0.4"
 
@@ -19037,6 +19083,13 @@ split2@^2.0.0:
   dependencies:
     through2 "^2.0.2"
 
+split@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/split/-/split-0.3.1.tgz#cebcf142bf61bbb64b141628e6db482a2914654c"
+  integrity sha512-hCHXkQDs1HFKRsrT9EutGT1hmjS1FW1Aei8dk/CxrT7mslcMtAxbiv8LYA/AYDvjB6h9rSXgW8zAZwg20tKMTw==
+  dependencies:
+    through "2"
+
 split@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/split/-/split-1.0.1.tgz#605bd9be303aa59fb35f9229fbea0ddec9ea07d9"
@@ -19576,6 +19629,41 @@ supports-hyperlinks@^2.0.0:
     has-flag "^4.0.0"
     supports-color "^7.0.0"
 
+surge-fstream-ignore@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/surge-fstream-ignore/-/surge-fstream-ignore-1.0.6.tgz#e30efce95574b91fd571b5b02f32a611ea829731"
+  integrity sha512-hNN52cz2fYCAzhlHmWPn4aE3bFbpBt01AkWFLljrtSzFvxlipLAeLuLtQ3t4f0RKoUkjzXWCAFK13WoET2iM1A==
+  dependencies:
+    fstream ">=1.0.12"
+    inherits "2"
+    minimatch "^3.0.0"
+
+surge-ignore@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/surge-ignore/-/surge-ignore-0.2.0.tgz#5a7f8a20a71188cf9e75a2cfe8eb182de90daf3b"
+  integrity sha512-ay4MPFjfiQzDsyTidljJLXQi22l2AwjcuamYnJWj/LdhaHdKmDJxRox52WXimdcLpMuLDtkQvv4+jEu+wu9eSw==
+
+surge@^0.23.1:
+  version "0.23.1"
+  resolved "https://registry.yarnpkg.com/surge/-/surge-0.23.1.tgz#3cb283edad4e632e27162c633863ef4a915b961d"
+  integrity sha512-w92meVuKxqO1up0JpSe2iVSiVTv7E7t1qDA9fZhCSZx/+6Q85I3Y2LCoZIcWLpMm9BM0iB843NAWAwdScTR4Uw==
+  dependencies:
+    cli-table3 "^0.5.1"
+    colors "1.4.0"
+    inquirer "^6.2.2"
+    is-domain "0.0.1"
+    minimist "1.2.3"
+    moniker "0.1.2"
+    netrc "0.1.4"
+    progress "1.1.8"
+    read "1.0.5"
+    request "^2.88.0"
+    split "0.3.1"
+    surge-fstream-ignore "^1.0.6"
+    surge-ignore "0.2.0"
+    tarr "1.1.0"
+    url-parse-as-address "1.0.0"
+
 svg-parser@^2.0.2:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/svg-parser/-/svg-parser-2.0.4.tgz#fdc2e29e13951736140b76cb122c8ee6630eb6b5"
@@ -19684,6 +19772,15 @@ tar@^6.0.2, tar@^6.1.11, tar@^6.1.2:
     minizlib "^2.1.1"
     mkdirp "^1.0.3"
     yallist "^4.0.0"
+
+tarr@1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tarr/-/tarr-1.1.0.tgz#d7a9532ce97f08f5200b78ae0a82a6883173c8c8"
+  integrity sha512-tENbQ43IQckay71stp1p1lljRhoEZpZk10FzEZKW2tJcMcnLwV3CfZdxBAERlH6nwnFvnHMS9eJOJl6IzSsG0g==
+  dependencies:
+    block-stream "*"
+    fstream ">=1.0.12"
+    inherits "2"
 
 tcp-port-used@^1.0.1:
   version "1.0.1"
@@ -20610,6 +20707,11 @@ url-loader@4.1.1:
     loader-utils "^2.0.0"
     mime-types "^2.1.27"
     schema-utils "^3.0.0"
+
+url-parse-as-address@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/url-parse-as-address/-/url-parse-as-address-1.0.0.tgz#fb80901883f338b3cbed3538f5faa26adaf7f2e7"
+  integrity sha512-1WJ8YX1Kcec9wgxy8d/ATzGP1ayO6BRnd3iB6NlM+7cOnn6U8p5PKppRTCPLobh3CSdJ4d0TdPjopzyU2KcVFw==
 
 url-parse-lax@^3.0.0:
   version "3.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6614,6 +6614,13 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
+circleci-pr-commenter@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/circleci-pr-commenter/-/circleci-pr-commenter-0.1.2.tgz#e473ac5fa7a8ba2a31e8f7a98d47b2a61a4427ca"
+  integrity sha512-u+AY2sd1gyc31HS+ezIBFhggSdC0V8FEzAUf2/CSFkoFWA9QbfDshfaIDPzBm14laxZRk8gVVrdVr8aHj1DUBg==
+  dependencies:
+    gh-got "^8.1.0"
+
 cjs-module-lexer@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/cjs-module-lexer/-/cjs-module-lexer-0.6.0.tgz#4186fcca0eae175970aee870b9fe2d6cf8d5655f"
@@ -10438,6 +10445,13 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
+gh-got@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/gh-got/-/gh-got-8.1.0.tgz#2378d07ac293f524549c75f8dc6f3604a885ab01"
+  integrity sha512-Jy7+73XqsAVeAtM5zA0dd+A7mmzkQVIzFuw3xRjFbPsQVqS+aeci8v8H1heOCAPlBYWED5ZYPhlYqZVXdD3Fmg==
+  dependencies:
+    got "^9.5.0"
+
 git-raw-commits@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/git-raw-commits/-/git-raw-commits-2.0.0.tgz#d92addf74440c14bcc5c83ecce3fb7f8a79118b5"
@@ -10771,7 +10785,7 @@ google-p12-pem@^3.0.3:
   dependencies:
     node-forge "^0.10.0"
 
-got@^9.6.0:
+got@^9.5.0, got@^9.6.0:
   version "9.6.0"
   resolved "https://registry.yarnpkg.com/got/-/got-9.6.0.tgz#edf45e7d67f99545705de1f7bbeeeb121765ed85"
   integrity sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/741

Adds a CI step to Circle CI, which deploy the website to surge on every push. Also automatically comments  on the PR with the surge URL if the the deployment succeeds.

TODO: change `GH_USER` and `GH_TOKEN` in Circle CI env so it does not look like i make the comments.