### PR TITLE
Remove Metrics table

### DIFF
--- a/packages/api/migration/1683810744881-RemoveMetricsTable.ts
+++ b/packages/api/migration/1683810744881-RemoveMetricsTable.ts
@@ -1,0 +1,29 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class RemoveMetricsTable1683810744881 implements MigrationInterface {
+  name = 'RemoveMetricsTable1683810744881';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "metrics"`);
+    await queryRunner.query(`DROP TYPE "public"."metrics_metric_enum"`);
+    await queryRunner.query(`DROP TYPE "public"."metrics_units_enum"`);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TYPE "public"."metrics_units_enum" AS ENUM('celsius', 'm', 'm/s', 'dhw', 'hPa')`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."metrics_metric_enum" AS ENUM('temp_alert', 'temp_weekly_alert', 'dhw', 'satellite_temperature', 'air_temperature', 'top_temperature', 'bottom_temperature', 'sst_anomaly', 'significant_wave_height', 'wave_mean_period', 'wave_peak_period', 'wave_mean_direction', 'wind_speed', 'wind_direction', 'barometric_pressure_top', 'barometric_pressure_top_diff', 'barometric_pressure_bottom', 'cholorophyll_rfu', 'cholorophyll_concentration', 'conductivity', 'water_depth', 'odo_saturation', 'odo_concentration', 'salinity', 'specific_conductance', 'tds', 'turbidity', 'total_suspended_solids', 'sonde_wiper_position', 'ph', 'ph_mv', 'sonde_battery_voltage', 'sonde_cable_power_voltage', 'pressure', 'precipitation', 'rh', 'wind_gust_speed', 'nitrogen_total', 'phosphorus_total', 'phosphorus', 'silicate', 'nitrate_plus_nitrite', 'ammonium')`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE public.metrics (
+        id serial4 NOT NULL,
+        metric public.metrics_metric_enum NOT NULL,
+        description varchar NULL,
+        units public.metrics_units_enum NULL,
+        CONSTRAINT "PK_5283cad666a83376e28a715bf0e" PRIMARY KEY (id)
+      );`,
+    );
+  }
+}

--- a/packages/api/scripts/sst-backfill.ts
+++ b/packages/api/scripts/sst-backfill.ts
@@ -12,8 +12,8 @@ import {
   refreshMaterializedView,
 } from '../src/utils/time-series.utils';
 import { TimeSeries } from '../src/time-series/time-series.entity';
-import { Metric } from '../src/time-series/metrics.entity';
 import AqualinkDataSource from '../ormconfig';
+import { Metric } from '../src/time-series/metrics.enum';
 
 // Sites and years to backfill SST for
 const yearsArray = [2017, 2018, 2019, 2020, 2021, 2022];

--- a/packages/api/src/collections/collections.service.ts
+++ b/packages/api/src/collections/collections.service.ts
@@ -19,8 +19,8 @@ import {
   getCollectionData,
   heatStressTracker,
 } from '../utils/collections.utils';
