### PR TITLE
Reduce number of requests in scheduledSSTTimeSeriesUpdate

### DIFF
--- a/packages/api/scripts/backfill-sofar-time-series.ts
+++ b/packages/api/scripts/backfill-sofar-time-series.ts
@@ -84,7 +84,6 @@ async function run() {
   return fn(
     parsedSiteIds,
     days,
-    connection,
     // Fetch all needed repositories
     {
       siteRepository: connection.getRepository(Site),

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -1,7 +1,7 @@
 import { Logger } from '@nestjs/common';
 import { get, times } from 'lodash';
 import moment from 'moment';
-import { Connection, In, IsNull, Not, Repository } from 'typeorm';
+import { In, IsNull, Not, Repository } from 'typeorm';
 import Bluebird from 'bluebird';
 import { Site } from '../sites/sites.entity';
 import { Sources } from '../sites/sources.entity';
@@ -95,13 +95,11 @@ const saveDataBatch = (
  * Fetch spotter and wave data from sofar and save them on time_series table
  * @param siteIds The siteIds for which to perform the update
  * @param days How many days will this script need to backfill (1 = daily update)
- * @param connection An active typeorm connection object
  * @param repositories The needed repositories, as defined by the interface
  */
 export const addSpotterData = async (
   siteIds: number[],
   days: number,
-  connection: Connection,
   repositories: Repositories,
 ) => {
   logger.log('Fetching sites');

--- a/packages/api/src/utils/sst-time-series.ts
+++ b/packages/api/src/utils/sst-time-series.ts
@@ -173,7 +173,7 @@ export const updateSST = async (
               if (!latest) return undefined;
               return {
                 value: alert,
-                timestamp: latest?.timestamp,
+                timestamp: latest.timestamp,
               };
             })
             .filter((x) => x !== undefined) as ValueWithTimestamp[];

--- a/packages/api/src/workers/spotterTimeSeries.ts
+++ b/packages/api/src/workers/spotterTimeSeries.ts
@@ -8,7 +8,7 @@ import { addSpotterData } from '../utils/spotter-time-series';
 import { addWindWaveData } from '../utils/hindcast-wind-wave';
 
 export function runSpotterTimeSeriesUpdate(connection: Connection) {
-  return addSpotterData([], 1, connection, {
+  return addSpotterData([], 1, {
     siteRepository: connection.getRepository(Site),
     sourceRepository: connection.getRepository(Sources),
     timeSeriesRepository: connection.getRepository(TimeSeries),

--- a/packages/api/src/workers/spotterTimeSeries.ts
+++ b/packages/api/src/workers/spotterTimeSeries.ts
@@ -7,8 +7,11 @@ import { TimeSeries } from '../time-series/time-series.entity';
 import { addSpotterData } from '../utils/spotter-time-series';
 import { addWindWaveData } from '../utils/hindcast-wind-wave';
 
+// since this is hourly run we want to only take the latest data.
+const DAYS_OF_SPOTTER_DATA = 1;
+
 export function runSpotterTimeSeriesUpdate(connection: Connection) {
-  return addSpotterData([], 1, {
+  return addSpotterData([], DAYS_OF_SPOTTER_DATA, {
     siteRepository: connection.getRepository(Site),
     sourceRepository: connection.getRepository(Sources),
     timeSeriesRepository: connection.getRepository(TimeSeries),

--- a/packages/api/src/workers/sstTimeSeries.ts
+++ b/packages/api/src/workers/sstTimeSeries.ts
@@ -4,8 +4,12 @@ import { Sources } from '../sites/sources.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { updateSST } from '../utils/sst-time-series';
 
+// we want to backfill at least 3 days ago, since the
+// hindcast api has available data only from 2 days ago and before.
+const SST_BACKFILL_DAYS = 4;
+
 export function runSSTTimeSeriesUpdate(connection: Connection) {
-  return updateSST([], 4, {
+  return updateSST([], SST_BACKFILL_DAYS, {
     siteRepository: connection.getRepository(Site),
     timeSeriesRepository: connection.getRepository(TimeSeries),
     sourceRepository: connection.getRepository(Sources),

--- a/packages/api/src/workers/sstTimeSeries.ts
+++ b/packages/api/src/workers/sstTimeSeries.ts
@@ -5,7 +5,7 @@ import { TimeSeries } from '../time-series/time-series.entity';
 import { updateSST } from '../utils/sst-time-series';
 
 export function runSSTTimeSeriesUpdate(connection: Connection) {
-  return updateSST([], 4, connection, {
+  return updateSST([], 4, {
     siteRepository: connection.getRepository(Site),
     timeSeriesRepository: connection.getRepository(TimeSeries),
     sourceRepository: connection.getRepository(Sources),


### PR DESCRIPTION
The purpose of this PR is to solve an issue where not all sites would get SST updates daily from the functions.
We suspect that sofar API fails to answer the big amount of the functions' requests.
This PR combines the 4 per site requests to 1 per site, by combining the start and end API parameters.
It also cleans up the functions logs so they are more useful.

Also since the sofar hindcast gives only one value per day, we could reduce the `scheduledSSTTimeSeriesUpdate` function calls from 1 per hour to one per day.