### PR TITLE
Improve Collections

### DIFF
--- a/packages/api/src/collections/collections.controller.ts
+++ b/packages/api/src/collections/collections.controller.ts
@@ -20,13 +20,11 @@ import {
 import { Auth } from '../auth/auth.decorator';
 import { AuthRequest } from '../auth/auth.types';
 import { CollectionGuard } from '../auth/collection.guard';
-import { OverrideLevelAccess } from '../auth/override-level-access.decorator';
 import { Public } from '../auth/public.decorator';
 import {
   ApiNestNotFoundResponse,
   ApiNestUnauthorizedResponse,
 } from '../docs/api-response';
-import { AdminLevel } from '../users/users.entity';
 import { CollectionsService } from './collections.service';
 import { CreateCollectionDto } from './dto/create-collection.dto';
 import { FilterCollectionDto } from './dto/filter-collection.dto';
@@ -40,10 +38,12 @@ export class CollectionsController {
 
   @ApiBearerAuth()
   @ApiOperation({ summary: 'Creates a new collection' })
-  @OverrideLevelAccess(AdminLevel.SuperAdmin)
   @Post()
-  create(@Body() createCollectionDto: CreateCollectionDto) {
-    return this.collectionsService.create(createCollectionDto);
+  create(
+    @Body() createCollectionDto: CreateCollectionDto,
+    @Req() request: AuthRequest,
+  ) {
+    return this.collectionsService.create(createCollectionDto, request.user);
   }
 
   @ApiBearerAuth()

--- a/packages/api/src/collections/collections.service.ts
+++ b/packages/api/src/collections/collections.service.ts
@@ -46,7 +46,12 @@ export class CollectionsService {
   ): Promise<Collection> {
     const { name, isPublic, siteIds, userId: idFromDTO } = createCollectionDto;
 
-    if (idFromDTO && user?.adminLevel !== AdminLevel.SuperAdmin) {
+    // Users who are not admins can only create collections for themselves
+    if (
+      idFromDTO &&
+      idFromDTO !== user?.id &&
+      user?.adminLevel !== AdminLevel.SuperAdmin
+    ) {
       throw new ForbiddenException(
         'You are not allowed to execute this operation',
       );

--- a/packages/api/src/collections/collections.service.ts
+++ b/packages/api/src/collections/collections.service.ts
@@ -166,7 +166,7 @@ export class CollectionsService {
     const heatStressSiteIds = heatStressData.map((data) => data.siteId);
 
     const heatStressSites = await this.siteRepository.find({
-      where: { id: In(heatStressSiteIds), approved: true },
+      where: { id: In(heatStressSiteIds), display: true },
     });
 
     return this.processCollection(heatStressTracker, heatStressSites);

--- a/packages/api/src/collections/collections.spec.ts
+++ b/packages/api/src/collections/collections.spec.ts
@@ -27,7 +27,6 @@ import { TestService } from '../../test/test.service';
 import { mockExtractAndVerifyToken } from '../../test/utils';
 import { Metric } from '../time-series/metrics.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
-import { DEFAULT_COLLECTION_NAME } from '../utils/collections.utils';
 import { CreateCollectionDto } from './dto/create-collection.dto';
 import { UpdateCollectionDto } from './dto/update-collection.dto';
 
@@ -87,13 +86,9 @@ export const collectionTests = () => {
       const rsp = await request(app.getHttpServer()).get('/collections/');
 
       expect(rsp.status).toBe(200);
-      expect(rsp.body.length).toBe(2);
+      expect(rsp.body.length).toBe(1);
       const sortedRsp = sortBy(rsp.body, (o) => o.createdAt);
       expect(sortedRsp[0]).toMatchObject({
-        name: DEFAULT_COLLECTION_NAME,
-        isPublic: false,
-      });
-      expect(sortedRsp[1]).toMatchObject({
         name: createCollectionDto.name,
         isPublic: createCollectionDto.isPublic,
       });
@@ -120,7 +115,7 @@ export const collectionTests = () => {
         .query({ siteId: floridaSite.id });
 
       expect(rsp.status).toBe(200);
-      expect(rsp.body.length).toBe(2);
+      expect(rsp.body.length).toBe(1);
     });
 
     it('PUT /:id update the test collection', async () => {
@@ -278,9 +273,9 @@ export const collectionTests = () => {
     expect(rsp.status).toBe(404);
   });
 
-  it('GET /heat-stress get heat stress collection', async () => {
+  it('GET /heat-stress-tracker get heat stress collection', async () => {
     const rsp = await request(app.getHttpServer()).get(
-      '/collections/heat-stress',
+      '/collections/heat-stress-tracker',
     );
 
     expect(rsp.status).toBe(200);

--- a/packages/api/src/collections/collections.spec.ts
+++ b/packages/api/src/collections/collections.spec.ts
@@ -277,4 +277,12 @@ export const collectionTests = () => {
 
     expect(rsp.status).toBe(404);
   });
+
+  it('GET /heat-stress get heat stress collection', async () => {
+    const rsp = await request(app.getHttpServer()).get(
+      '/collections/heat-stress',
+    );
+
+    expect(rsp.status).toBe(200);
+  });
 };

--- a/packages/api/src/collections/dto/create-collection.dto.ts
+++ b/packages/api/src/collections/dto/create-collection.dto.ts
@@ -22,7 +22,7 @@ export class CreateCollectionDto {
   isPublic?: boolean;
 
   @ApiProperty({ example: 1 })
-  @IsNotEmpty()
+  @IsOptional()
   @IsNumber()
   @Validate(EntityExists, [User])
   userId: number;

--- a/packages/api/src/users/users.service.ts
+++ b/packages/api/src/users/users.service.ts
@@ -13,7 +13,6 @@ import { SiteApplication } from '../site-applications/site-applications.entity';
 import { Site } from '../sites/sites.entity';
 import { Collection } from '../collections/collections.entity';
 import { extractAndVerifyToken } from '../auth/firebase-auth.utils';
-import { defaultUserCollection } from '../utils/collections.utils';
 
 @Injectable()
 export class UsersService {
@@ -75,19 +74,6 @@ export class UsersService {
       firebaseUid,
     };
     const createdUser = await this.usersRepository.save(user);
-
-    const collection = await this.collectionRepository.findOne({
-      where: { user: createdUser },
-    });
-
-    if (!collection) {
-      await this.collectionRepository.save(
-        defaultUserCollection(
-          createdUser.id,
-          priorAccount?.administeredSites.map((site) => site.id),
-        ),
-      );
-    }
 
     return createdUser;
   }

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -50,15 +50,3 @@ export const heatStressTracker: DynamicCollection = {
   siteIds: [],
   isPublic: true,
 };
-
-export const DEFAULT_COLLECTION_NAME = 'My Dashboard';
-
-export const defaultUserCollection = (
-  userId: number,
-  siteIds: number[] = [],
-  name = DEFAULT_COLLECTION_NAME,
-) => ({
-  user: { id: userId },
-  name,
-  sites: siteIds.map((siteId) => ({ id: siteId })),
-});

--- a/packages/website/src/common/Banner/index.tsx
+++ b/packages/website/src/common/Banner/index.tsx
@@ -1,0 +1,40 @@
+import {
+  createStyles,
+  Theme,
+  Typography,
+  withStyles,
+  WithStyles,
+} from "@material-ui/core";
+import React from "react";
+
+function Banner({ message, classes }: BannerProps) {
+  return (
+    <div className={classes.banner}>
+      <Typography variant="h6" className={classes.text}>
+        {message}
+      </Typography>
+    </div>
+  );
+}
+
+interface BannerIncomingProps {
+  message: string;
+}
+
+interface BannerProps extends BannerIncomingProps, WithStyles<typeof styles> {}
+
+const styles = (theme: Theme) =>
+  createStyles({
+    banner: {
+      backgroundColor: theme.palette.warning.dark,
+      minHeight: "4rem",
+      display: "flex",
+      justifyContent: "center",
+      alignItems: "center",
+    },
+    text: {
+      color: theme.palette.text.primary,
+    },
+  });
+
+export default withStyles(styles)(Banner);

--- a/packages/website/src/helpers/siteUtils.ts
+++ b/packages/website/src/helpers/siteUtils.ts
@@ -71,7 +71,7 @@ export const hasDeployedSpotter = (site?: Site | null) =>
   Boolean(site?.sensorId && site?.status === "deployed");
 
 export const belongsToCollection = (siteId: number, siteIds?: number[]) =>
-  siteIds?.includes(siteId);
+  siteIds?.includes(siteId) || false;
 
 export const setSiteNameFromList = ({
   id,

--- a/packages/website/src/helpers/user.ts
+++ b/packages/website/src/helpers/user.ts
@@ -17,8 +17,6 @@ export const isManager = (user: User | null) =>
 export const isSuperAdmin = (user: User | null) =>
   user ? user.adminLevel === "super_admin" : false;
 
-export const hasCollection = (user: User | null) => !!user?.collection;
-
 export const isCollectionOwner = (
   user: User | null,
   collection: CollectionDetails

--- a/packages/website/src/routes/Dashboard/Content.tsx
+++ b/packages/website/src/routes/Dashboard/Content.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { Container, Grid, LinearProgress } from "@material-ui/core";
 import { useSelector } from "react-redux";
-
 import Header from "./Header";
 import Map from "./Map";
 import Info from "./Info";
@@ -12,6 +11,7 @@ import {
   collectionErrorSelector,
   collectionLoadingSelector,
 } from "../../store/Collection/collectionSlice";
+import Tracker from "../Tracker";
 
 const Content = () => {
   const collection = useSelector(collectionDetailsSelector);
@@ -27,9 +27,7 @@ const Content = () => {
   }
 
   if (collection?.sites.length === 0) {
-    return (
-      <FullScreenMessage message="There are no sites in your dashboard. Add sites to your dashboard to monitor multiple locations in a single view." />
-    );
+    return <Tracker shouldShowNav={false} />;
   }
 
   return collection ? (
@@ -45,7 +43,9 @@ const Content = () => {
       </Grid>
       <Table collection={collection} />
     </Container>
-  ) : null;
+  ) : (
+    <Tracker shouldShowNav={false} />
+  );
 };
 
 export default Content;

--- a/packages/website/src/routes/Dashboard/Content.tsx
+++ b/packages/website/src/routes/Dashboard/Content.tsx
@@ -12,6 +12,11 @@ import {
   collectionLoadingSelector,
 } from "../../store/Collection/collectionSlice";
 import Tracker from "../Tracker";
+import Banner from "../../common/Banner";
+
+const bannerMessage = `You have not saved any sites yet. \
+Follow the instructions on this page and come back \
+to your dashboard after saving a few sites!`;
 
 const Content = () => {
   const collection = useSelector(collectionDetailsSelector);
@@ -27,7 +32,12 @@ const Content = () => {
   }
 
   if (collection?.sites.length === 0) {
-    return <Tracker shouldShowNav={false} />;
+    return (
+      <>
+        <Banner message={bannerMessage} />
+        <Tracker shouldShowNav={false} />
+      </>
+    );
   }
 
   return collection ? (
@@ -44,7 +54,10 @@ const Content = () => {
       <Table collection={collection} />
     </Container>
   ) : (
-    <Tracker shouldShowNav={false} />
+    <>
+      <Banner message={bannerMessage} />
+      <Tracker shouldShowNav={false} />
+    </>
   );
 };
 

--- a/packages/website/src/routes/Dashboard/index.tsx
+++ b/packages/website/src/routes/Dashboard/index.tsx
@@ -64,9 +64,10 @@ const Dashboard = ({ match, classes }: DashboardProps) => {
     if (!atDashboard) {
       const { collectionName: urlCollectionName } = match.params;
       const isHeatStress = urlCollectionName === "heat-stress";
-      const urlCollectionId = urlCollectionName
-        ? collections[urlCollectionName]
-        : undefined;
+      const isId = !Number.isNaN(Number(urlCollectionName));
+      const urlCollectionId = isId
+        ? Number(urlCollectionName)
+        : (!!urlCollectionName && collections[urlCollectionName]) || undefined;
 
       if (
         (urlCollectionId && storedCollectionId !== urlCollectionId) ||

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/__snapshots__/index.test.tsx.snap
@@ -112,7 +112,24 @@ exports[`SiteNavBar should render with given state from Redux store 1`] = `
                 </div>
                 <div
                   class="MuiGrid-root SiteNavBar-headerButtonWrapper-3 MuiGrid-item"
-                />
+                >
+                  <mock-tooltip
+                    arrow="true"
+                    placement="top"
+                    title="Add to your dashboard"
+                  >
+                    <mock-iconbutton
+                      classname="CollectionButton-root-6"
+                      disabled="false"
+                    >
+                      <svg
+                        color="#3f51b5"
+                      >
+                        watch.svg
+                      </svg>
+                    </mock-iconbutton>
+                  </mock-tooltip>
+                </div>
               </div>
             </div>
             <div

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -995,7 +995,24 @@ exports[`Site Detail Page should render with given state from Redux store: snaps
                     </div>
                     <div
                       class="MuiGrid-root SiteNavBar-headerButtonWrapper-241 MuiGrid-item"
-                    />
+                    >
+                      <mock-tooltip
+                        arrow="true"
+                        placement="top"
+                        title="Add to your dashboard"
+                      >
+                        <mock-iconbutton
+                          classname="CollectionButton-root-244"
+                          disabled="false"
+                        >
+                          <svg
+                            color="#3f51b5"
+                          >
+                            watch.svg
+                          </svg>
+                        </mock-iconbutton>
+                      </mock-tooltip>
+                    </div>
                   </div>
                 </div>
                 <div
@@ -2747,7 +2764,24 @@ exports[`Site Detail Page should render with given state from Redux store: snaps
                     </div>
                     <div
                       class="MuiGrid-root SiteNavBar-headerButtonWrapper-52 MuiGrid-item"
-                    />
+                    >
+                      <mock-tooltip
+                        arrow="true"
+                        placement="top"
+                        title="Add to your dashboard"
+                      >
+                        <mock-iconbutton
+                          classname="CollectionButton-root-55"
+                          disabled="false"
+                        >
+                          <svg
+                            color="#3f51b5"
+                          >
+                            watch.svg
+                          </svg>
+                        </mock-iconbutton>
+                      </mock-tooltip>
+                    </div>
                   </div>
                 </div>
                 <div

--- a/packages/website/src/routes/Tracker/index.tsx
+++ b/packages/website/src/routes/Tracker/index.tsx
@@ -120,7 +120,11 @@ const useStyles = makeStyles((theme: Theme) =>
   })
 );
 
-const Tracker = () => {
+interface TrackerProps {
+  shouldShowNav?: boolean;
+}
+
+const Tracker = ({ shouldShowNav = true }: TrackerProps) => {
   const heroAspectRatio = useImageAspectRatio(hero);
   const image1AspectRatio = useImageAspectRatio(image1);
   const image2AspectRatio = useImageAspectRatio(image2);
@@ -135,7 +139,7 @@ const Tracker = () => {
 
   return (
     <>
-      <NavBar searchLocation={false} />
+      {shouldShowNav && <NavBar searchLocation={false} />}
       <Box className={classes.hero}>
         <CardMedia className={classes.image} image={hero} />
         <Container className={classes.titleWrapper}>

--- a/packages/website/src/services/collectionServices.ts
+++ b/packages/website/src/services/collectionServices.ts
@@ -5,6 +5,19 @@ import {
   CollectionUpdateParams,
 } from "../store/Collection/types";
 
+const createCollection = (
+  name: string,
+  isPublic: boolean,
+  siteIds: number[],
+  token?: string
+) =>
+  requests.send<CollectionDetailsResponse>({
+    method: "POST",
+    url: "collections",
+    token,
+    data: { name, isPublic, siteIds },
+  });
+
 const getCollections = (token?: string) =>
   requests.send<CollectionSummary[]>({
     method: "GET",
@@ -43,6 +56,7 @@ const updateCollection = (
   });
 
 export default {
+  createCollection,
   getCollections,
   getPublicCollection,
   getHeatStressCollection,

--- a/packages/website/src/store/Collection/collectionSlice.ts
+++ b/packages/website/src/store/Collection/collectionSlice.ts
@@ -1,5 +1,4 @@
 import { createAsyncThunk, createSlice, PayloadAction } from "@reduxjs/toolkit";
-
 import { CollectionState, CollectionRequestParams } from "./types";
 import type { CreateAsyncThunkTypes, RootState } from "../configure";
 import collectionServices from "../../services/collectionServices";

--- a/packages/website/src/store/Collection/types.ts
+++ b/packages/website/src/store/Collection/types.ts
@@ -10,7 +10,7 @@ export interface CollectionSummary {
 }
 
 export interface CollectionDetails {
-  id?: number;
+  id: number;
   name: string;
   isPublic: boolean;
   sites: Site[];

--- a/packages/website/src/store/User/types.ts
+++ b/packages/website/src/store/User/types.ts
@@ -18,6 +18,7 @@ export interface User {
 export interface UserState {
   userInfo: User | null;
   loading: boolean;
+  loadingCollection: boolean;
   error?: string | null;
 }
 
@@ -35,4 +36,11 @@ export interface UserSignInParams {
 
 export interface PasswordResetParams {
   email: string;
+}
+
+export interface CreateUserCollectionRequestParams {
+  name: string;
+  siteIds: number[];
+  token?: string;
+  isPublic?: boolean;
 }


### PR DESCRIPTION
The purpose of this PR is to resolve https://github.com/aqualinkorg/aqualink-app/issues/802 and https://github.com/aqualinkorg/aqualink-app/issues/755

This PR fixes:
- [heat-stress](https://aqualink.org/collections/heat-stress) collection not being accessible

Changes: 
- Collections are created when a user tries to add their first site. This change does not affect the user's flow.
- Default collection name now is: "User Name's collection"

Adds:
- It is now possible to access public collection throw their id
- The [/tracker](https://aqualink.org/tracker) page is now also displayed when a user either has no collection or its empty with an extra banner

![Screenshot from 2022-12-09 13-16-25](https://user-images.githubusercontent.com/80451946/206690988-5bbc9177-068d-4595-b37c-edd05eafcb47.png)

Additionally we can run the following SQL code to remove unused collections:
```
delete from collection c2
	where c2.id not in  
	(select c.id from collection c inner join collection_sites_site css on c.id = css.collection_id)
	and c2."name" = 'My Dashboard'
```
