### PR TITLE
Standardize API case

### DIFF
--- a/packages/api/src/collections/collections.spec.ts
+++ b/packages/api/src/collections/collections.spec.ts
@@ -234,7 +234,11 @@ export const collectionTests = () => {
 
     expect(sortedSites[0].collectionData).toStrictEqual(
       // Omit top and bottom temperature since hobo data are not included in collection data
-      omit(athensLatestData, Metric.TOP_TEMPERATURE, Metric.BOTTOM_TEMPERATURE),
+      omit(
+        athensLatestData,
+        _.camelCase(Metric.TOP_TEMPERATURE),
+        _.camelCase(Metric.BOTTOM_TEMPERATURE),
+      ),
     );
     expect(sortedSites[1].collectionData).toStrictEqual(californiaLatestData);
     expect(sortedSites[2].collectionData).toStrictEqual(floridaLatestData);

--- a/packages/api/src/collections/collections.spec.ts
+++ b/packages/api/src/collections/collections.spec.ts
@@ -39,7 +39,7 @@ const collectionDtoToEntity = (dto: CreateCollectionDto) => ({
 
 const getLatestData = (data: DeepPartial<TimeSeries>[]) =>
   _(data)
-    .groupBy((o) => o.metric)
+    .groupBy((o) => _.camelCase(o.metric))
     .mapValues((o) => maxBy(o, (obj) => obj.timestamp)?.value)
     .toJSON();
 

--- a/packages/api/src/collections/dto/collection-data.dto.ts
+++ b/packages/api/src/collections/dto/collection-data.dto.ts
@@ -1,5 +1,8 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { MetricAsCamelcase } from '../../time-series/metrics.entity';
+import { KeysToCamelCase } from '../../utils/type-utils';
+import { Metric } from '../../time-series/metrics.entity';
+
+type MetricAsCamelcase = KeysToCamelCase<Record<Metric, number>>;
 
 type CollectionDataDtoType = Partial<
   Pick<

--- a/packages/api/src/collections/dto/collection-data.dto.ts
+++ b/packages/api/src/collections/dto/collection-data.dto.ts
@@ -1,44 +1,62 @@
-/* eslint-disable camelcase */
 import { ApiPropertyOptional } from '@nestjs/swagger';
-import { Metric } from '../../time-series/metrics.entity';
+import { MetricAsCamelcase } from '../../time-series/metrics.entity';
 
-export class CollectionDataDto {
+type CollectionDataDtoType = Partial<
+  Pick<
+    MetricAsCamelcase,
+    | 'bottomTemperature'
+    | 'topTemperature'
+    | 'satelliteTemperature'
+    | 'dhw'
+    | 'tempAlert'
+    | 'tempWeeklyAlert'
+    | 'sstAnomaly'
+    | 'significantWaveHeight'
+    | 'waveMeanDirection'
+    | 'waveMeanPeriod'
+    | 'wavePeakPeriod'
+    | 'windDirection'
+    | 'windSpeed'
+  >
+>;
+
+export class CollectionDataDto implements CollectionDataDtoType {
   @ApiPropertyOptional({ example: 28.05 })
-  [Metric.BOTTOM_TEMPERATURE]?: number;
+  bottomTemperature?: number;
 
   @ApiPropertyOptional({ example: 29.05 })
-  [Metric.TOP_TEMPERATURE]?: number;
+  topTemperature?: number;
 
   @ApiPropertyOptional({ example: 29.13 })
-  [Metric.SATELLITE_TEMPERATURE]?: number;
+  satelliteTemperature?: number;
 
   @ApiPropertyOptional({ example: 0 })
-  [Metric.DHW]?: number;
+  dhw?: number;
 
   @ApiPropertyOptional({ example: 1 })
-  [Metric.ALERT]?: number;
+  tempAlert?: number;
 
   @ApiPropertyOptional({ example: 1 })
-  [Metric.WEEKLY_ALERT]?: number;
+  tempWeeklyAlert?: number;
 
   @ApiPropertyOptional({ example: -0.101 })
-  [Metric.SST_ANOMALY]?: number;
+  sstAnomaly?: number;
 
   @ApiPropertyOptional({ example: 1.32 })
-  [Metric.SIGNIFICANT_WAVE_HEIGHT]?: number;
+  significantWaveHeight?: number;
 
   @ApiPropertyOptional({ example: 2 })
-  [Metric.WAVE_MEAN_DIRECTION]?: number;
+  waveMeanDirection?: number;
 
   @ApiPropertyOptional({ example: 12 })
-  [Metric.WAVE_MEAN_PERIOD]?: number;
+  waveMeanPeriod?: number;
 
   @ApiPropertyOptional({ example: 12 })
-  [Metric.WAVE_PEAK_PERIOD]?: number;
+  wavePeakPeriod?: number;
 
   @ApiPropertyOptional({ example: 153 })
-  [Metric.WIND_DIRECTION]?: number;
+  windDirection?: number;
 
   @ApiPropertyOptional({ example: 10.4 })
-  [Metric.WIND_SPEED]?: number;
+  windSpeed?: number;
 }

--- a/packages/api/src/docs/api-sensor-data.ts
+++ b/packages/api/src/docs/api-sensor-data.ts
@@ -1,7 +1,6 @@
 import { ApiPropertyOptions, getSchemaPath } from '@nestjs/swagger';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { TimeSeriesPoint } from '../time-series/dto/time-series-point.dto';
-import { Metric } from '../time-series/metrics.entity';
 
 export const sensorDataSchema: ApiPropertyOptions = {
   type: 'object',
@@ -9,10 +8,10 @@ export const sensorDataSchema: ApiPropertyOptions = {
     [SourceType.SPOTTER]: {
       type: 'object',
       properties: {
-        [Metric.BOTTOM_TEMPERATURE]: {
+        bottomTemperature: {
           $ref: getSchemaPath(TimeSeriesPoint),
         },
-        [Metric.TOP_TEMPERATURE]: {
+        topTemperature: {
           $ref: getSchemaPath(TimeSeriesPoint),
         },
       },
@@ -20,7 +19,7 @@ export const sensorDataSchema: ApiPropertyOptions = {
     [SourceType.HOBO]: {
       type: 'object',
       properties: {
-        [Metric.BOTTOM_TEMPERATURE]: {
+        bottomTemperature: {
           $ref: getSchemaPath(TimeSeriesPoint),
         },
       },
@@ -28,7 +27,7 @@ export const sensorDataSchema: ApiPropertyOptions = {
     [SourceType.NOAA]: {
       type: 'object',
       properties: {
-        [Metric.SATELLITE_TEMPERATURE]: {
+        satelliteTemperature: {
           $ref: getSchemaPath(TimeSeriesPoint),
         },
       },

--- a/packages/api/src/sensors/dto/sensor-data.dto.ts
+++ b/packages/api/src/sensors/dto/sensor-data.dto.ts
@@ -1,16 +1,27 @@
 import { SourceType } from '../../sites/schemas/source-type.enum';
 import { TimeSeriesPoint } from '../../time-series/dto/time-series-point.dto';
 import { Metric } from '../../time-series/metrics.entity';
+import { KeysToCamelCase } from '../../utils/type-utils';
 
-export class SensorDataDto {
+type MetricAsCamelcase = KeysToCamelCase<Record<Metric, TimeSeriesPoint>>;
+
+interface SensorDataDtoType {
+  [SourceType.SPOTTER]?: Partial<
+    Pick<MetricAsCamelcase, 'bottomTemperature' | 'topTemperature'>
+  >;
+  [SourceType.HOBO]?: Partial<Pick<MetricAsCamelcase, 'bottomTemperature'>>;
+  [SourceType.NOAA]?: Partial<Pick<MetricAsCamelcase, 'satelliteTemperature'>>;
+}
+
+export class SensorDataDto implements SensorDataDtoType {
   [SourceType.SPOTTER]?: {
-    [Metric.BOTTOM_TEMPERATURE]?: TimeSeriesPoint;
-    [Metric.TOP_TEMPERATURE]?: TimeSeriesPoint;
+    bottomTemperature?: TimeSeriesPoint;
+    topTemperature?: TimeSeriesPoint;
   };
   [SourceType.HOBO]?: {
-    [Metric.BOTTOM_TEMPERATURE]?: TimeSeriesPoint;
+    bottomTemperature?: TimeSeriesPoint;
   };
   [SourceType.NOAA]?: {
-    [Metric.SATELLITE_TEMPERATURE]?: TimeSeriesPoint;
+    satelliteTemperature?: TimeSeriesPoint;
   };
 }

--- a/packages/api/src/time-series/metrics.entity.ts
+++ b/packages/api/src/time-series/metrics.entity.ts
@@ -50,19 +50,6 @@ export enum Metric {
   AMMONIUM = 'ammonium',
 }
 
-type CamelCase<S extends string> =
-  S extends `${infer P1}_${infer P2}${infer P3}`
-    ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
-    : Lowercase<S>;
-
-type KeysToCamelCase<T> = {
-  [K in keyof T as CamelCase<string & K>]: T[K] extends {}
-    ? KeysToCamelCase<T[K]>
-    : T[K];
-};
-
-export type MetricAsCamelcase = KeysToCamelCase<Record<Metric, number>>;
-
 export enum Units {
   CELSIUS = 'celsius',
   METERS = 'm',

--- a/packages/api/src/time-series/metrics.entity.ts
+++ b/packages/api/src/time-series/metrics.entity.ts
@@ -50,6 +50,19 @@ export enum Metric {
   AMMONIUM = 'ammonium',
 }
 
+type CamelCase<S extends string> =
+  S extends `${infer P1}_${infer P2}${infer P3}`
+    ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+    : Lowercase<S>;
+
+type KeysToCamelCase<T> = {
+  [K in keyof T as CamelCase<string & K>]: T[K] extends {}
+    ? KeysToCamelCase<T[K]>
+    : T[K];
+};
+
+export type MetricAsCamelcase = KeysToCamelCase<Record<Metric, number>>;
+
 export enum Units {
   CELSIUS = 'celsius',
   METERS = 'm',

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
@@ -37,7 +37,7 @@ export const getCollectionData = async (
       data.reduce<CollectionDataDto>((acc, siteData): CollectionDataDto => {
         return {
           ...acc,
-          [siteData.metric]: siteData.value,
+          [camelCase(siteData.metric)]: siteData.value,
         };
       }, {}),
     )

--- a/packages/api/src/utils/type-utils.ts
+++ b/packages/api/src/utils/type-utils.ts
@@ -1,0 +1,8 @@
+export type CamelCase<S extends string> =
+  S extends `${infer P1}_${infer P2}${infer P3}`
+    ? `${Lowercase<P1>}${Uppercase<P2>}${CamelCase<P3>}`
+    : Lowercase<S>;
+
+export type KeysToCamelCase<T> = {
+  [K in keyof T as CamelCase<string & K>]: T[K];
+};

--- a/packages/website/src/store/Collection/utils.ts
+++ b/packages/website/src/store/Collection/utils.ts
@@ -1,22 +1,4 @@
-import { CollectionData, CollectionDataResponse } from "../Sites/types";
 import { CollectionDetails, CollectionDetailsResponse } from "./types";
-
-export const mapCollectionData = (
-  data: CollectionDataResponse
-): CollectionData => ({
-  bottomTemperature: data.bottom_temperature,
-  dhw: data.dhw,
-  satelliteTemperature: data.satellite_temperature,
-  sstAnomaly: data.sst_anomaly,
-  topTemperature: data.top_temperature,
-  significantWaveHeight: data.significant_wave_height,
-  tempAlert: data.temp_alert,
-  tempWeeklyAlert: data.temp_weekly_alert,
-  waveMeanDirection: data.wave_mean_direction,
-  waveMeanPeriod: data.wave_mean_period,
-  windDirection: data.wind_direction,
-  windSpeed: data.wind_speed,
-});
 
 export const constructCollection = (
   data: CollectionDetailsResponse
@@ -24,6 +6,6 @@ export const constructCollection = (
   ...data,
   sites: data.sites.map((item) => ({
     ...item,
-    collectionData: mapCollectionData(item.collectionData || {}),
+    collectionData: item.collectionData || {},
   })),
 });

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -17,7 +17,6 @@ import {
   timeSeriesRequest,
 } from "./helpers";
 import { getAxiosErrorMessage } from "../../helpers/errors";
-import { mapCollectionData } from "../Collection/utils";
 
 const selectedSiteInitialState: SelectedSiteState = {
   draft: null,
@@ -99,7 +98,7 @@ export const siteRequest = createAsyncThunk<
 
       return {
         ...data,
-        collectionData: mapCollectionData(data.collectionData || {}),
+        collectionData: data.collectionData || {},
         dailyData,
         sketchFab,
         historicalMonthlyMean: sortBy(

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -11,7 +11,6 @@ import type {
   UpdateSiteNameFromListArgs,
 } from "./types";
 import type { CreateAsyncThunkTypes, RootState } from "../configure";
-import { mapCollectionData } from "../Collection/utils";
 import { getAxiosErrorMessage } from "../../helpers/errors";
 
 const sitesListInitialState: SitesListState = {
@@ -34,7 +33,7 @@ export const sitesRequest = createAsyncThunk<
       const sortedData = sortBy(data, "name");
       const transformedData = sortedData.map((item) => ({
         ...item,
-        collectionData: mapCollectionData(item.collectionData || {}),
+        collectionData: item.collectionData || {},
       }));
       return {
         list: transformedData,

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -251,9 +251,9 @@ export interface CollectionMetrics {
   sstAnomaly?: number;
 }
 
-export type CollectionDataResponse = Partial<Record<MetricsKeys, number>>;
+export type CollectionDataResponse = Partial<Record<Metrics, number>>;
 
-export type CollectionData = Partial<Record<Metrics, number>>;
+export type CollectionData = CollectionDataResponse;
 
 export interface Site {
   id: number;


### PR DESCRIPTION
The purpose of this PR is to resolve https://github.com/aqualinkorg/aqualink-app/issues/716

This PR aims to change all API case to camelCase.
In summary some API DTOs which were using `Metric` enum's raw values as keys, now use their camelCase equivalents.