-import { Metric } from '../time-series/metrics.entity';
 import { Site } from '../sites/sites.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 @Injectable()
 export class CollectionsService {

--- a/packages/api/src/collections/collections.spec.ts
+++ b/packages/api/src/collections/collections.spec.ts
@@ -25,7 +25,7 @@ import {
 } from '../../test/mock/user.mock';
 import { TestService } from '../../test/test.service';
 import { mockExtractAndVerifyToken } from '../../test/utils';
-import { Metric } from '../time-series/metrics.entity';
+import { Metric } from '../time-series/metrics.enum';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { CreateCollectionDto } from './dto/create-collection.dto';
 import { UpdateCollectionDto } from './dto/update-collection.dto';

--- a/packages/api/src/collections/dto/collection-data.dto.ts
+++ b/packages/api/src/collections/dto/collection-data.dto.ts
@@ -1,6 +1,6 @@
 import { ApiPropertyOptional } from '@nestjs/swagger';
+import { Metric } from '../../time-series/metrics.enum';
 import { KeysToCamelCase } from '../../utils/type-utils';
-import { Metric } from '../../time-series/metrics.entity';
 
 type MetricAsCamelcase = KeysToCamelCase<Record<Metric, number>>;
 

--- a/packages/api/src/data-uploads/data-uploads.entity.ts
+++ b/packages/api/src/data-uploads/data-uploads.entity.ts
@@ -13,7 +13,7 @@ import { Exclude } from 'class-transformer';
 import { Site } from '../sites/sites.entity';
 import { SiteSurveyPoint } from '../site-survey-points/site-survey-points.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
-import { Metric } from '../time-series/metrics.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 @Entity()
 @Unique(['file', 'signature'])

--- a/packages/api/src/docs/api-time-series-response.ts
+++ b/packages/api/src/docs/api-time-series-response.ts
@@ -2,7 +2,7 @@ import { applyDecorators } from '@nestjs/common';
 import { ApiOkResponse } from '@nestjs/swagger';
 import { SchemaObject } from '@nestjs/swagger/dist/interfaces/open-api-spec.interface';
 import { SourceType } from '../sites/schemas/source-type.enum';
-import { Metric } from '../time-series/metrics.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 const reduceArrayToObject = <T>(previousValue: T, currentValue: T) => {
   return {

--- a/packages/api/src/seeds/create-sites.seeds.ts
+++ b/packages/api/src/seeds/create-sites.seeds.ts
@@ -5,9 +5,9 @@ import { Site } from '../sites/sites.entity';
 import { DailyData } from '../sites/daily-data.entity';
 import { SiteSurveyPoint } from '../site-survey-points/site-survey-points.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
-import { Metric } from '../time-series/metrics.entity';
 import { Sources } from '../sites/sources.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
+import { Metric } from '../time-series/metrics.enum';
 
 export class CreateSite implements Seeder {
   public async run(factory: Factory) {

--- a/packages/api/src/sensors/dto/sensor-data.dto.ts
+++ b/packages/api/src/sensors/dto/sensor-data.dto.ts
@@ -1,6 +1,6 @@
 import { SourceType } from '../../sites/schemas/source-type.enum';
 import { TimeSeriesPoint } from '../../time-series/dto/time-series-point.dto';
-import { Metric } from '../../time-series/metrics.entity';
+import { Metric } from '../../time-series/metrics.enum';
 import { KeysToCamelCase } from '../../utils/type-utils';
 
 type MetricAsCamelcase = KeysToCamelCase<Record<Metric, TimeSeriesPoint>>;

--- a/packages/api/src/sensors/sensors.service.ts
+++ b/packages/api/src/sensors/sensors.service.ts
@@ -6,7 +6,6 @@ import { GeoJSON, Point } from 'geojson';
 import { IsNull, Not, Repository } from 'typeorm';
 import { Site, SensorType } from '../sites/sites.entity';
 import { Survey } from '../surveys/surveys.entity';
-import { Metric } from '../time-series/metrics.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { getSiteFromSensorId } from '../utils/site.utils';
 import { getSpotterData, getLatestData } from '../utils/sofar';
@@ -22,6 +21,7 @@ import { Sources } from '../sites/sources.entity';
 import { SensorDataDto } from './dto/sensor-data.dto';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { SOFAR_API_TOKEN } from '../utils/constants';
+import { Metric } from '../time-series/metrics.enum';
 
 @Injectable()
 export class SensorsService {

--- a/packages/api/src/sensors/sensors.spec.ts
+++ b/packages/api/src/sensors/sensors.spec.ts
@@ -4,7 +4,7 @@ import request from 'supertest';
 import { californiaSite } from '../../test/mock/site.mock';
 import { TestService } from '../../test/test.service';
 import { SourceType } from '../sites/schemas/source-type.enum';
-import { Metric } from '../time-series/metrics.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 export const sensorTests = () => {
   const testService = TestService.getInstance();

--- a/packages/api/src/time-series/latest-data.entity.ts
+++ b/packages/api/src/time-series/latest-data.entity.ts
@@ -10,8 +10,8 @@ import {
 import { SiteSurveyPoint } from '../site-survey-points/site-survey-points.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
-import { Metric } from './metrics.entity';
 import { TimeSeries } from './time-series.entity';
+import { Metric } from './metrics.enum';
 
 @ViewEntity({
   expression: (dataSource: DataSource) => {

--- a/packages/api/src/time-series/metrics.enum.ts
+++ b/packages/api/src/time-series/metrics.enum.ts
@@ -1,6 +1,3 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
-
 export enum Metric {
   // Default Metrics
   ALERT = 'temp_alert',
@@ -48,29 +45,4 @@ export enum Metric {
   SILICATE = 'silicate',
   NNN = 'nitrate_plus_nitrite',
   AMMONIUM = 'ammonium',
-}
-
-export enum Units {
-  CELSIUS = 'celsius',
-  METERS = 'm',
-  METERS_PER_SECOND = 'm/s',
-  DHW = 'dhw',
-  HPA = 'hPa',
-}
-
-@Entity()
-export class Metrics {
-  @ApiProperty({ example: 1 })
-  @PrimaryGeneratedColumn()
-  id: number;
-
-  @Column({ type: 'enum', enum: Metric, nullable: false })
-  metric: Metric;
-
-  @ApiProperty({ example: 'Metric Description' })
-  @Column({ nullable: true })
-  description: string;
-
-  @Column({ type: 'enum', enum: Units, nullable: true })
-  units: Units;
 }

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -19,7 +19,6 @@ import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
 import type { Response } from 'express';
 import { SiteDataDto } from './dto/site-data.dto';
 import { SurveyPointDataDto } from './dto/survey-point-data.dto';
-import { Metric } from './metrics.entity';
 import { TimeSeriesService } from './time-series.service';
 import { SurveyPointDataRangeDto } from './dto/survey-point-data-range.dto';
 import { SiteDataRangeDto } from './dto/site-data-range.dto';
@@ -34,6 +33,7 @@ import { Auth } from '../auth/auth.decorator';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { fileFilter } from '../utils/uploads/upload-sheet-data';
 import { SampleUploadFilesDto } from './dto/sample-upload-files.dto';
+import { Metric } from './metrics.enum';
 
 const MAX_FILE_COUNT = 10;
 const MAX_FILE_SIZE_MB = 10;

--- a/packages/api/src/time-series/time-series.entity.ts
+++ b/packages/api/src/time-series/time-series.entity.ts
@@ -11,7 +11,7 @@ import {
 } from 'typeorm';
 import { DataUploads } from '../data-uploads/data-uploads.entity';
 import { Sources } from '../sites/sources.entity';
-import { Metric } from './metrics.entity';
+import { Metric } from './metrics.enum';
 
 @Entity()
 @Unique('no_duplicate_data', ['metric', 'source', 'timestamp'])

--- a/packages/api/src/time-series/time-series.service.ts
+++ b/packages/api/src/time-series/time-series.service.ts
@@ -12,7 +12,6 @@ import {
 import { join } from 'path';
 import { SiteDataDto } from './dto/site-data.dto';
 import { SurveyPointDataDto } from './dto/survey-point-data.dto';
-import { Metric } from './metrics.entity';
 import { TimeSeries } from './time-series.entity';
 import { SurveyPointDataRangeDto } from './dto/survey-point-data-range.dto';
 import { SiteDataRangeDto } from './dto/site-data-range.dto';
@@ -33,6 +32,7 @@ import { SourceType } from '../sites/schemas/source-type.enum';
 import { DataUploads } from '../data-uploads/data-uploads.entity';
 import { surveyPointBelongsToSite } from '../utils/site.utils';
 import { SampleUploadFilesDto } from './dto/sample-upload-files.dto';
+import { Metric } from './metrics.enum';
 
 @Injectable()
 export class TimeSeriesService {

--- a/packages/api/src/utils/site.utils.ts
+++ b/packages/api/src/utils/site.utils.ts
@@ -20,10 +20,10 @@ import { Site } from '../sites/sites.entity';
 import { Sources } from '../sites/sources.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
-import { Metric } from '../time-series/metrics.entity';
 import { SiteSurveyPoint } from '../site-survey-points/site-survey-points.entity';
 import { getHistoricalMonthlyMeans, getMMM } from './temperature';
 import { HistoricalMonthlyMean } from '../sites/historical-monthly-mean.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 const googleMapsClient = new Client({});
 const logger = new Logger('Site Utils');

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -7,7 +7,6 @@ import { distance } from '@turf/turf';
 import { Point } from 'geojson';
 import { Site } from '../sites/sites.entity';
 import { Sources } from '../sites/sources.entity';
-import { Metric } from '../time-series/metrics.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { getSpotterData } from './sofar';
 import {
@@ -20,6 +19,7 @@ import { ExclusionDates } from '../sites/exclusion-dates.entity';
 import { excludeSpotterData } from './site.utils';
 import { getSources, refreshMaterializedView } from './time-series.utils';
 import { SOFAR_API_TOKEN } from './constants';
+import { Metric } from '../time-series/metrics.enum';
 
 const MAX_DISTANCE_FROM_SITE = 50;
 

--- a/packages/api/src/utils/sst-time-series.ts
+++ b/packages/api/src/utils/sst-time-series.ts
@@ -15,10 +15,10 @@ import {
   insertSiteDataToTimeSeries,
   refreshMaterializedView,
 } from './time-series.utils';
-import { Metric } from '../time-series/metrics.entity';
 import { calculateAlertLevel } from './bleachingAlert';
 import { getSstAnomaly } from './liveData';
 import { ValueWithTimestamp } from './sofar.types';
+import { Metric } from '../time-series/metrics.enum';
 
 const MAX_SOFAR_DATE_DIFF_DAYS = 7;
 

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -4,9 +4,9 @@ import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { Sources } from '../sites/sources.entity';
 import { TimeSeriesValueDto } from '../time-series/dto/time-series-value.dto';
-import { Metric } from '../time-series/metrics.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { getTimeSeriesDefaultDates } from './dates';
+import { Metric } from '../time-series/metrics.enum';
 
 interface TimeSeriesGroupable {
   metric: Metric;

--- a/packages/api/src/utils/uploads/upload-hobo-data.ts
+++ b/packages/api/src/utils/uploads/upload-hobo-data.ts
@@ -16,7 +16,6 @@ import parse from 'csv-parse/lib/sync';
 
 import { Site, SiteStatus } from '../../sites/sites.entity';
 import { SiteSurveyPoint } from '../../site-survey-points/site-survey-points.entity';
-import { Metric } from '../../time-series/metrics.entity';
 import { TimeSeries } from '../../time-series/time-series.entity';
 import { User } from '../../users/users.entity';
 import { Survey, WeatherConditions } from '../../surveys/surveys.entity';
@@ -36,6 +35,7 @@ import { createPoint } from '../coordinates';
 import { SourceType } from '../../sites/schemas/source-type.enum';
 import { DataUploads } from '../../data-uploads/data-uploads.entity';
 import { refreshMaterializedView } from '../time-series.utils';
+import { Metric } from '../../time-series/metrics.enum';
 
 /**
  * Parse csv data

--- a/packages/api/src/utils/uploads/upload-sheet-data.ts
+++ b/packages/api/src/utils/uploads/upload-sheet-data.ts
@@ -19,7 +19,6 @@ import { MulterOptions } from '@nestjs/platform-express/multer/interfaces/multer
 import { QueryDeepPartialEntity } from 'typeorm/query-builder/QueryPartialEntity';
 import { Site } from '../../sites/sites.entity';
 import { SiteSurveyPoint } from '../../site-survey-points/site-survey-points.entity';
-import { Metric } from '../../time-series/metrics.entity';
 import { TimeSeries } from '../../time-series/time-series.entity';
 import { Sources } from '../../sites/sources.entity';
 import { SourceType } from '../../sites/schemas/source-type.enum';
@@ -28,6 +27,7 @@ import { getSite } from '../site.utils';
 import { GoogleCloudService } from '../../google-cloud/google-cloud.service';
 import { getBarometricDiff } from '../sofar';
 import { refreshMaterializedView } from '../time-series.utils';
+import { Metric } from '../../time-series/metrics.enum';
 
 interface Repositories {
   siteRepository: Repository<Site>;

--- a/packages/api/src/wind-wave-data/wind-wave-data.types.ts
+++ b/packages/api/src/wind-wave-data/wind-wave-data.types.ts
@@ -1,4 +1,4 @@
-import { Metric } from '../time-series/metrics.entity';
+import { Metric } from '../time-series/metrics.enum';
 
 // This enum should always be a subset of Metric enum
 export enum WindWaveMetric {

--- a/packages/api/test/mock/time-series.mock.ts
+++ b/packages/api/test/mock/time-series.mock.ts
@@ -3,7 +3,7 @@ import moment from 'moment';
 import { DeepPartial } from 'typeorm';
 import { SourceType } from '../../src/sites/schemas/source-type.enum';
 import { Sources } from '../../src/sites/sources.entity';
-import { Metric } from '../../src/time-series/metrics.entity';
+import { Metric } from '../../src/time-series/metrics.enum';
 import { TimeSeries } from '../../src/time-series/time-series.entity';
 import {
   athensPiraeusHoboSource,


### PR DESCRIPTION
The PR removes unused `public.metrics` table, cleaning up the code a bit.