### PR TITLE
Index "timestamp" column on "time_series" table

### DIFF
--- a/packages/api/migration/1680793520417-AddTimestampIndexToTimeSeries.ts
+++ b/packages/api/migration/1680793520417-AddTimestampIndexToTimeSeries.ts
@@ -1,0 +1,19 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddTimestampIndexToTimeSeries1680793520417
+  implements MigrationInterface
+{
+  name = 'AddTimestampIndexToTimeSeries1680793520417';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX "IDX_50ce87d671efea12c27fae36eb" ON "time_series" ("timestamp") `,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_50ce87d671efea12c27fae36eb"`,
+    );
+  }
+}

--- a/packages/api/src/time-series/time-series.entity.ts
+++ b/packages/api/src/time-series/time-series.entity.ts
@@ -23,6 +23,7 @@ export class TimeSeries {
   @PrimaryGeneratedColumn()
   id: number;
 
+  @Index()
   @Column({ nullable: false })
   timestamp: Date;
 


### PR DESCRIPTION
Resolves https://github.com/aqualinkorg/aqualink-app/issues/786

Add index on `timestamp` on `time_series` table to speed up queries and `lates_data` refresh time.