### PR TITLE
Add sampling card for HUI data

### DIFF
--- a/packages/website/src/common/Chip/index.tsx
+++ b/packages/website/src/common/Chip/index.tsx
@@ -74,6 +74,7 @@ const LinkWrapper: FC<
       to={to || { pathname: href }}
       target={href ? "_blank" : undefined}
       className={className}
+      rel="noopener noreferrer"
     >
       {children}
     </Link>

--- a/packages/website/src/common/Chip/index.tsx
+++ b/packages/website/src/common/Chip/index.tsx
@@ -12,7 +12,7 @@ import { grey, green } from "@material-ui/core/colors";
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
-    chip: ({ width }: { width: number }) => ({
+    chip: ({ width }: { width?: number }) => ({
       backgroundColor: grey[300],
       borderRadius: 8,
       height: 24,
@@ -61,7 +61,7 @@ interface ChipProps {
   liveText?: string;
   imageText?: string | null;
   image?: string | null;
-  width: number;
+  width?: number;
   onClick?: () => void;
 }
 

--- a/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root makeStyles-updateInfo-12 makeStyles-withMargin-13 MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
         >
           <div
-            class="MuiGrid-root makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-18 MuiGrid-item"
+            class="MuiGrid-root makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-18 MuiGrid-item MuiGrid-grid-xs-8"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
@@ -96,26 +96,31 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root makeStyles-chip-19 makeStyles-chip-25 MuiGrid-item"
+            class="MuiGrid-root MuiGrid-grid-xs-4"
+            style="display: flex; justify-content: flex-end;"
           >
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+              class="MuiGrid-root makeStyles-chip-19 makeStyles-chip-25 MuiGrid-item"
             >
-              <mock-button
-                classname="makeStyles-button-24"
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
               >
-                <a
-                  class="makeStyles-link-22"
-                  href="https://coralsitewatch.noaa.gov/product/5km/index_5km_baa_max_r07d.php"
-                  target="_blank"
+                <mock-button
+                  classname="makeStyles-button-24"
                 >
-                  <mock-typography
-                    classname="makeStyles-chipText-20"
+                  <a
+                    class="makeStyles-link-22"
+                    href="https://coralsitewatch.noaa.gov/product/5km/index_5km_baa_max_r07d.php"
+                    target="_blank"
                   >
-                    NOAA CRW
-                  </mock-typography>
-                </a>
-              </mock-button>
+                    <mock-typography
+                      classname="makeStyles-chipText-20"
+                    >
+                      NOAA CRW
+                    </mock-typography>
+                  </a>
+                </mock-button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
@@ -111,6 +111,7 @@ exports[`renders as expected 1`] = `
                   <a
                     class="makeStyles-link-22"
                     href="https://coralsitewatch.noaa.gov/product/5km/index_5km_baa_max_r07d.php"
+                    rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography

--- a/packages/website/src/common/SiteDetails/HUICard/index.tsx
+++ b/packages/website/src/common/SiteDetails/HUICard/index.tsx
@@ -28,27 +28,16 @@ const watchColor = "#e5bb2bd0";
 const warningColor = "#ef883cd0";
 const alertColor = "#dd143ed0";
 
-// TODO: Change these thresholds with some meaningful values
 const thresholds = {
-  bottomTemperature: {
-    good: 15,
-    watch: 20,
-    warning: 30,
-  },
   nitratePlusNitrite: {
-    good: 15,
-    watch: 20,
-    warning: 30,
-  },
-  salinity: {
-    good: 15,
-    watch: 20,
-    warning: 30,
+    good: 3.5,
+    watch: 30,
+    warning: 100,
   },
   turbidity: {
-    good: 3,
-    watch: 7,
-    warning: 12,
+    good: 1,
+    watch: 5,
+    warning: 10,
   },
 };
 
@@ -63,12 +52,8 @@ function getAlertColor(metric: HUICardMetrics, value?: number) {
   };
 
   switch (metric) {
-    case "ph":
-      return compare(thresholds.bottomTemperature);
     case "nitratePlusNitrite":
       return compare(thresholds.nitratePlusNitrite);
-    case "salinity":
-      return compare(thresholds.salinity);
     case "turbidity":
       return compare(thresholds.turbidity);
     default:
@@ -99,13 +84,11 @@ function HUICard({ data, classes }: HUICardProps) {
     {
       label: "pH",
       value: `${formatNumber(data?.ph?.value, 1)}`,
-      color: getAlertColor("ph", data?.ph?.value),
     },
     {
       label: "Salinity",
       value: `${formatNumber(data?.salinity?.value, 1)}`,
       unit: "psu",
-      color: getAlertColor("salinity", data?.salinity?.value),
     },
   ];
 

--- a/packages/website/src/common/SiteDetails/HUICard/index.tsx
+++ b/packages/website/src/common/SiteDetails/HUICard/index.tsx
@@ -1,0 +1,230 @@
+import {
+  Box,
+  Card,
+  CardContent,
+  CardHeader,
+  createStyles,
+  Grid,
+  Typography,
+  WithStyles,
+  withStyles,
+} from "@material-ui/core";
+import React from "react";
+import WarningIcon from "@material-ui/icons/Warning";
+import { toRelativeTime } from "../../../helpers/dates";
+import { formatNumber } from "../../../helpers/numberUtils";
+import { LatestDataASSofarValue, Metrics } from "../../../store/Sites/types";
+import UpdateInfo from "../../UpdateInfo";
+import { styles as incomingStyles } from "../styles";
+
+type HUICardMetrics =
+  | "salinity"
+  | "nitratePlusNitrite"
+  | "bottomTemperature"
+  | "turbidity";
+
+const watchColor = "#e5bb2bd0";
+const warningColor = "#ef883cd0";
+const alertColor = "#dd143ed0";
+
+// TODO: Change these thresholds with some meaningful values
+const thresholds = {
+  bottomTemperature: {
+    good: 15,
+    watch: 20,
+    warning: 30,
+  },
+  nitratePlusNitrite: {
+    good: 15,
+    watch: 20,
+    warning: 30,
+  },
+  salinity: {
+    good: 15,
+    watch: 20,
+    warning: 30,
+  },
+  turbidity: {
+    good: 3,
+    watch: 7,
+    warning: 12,
+  },
+};
+
+function getAlertColor(
+  metric: Extract<Metrics, HUICardMetrics>,
+  value?: number
+) {
+  if (!value) return undefined;
+
+  const compare = (th: { good: number; watch: number; warning: number }) => {
+    if (value < th.good) return undefined;
+    if (value < th.watch) return watchColor;
+    if (value < th.warning) return warningColor;
+    return alertColor;
+  };
+
+  switch (metric) {
+    case "bottomTemperature":
+      return compare(thresholds.bottomTemperature);
+    case "nitratePlusNitrite":
+      return compare(thresholds.nitratePlusNitrite);
+    case "salinity":
+      return compare(thresholds.salinity);
+    case "turbidity":
+      return compare(thresholds.turbidity);
+    default:
+      return undefined;
+  }
+}
+
+function HUICard({ data, classes }: HUICardProps) {
+  const relativeTime =
+    data?.salinity?.timestamp && toRelativeTime(data?.salinity?.timestamp);
+
+  const metrics = [
+    {
+      label: "Turbidity",
+      value: `${formatNumber(data?.turbidity?.value, 1)} FNU`,
+      color: getAlertColor("turbidity", data?.turbidity?.value),
+    },
+    {
+      label: "Nitrate Nitrite Nitrogen",
+      value: `${formatNumber(data?.nitratePlusNitrite?.value, 1)} psu`,
+      color: getAlertColor(
+        "nitratePlusNitrite",
+        data?.nitratePlusNitrite?.value
+      ),
+    },
+    {
+      label: "Temperature",
+      value: `${formatNumber(data?.bottomTemperature?.value, 1)}°C`,
+      color: getAlertColor("bottomTemperature", data?.bottomTemperature?.value),
+    },
+    {
+      label: "Salinity",
+      value: `${formatNumber(data?.salinity?.value, 1)} psu`,
+      color: getAlertColor("salinity", data?.salinity?.value),
+    },
+  ];
+
+  return (
+    <Card className={classes.root}>
+      <CardHeader
+        className={classes.header}
+        title={
+          <Grid container>
+            <Grid item>
+              <Typography className={classes.cardTitle} variant="h6">
+                WATER SAMPLING
+              </Typography>
+            </Grid>
+          </Grid>
+        }
+      />
+      <CardContent className={classes.content}>
+        <Box p="1rem" display="flex" flexGrow={1}>
+          <Grid container spacing={1}>
+            {metrics.map(({ label, value, color }) => (
+              <>
+                <Grid key={label} item xs={6}>
+                  <Grid container>
+                    <Grid item xs={12}>
+                      <div
+                        style={{
+                          display: "flex",
+                          alignItems: "center",
+                          flexWrap: "nowrap",
+                        }}
+                      >
+                        <Typography
+                          className={classes.contentTextTitles}
+                          variant="subtitle2"
+                        >
+                          {label}
+                        </Typography>
+                        {color && (
+                          <WarningIcon
+                            className={classes.contentTextTitles}
+                            style={{
+                              fontSize: "1.1em",
+                              marginRight: "1em",
+                              marginLeft: "auto",
+                              color,
+                            }}
+                          />
+                        )}
+                      </div>
+                    </Grid>
+                    <Grid item xs={12}>
+                      <Typography
+                        className={classes.contentTextValues}
+                        variant="h3"
+                      >
+                        {value}
+                      </Typography>
+                    </Grid>
+                  </Grid>
+                </Grid>
+              </>
+            ))}
+          </Grid>
+        </Box>
+
+        <Grid container>
+          {[
+            { text: "watch", color: watchColor },
+            { text: "warning", color: warningColor },
+            { text: "alert", color: alertColor },
+          ].map(({ text, color }) => (
+            <Grid
+              key={text}
+              item
+              xs={4}
+              style={{ backgroundColor: color, height: "2rem" }}
+            >
+              <Box textAlign="center">
+                <Typography variant="caption" align="center">
+                  {text}
+                </Typography>
+              </Box>
+            </Grid>
+          ))}
+        </Grid>
+
+        <UpdateInfo
+          relativeTime={relativeTime}
+          timeText="Last data received"
+          imageText="HUI"
+          live={false}
+        />
+      </CardContent>
+    </Card>
+  );
+}
+
+const styles = () =>
+  createStyles({
+    ...incomingStyles,
+    root: {
+      height: "100%",
+      display: "flex",
+      flexDirection: "column",
+      backgroundColor: "#37a692",
+    },
+    content: {
+      display: "flex",
+      flexDirection: "column",
+      justifyContent: "space-between",
+      flexGrow: 1,
+      padding: 0,
+    },
+  });
+
+interface HUICardIncomingProps {
+  data: Partial<Pick<LatestDataASSofarValue, HUICardMetrics>>;
+}
+
+type HUICardProps = WithStyles<typeof styles> & HUICardIncomingProps;
+
+export default withStyles(styles)(HUICard);

--- a/packages/website/src/common/SiteDetails/HUICard/index.tsx
+++ b/packages/website/src/common/SiteDetails/HUICard/index.tsx
@@ -16,12 +16,13 @@ import { formatNumber } from "../../../helpers/numberUtils";
 import { LatestDataASSofarValue, Metrics } from "../../../store/Sites/types";
 import UpdateInfo from "../../UpdateInfo";
 import { styles as incomingStyles } from "../styles";
+import { Extends } from "../../types";
+import { colors } from "../../../layout/App/theme";
 
-type HUICardMetrics =
-  | "salinity"
-  | "nitratePlusNitrite"
-  | "bottomTemperature"
-  | "turbidity";
+type HUICardMetrics = Extends<
+  Metrics,
+  "salinity" | "nitratePlusNitrite" | "ph" | "turbidity"
+>;
 
 const watchColor = "#e5bb2bd0";
 const warningColor = "#ef883cd0";
@@ -51,10 +52,7 @@ const thresholds = {
   },
 };
 
-function getAlertColor(
-  metric: Extract<Metrics, HUICardMetrics>,
-  value?: number
-) {
+function getAlertColor(metric: HUICardMetrics, value?: number) {
   if (!value) return undefined;
 
   const compare = (th: { good: number; watch: number; warning: number }) => {
@@ -65,7 +63,7 @@ function getAlertColor(
   };
 
   switch (metric) {
-    case "bottomTemperature":
+    case "ph":
       return compare(thresholds.bottomTemperature);
     case "nitratePlusNitrite":
       return compare(thresholds.nitratePlusNitrite);
@@ -85,25 +83,28 @@ function HUICard({ data, classes }: HUICardProps) {
   const metrics = [
     {
       label: "Turbidity",
-      value: `${formatNumber(data?.turbidity?.value, 1)} FNU`,
+      value: `${formatNumber(data?.turbidity?.value, 1)}`,
+      unit: "FNU",
       color: getAlertColor("turbidity", data?.turbidity?.value),
     },
     {
       label: "Nitrate Nitrite Nitrogen",
-      value: `${formatNumber(data?.nitratePlusNitrite?.value, 1)} psu`,
+      value: `${formatNumber(data?.nitratePlusNitrite?.value, 1)}`,
+      unit: "mg/L",
       color: getAlertColor(
         "nitratePlusNitrite",
         data?.nitratePlusNitrite?.value
       ),
     },
     {
-      label: "Temperature",
-      value: `${formatNumber(data?.bottomTemperature?.value, 1)}°C`,
-      color: getAlertColor("bottomTemperature", data?.bottomTemperature?.value),
+      label: "pH",
+      value: `${formatNumber(data?.ph?.value, 1)}`,
+      color: getAlertColor("ph", data?.ph?.value),
     },
     {
       label: "Salinity",
-      value: `${formatNumber(data?.salinity?.value, 1)} psu`,
+      value: `${formatNumber(data?.salinity?.value, 1)}`,
+      unit: "psu",
       color: getAlertColor("salinity", data?.salinity?.value),
     },
   ];
@@ -125,7 +126,7 @@ function HUICard({ data, classes }: HUICardProps) {
       <CardContent className={classes.content}>
         <Box p="1rem" display="flex" flexGrow={1}>
           <Grid container spacing={1}>
-            {metrics.map(({ label, value, color }) => (
+            {metrics.map(({ label, value, color, unit }) => (
               <>
                 <Grid key={label} item xs={6}>
                   <Grid container>
@@ -135,6 +136,7 @@ function HUICard({ data, classes }: HUICardProps) {
                           display: "flex",
                           alignItems: "center",
                           flexWrap: "nowrap",
+                          minHeight: "2em",
                         }}
                       >
                         <Typography
@@ -156,13 +158,26 @@ function HUICard({ data, classes }: HUICardProps) {
                         )}
                       </div>
                     </Grid>
-                    <Grid item xs={12}>
+                    <Grid
+                      item
+                      xs={12}
+                      style={{ display: "flex", alignItems: "baseline" }}
+                    >
                       <Typography
                         className={classes.contentTextValues}
                         variant="h3"
+                        style={{ whiteSpace: "nowrap" }}
                       >
                         {value}
                       </Typography>
+                      {unit && (
+                        <Typography
+                          className={classes.contentUnits}
+                          variant="h6"
+                        >
+                          {unit}
+                        </Typography>
+                      )}
                     </Grid>
                   </Grid>
                 </Grid>
@@ -210,7 +225,7 @@ const styles = () =>
       height: "100%",
       display: "flex",
       flexDirection: "column",
-      backgroundColor: "#37a692",
+      backgroundColor: colors.greenCardColor,
     },
     content: {
       display: "flex",

--- a/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
@@ -377,6 +377,7 @@ exports[`renders as expected 1`] = `
                 <a
                   class="makeStyles-link-20"
                   href="https://coralsitewatch.noaa.gov/"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography

--- a/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
@@ -313,10 +313,10 @@ exports[`renders as expected 1`] = `
         </div>
       </div>
       <div
-        class="MuiGrid-root makeStyles-updateInfo-11 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
+        class="MuiGrid-root makeStyles-updateInfo-10 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root makeStyles-dateInfoWrapper-15 makeStyles-dateInfoWrapper-17 MuiGrid-item"
+          class="MuiGrid-root makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-16 MuiGrid-item MuiGrid-grid-xs-8"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
@@ -326,7 +326,7 @@ exports[`renders as expected 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root makeStyles-updateIcon-13 MuiSvgIcon-fontSizeSmall"
+                class="MuiSvgIcon-root makeStyles-updateIcon-12 MuiSvgIcon-fontSizeSmall"
                 focusable="false"
                 viewBox="0 0 24 24"
               >
@@ -336,7 +336,7 @@ exports[`renders as expected 1`] = `
               </svg>
             </div>
             <div
-              class="MuiGrid-root makeStyles-dateInfo-16 MuiGrid-item"
+              class="MuiGrid-root makeStyles-dateInfo-15 MuiGrid-item"
             >
               <mock-box
                 display="flex"
@@ -344,7 +344,7 @@ exports[`renders as expected 1`] = `
                 width="100%"
               >
                 <mock-typography
-                  classname="makeStyles-updateInfoText-14"
+                  classname="makeStyles-updateInfoText-13"
                   variant="caption"
                 >
                   Last data received
@@ -352,7 +352,7 @@ exports[`renders as expected 1`] = `
                   1 day ago
                 </mock-typography>
                 <mock-typography
-                  classname="makeStyles-updateInfoText-14"
+                  classname="makeStyles-updateInfoText-13"
                   variant="caption"
                 >
                   Updated daily
@@ -362,31 +362,36 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root makeStyles-chip-18 makeStyles-chip-24 MuiGrid-item"
+          class="MuiGrid-root MuiGrid-grid-xs-4"
+          style="display: flex; justify-content: flex-end;"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+            class="MuiGrid-root makeStyles-chip-17 makeStyles-chip-23 MuiGrid-item"
           >
-            <mock-button
-              classname="makeStyles-button-23"
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
             >
-              <a
-                class="makeStyles-link-21"
-                href="https://coralsitewatch.noaa.gov/"
-                target="_blank"
+              <mock-button
+                classname="makeStyles-button-22"
               >
-                <mock-typography
-                  classname="makeStyles-chipText-19"
+                <a
+                  class="makeStyles-link-20"
+                  href="https://coralsitewatch.noaa.gov/"
+                  target="_blank"
                 >
-                  NOAA
-                </mock-typography>
-                <img
-                  alt="sensor-type"
-                  class="makeStyles-sensorImage-22"
-                  src="satellite.svg"
-                />
-              </a>
-            </mock-button>
+                  <mock-typography
+                    classname="makeStyles-chipText-18"
+                  >
+                    NOAA
+                  </mock-typography>
+                  <img
+                    alt="sensor-type"
+                    class="makeStyles-sensorImage-21"
+                    src="satellite.svg"
+                  />
+                </a>
+              </mock-button>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/website/src/common/SiteDetails/Satellite/index.tsx
+++ b/packages/website/src/common/SiteDetails/Satellite/index.tsx
@@ -153,10 +153,6 @@ const styles = () =>
       flexGrow: 1,
       padding: 0,
     },
-    contentText: {
-      marginTop: "1rem",
-      padding: "0 1rem",
-    },
   });
 
 interface SatelliteIncomingProps {

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root makeStyles-updateInfo-10 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
       >
         <div
-          class="MuiGrid-root makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-16 MuiGrid-item"
+          class="MuiGrid-root makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-16 MuiGrid-item MuiGrid-grid-xs-8"
         >
           <div
             class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
@@ -207,26 +207,31 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root makeStyles-chip-17 makeStyles-chip-23 MuiGrid-item"
+          class="MuiGrid-root MuiGrid-grid-xs-4"
+          style="display: flex; justify-content: flex-end;"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+            class="MuiGrid-root makeStyles-chip-17 makeStyles-chip-23 MuiGrid-item"
           >
-            <mock-button
-              classname="makeStyles-button-22"
+            <div
+              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
             >
-              <a
-                class="makeStyles-link-20"
-                href="/sites/1"
-                target="_blank"
+              <mock-button
+                classname="makeStyles-button-22"
               >
-                <mock-typography
-                  classname="makeStyles-chipText-18"
+                <a
+                  class="makeStyles-link-20"
+                  href="/sites/1"
+                  target="_blank"
                 >
-                  VIEW UPLOAD
-                </mock-typography>
-              </a>
-            </mock-button>
+                  <mock-typography
+                    classname="makeStyles-chipText-18"
+                  >
+                    VIEW UPLOAD
+                  </mock-typography>
+                </a>
+              </mock-button>
+            </div>
           </div>
         </div>
       </div>

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -222,6 +222,7 @@ exports[`renders as expected 1`] = `
                 <a
                   class="makeStyles-link-20"
                   href="/sites/1"
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -24,8 +24,9 @@ import {
 import UpdateInfo from "../../UpdateInfo";
 import requests from "../../../helpers/requests";
 import siteServices from "../../../services/siteServices";
+import { colors } from "../../../layout/App/theme";
 
-const CARD_BACKGROUND_COLOR = "#37A692";
+const CARD_BACKGROUND_COLOR = colors.greenCardColor;
 const METRICS: SondeMetricsKeys[] = [
   "odo_concentration",
   "cholorophyll_concentration",

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -255,6 +255,7 @@ exports[`renders as expected 1`] = `
                   <a
                     class="makeStyles-link-29"
                     href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
+                    rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root makeStyles-updateInfo-19 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
         >
           <div
-            class="MuiGrid-root makeStyles-dateInfoWrapper-23 makeStyles-dateInfoWrapper-25 MuiGrid-item"
+            class="MuiGrid-root makeStyles-dateInfoWrapper-23 makeStyles-dateInfoWrapper-25 MuiGrid-item MuiGrid-grid-xs-8"
           >
             <div
               class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
@@ -240,26 +240,31 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root makeStyles-chip-26 makeStyles-chip-32 MuiGrid-item"
+            class="MuiGrid-root MuiGrid-grid-xs-4"
+            style="display: flex; justify-content: flex-end;"
           >
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+              class="MuiGrid-root makeStyles-chip-26 makeStyles-chip-32 MuiGrid-item"
             >
-              <mock-button
-                classname="makeStyles-button-31"
+              <div
+                class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
               >
-                <a
-                  class="makeStyles-link-29"
-                  href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
-                  target="_blank"
+                <mock-button
+                  classname="makeStyles-button-31"
                 >
-                  <mock-typography
-                    classname="makeStyles-chipText-27"
+                  <a
+                    class="makeStyles-link-29"
+                    href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
+                    target="_blank"
                   >
-                    SOFAR MODEL
-                  </mock-typography>
-                </a>
-              </mock-button>
+                    <mock-typography
+                      classname="makeStyles-chipText-27"
+                    >
+                      SOFAR MODEL
+                    </mock-typography>
+                  </a>
+                </mock-button>
+              </div>
             </div>
           </div>
         </div>

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -122,7 +122,7 @@ const SiteDetails = ({
             data={latestDataAsSofarValues}
           />,
           (() => {
-            if (hasHUIData)
+            if (hasHUIData) {
               return (
                 <HUICard
                   data={{
@@ -130,13 +130,14 @@ const SiteDetails = ({
                     turbidity: latestDataAsSofarValues.turbidity,
                     nitratePlusNitrite:
                       latestDataAsSofarValues.nitratePlusNitrite,
-                    bottomTemperature:
-                      latestDataAsSofarValues.bottomTemperature,
+                    ph: latestDataAsSofarValues.ph,
                   }}
                 />
               );
-            if (hasSondeData)
+            }
+            if (hasSondeData) {
               return <WaterSamplingCard siteId={site.id.toString()} />;
+            }
             return (
               <CoralBleaching
                 dailyData={

--- a/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders as expected 1`] = `
     class="MuiGrid-root makeStyles-updateInfo-1 false MuiGrid-container MuiGrid-item MuiGrid-align-items-xs-center MuiGrid-justify-xs-space-between"
   >
     <div
-      class="MuiGrid-root makeStyles-dateInfoWrapper-5 makeStyles-dateInfoWrapper-7 MuiGrid-item"
+      class="MuiGrid-root makeStyles-dateInfoWrapper-5 makeStyles-dateInfoWrapper-7 MuiGrid-item MuiGrid-grid-xs-8"
     >
       <div
         class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
@@ -52,20 +52,25 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <div
-      class="MuiGrid-root makeStyles-chip-8 makeStyles-chip-14 MuiGrid-item"
+      class="MuiGrid-root MuiGrid-grid-xs-4"
+      style="display: flex; justify-content: flex-end;"
     >
       <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
+        class="MuiGrid-root makeStyles-chip-8 makeStyles-chip-14 MuiGrid-item"
       >
-        <mock-button
-          classname="makeStyles-button-13"
+        <div
+          class="MuiGrid-root MuiGrid-container MuiGrid-align-items-xs-center MuiGrid-justify-xs-center"
         >
-          <mock-typography
-            classname="makeStyles-chipText-9"
+          <mock-button
+            classname="makeStyles-button-13"
           >
-            NOAA
-          </mock-typography>
-        </mock-button>
+            <mock-typography
+              classname="makeStyles-chipText-9"
+            >
+              NOAA
+            </mock-typography>
+          </mock-button>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/website/src/common/UpdateInfo/index.tsx
+++ b/packages/website/src/common/UpdateInfo/index.tsx
@@ -1,13 +1,5 @@
 import React from "react";
-import {
-  Theme,
-  Grid,
-  Box,
-  Typography,
-  makeStyles,
-  useTheme,
-  useMediaQuery,
-} from "@material-ui/core";
+import { Theme, Grid, Box, Typography, makeStyles } from "@material-ui/core";
 import { grey } from "@material-ui/core/colors";
 import UpdateIcon from "@material-ui/icons/Update";
 import Chip from "../Chip";
@@ -31,8 +23,6 @@ const UpdateInfo = ({
   onClick,
 }: UpdateInfoProps) => {
   const classes = useStyles({ chipWidth });
-  const theme = useTheme();
-  const smallChip = useMediaQuery(theme.breakpoints.only("md"));
   return (
     <Grid
       className={`${classes.updateInfo} ${withMargin && classes.withMargin}`}
@@ -41,7 +31,7 @@ const UpdateInfo = ({
       alignItems="center"
       item
     >
-      <Grid item className={classes.dateInfoWrapper}>
+      <Grid item className={classes.dateInfoWrapper} xs={8}>
         <Grid container alignItems="center" justify="center">
           <Grid item>
             <UpdateIcon className={classes.updateIcon} fontSize="small" />
@@ -67,18 +57,15 @@ const UpdateInfo = ({
           </Grid>
         </Grid>
       </Grid>
-      <Chip
-        live={live}
-        href={live ? undefined : href}
-        image={image}
-        imageText={imageText}
-        onClick={onClick}
-        width={
-          smallChip
-            ? chipWidth || CHIP_SMALL_DEFAULT_WIDTH
-            : chipWidth || CHIP_LARGE_DEFAULT_WIDTH
-        }
-      />
+      <Grid xs={4} style={{ display: "flex", justifyContent: "flex-end" }}>
+        <Chip
+          live={live}
+          href={live ? undefined : href}
+          image={image}
+          imageText={imageText}
+          onClick={onClick}
+        />
+      </Grid>
     </Grid>
   );
 };
@@ -112,6 +99,8 @@ const useStyles = makeStyles((theme: Theme) => ({
     [theme.breakpoints.only("md")]: {
       width: `calc(100% - ${chipWidth || CHIP_SMALL_DEFAULT_WIDTH}px)`,
     },
+    display: "flex",
+    justifyContent: "flex-start",
   }),
   dateInfo: {
     width: `calc(100% - ${UPDATE_ICON_RIGHT_MARGIN + UPDATE_ICON_SIZE}px)`,

--- a/packages/website/src/common/types.ts
+++ b/packages/website/src/common/types.ts
@@ -10,3 +10,5 @@ export interface RegisterFormFields {
   emailAddress: string;
   password: string;
 }
+
+export type Extends<T, U extends T> = U;

--- a/packages/website/src/layout/App/theme.ts
+++ b/packages/website/src/layout/App/theme.ts
@@ -18,6 +18,7 @@ const black = "#2f2f2f";
 const white = "#ffffff";
 const lightGray = "#939393";
 const specialSensorColor = "#f78c21";
+const greenCardColor = "#37a692";
 
 const fontFamily =
   "-apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif";
@@ -29,6 +30,7 @@ export const colors = {
   darkGreyBlue,
   black,
   specialSensorColor,
+  greenCardColor,
 };
 
 const breakpoints = createBreakpoints({});

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -87,6 +87,7 @@ export const metricsKeysList = [
   "barometric_pressure_top",
   "barometric_pressure_bottom",
   "barometric_pressure_top_diff",
+  "nitrate_plus_nitrite",
 ] as const;
 
 export type MetricsKeys = typeof metricsKeysList[number];
@@ -106,7 +107,14 @@ type CamelCase<S extends string> =
 
 export type Metrics = CamelCase<MetricsKeys>;
 
-export type Sources = "spotter" | "hobo" | "noaa" | "gfs" | "sonde" | "metlog";
+export type Sources =
+  | "spotter"
+  | "hobo"
+  | "noaa"
+  | "gfs"
+  | "sonde"
+  | "metlog"
+  | "hui";
 
 export type LatestDataASSofarValue = {
   [keys in Metrics]?: ValueWithTimestamp;

--- a/packages/website/src/utils/google-analytics.ts
+++ b/packages/website/src/utils/google-analytics.ts
@@ -54,6 +54,9 @@ export const useGATagManager = () => {
 };
 
 export const initGA = () => {
+  if (!GA_TRACKING_ID) {
+    return;
+  }
   ReactGA.initialize(GA_TRACKING_ID);
   // TODO - test if custome page path is needed.
   // ReactGA.send("pageview");


### PR DESCRIPTION
This PR resolves https://github.com/aqualinkorg/aqualink-app/issues/801

Shows the following card, in the place of coral bleaching card, when HUI data are available. 

![Screenshot from 2023-01-16 12-34-16](https://user-images.githubusercontent.com/80451946/212847033-9e9a75fc-2f08-4696-a22c-be3041591eb3.png)


TODOs:
- Change value thresholds for metrics in HUI card with something meaningful
