### PR TITLE
Set timezone to UTC in tests

### DIFF
--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -142,23 +142,6 @@
     "webpack-cli": "^3.3.12",
     "yargs": "^15.4.1"
   },
-  "jest": {
-    "moduleFileExtensions": [
-      "js",
-      "json",
-      "ts"
-    ],
-    "rootDir": "src",
-    "testRegex": [
-      ".spec.ts$",
-      ".test.ts$"
-    ],
-    "transform": {
-      "^.+\\.(t|j)s$": "ts-jest"
-    },
-    "coverageDirectory": "../coverage",
-    "testEnvironment": "node"
-  },
   "optionalDependencies": {
     "netcdf4": "https://github.com/parro-it/netcdf4"
   }

--- a/packages/api/test/app.spec.ts
+++ b/packages/api/test/app.spec.ts
@@ -20,6 +20,10 @@ describe('AppController (e2e)', () => {
     app = await testService.getApp();
   });
 
+  it('timezone should always be UTC', () => {
+    expect(new Date().getTimezoneOffset()).toBe(0);
+  });
+
   it('App is defined', () => {
     expect(app).toBeDefined();
   });

--- a/packages/api/test/global-setup.js
+++ b/packages/api/test/global-setup.js
@@ -1,0 +1,3 @@
+module.exports = async () => {
+  process.env.TZ = 'UTC';
+};

--- a/packages/api/test/jest.json
+++ b/packages/api/test/jest.json
@@ -21,5 +21,6 @@
   ],
   "transform": {
     "\\.ts$": "ts-jest"
-  }
+  },
+  "globalSetup": "./test/global-setup.js"
 }

--- a/packages/api/test/test.service.ts
+++ b/packages/api/test/test.service.ts
@@ -37,6 +37,9 @@ export class TestService {
   private constructor() {}
 
   private async initializeApp() {
+    // eslint-disable-next-line no-extend-native
+    Date.prototype.getTimezoneOffset = jest.fn(() => 0);
+
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();

--- a/packages/api/test/test.service.ts
+++ b/packages/api/test/test.service.ts
@@ -37,9 +37,6 @@ export class TestService {
   private constructor() {}
 
   private async initializeApp() {
-    // eslint-disable-next-line no-extend-native
-    Date.prototype.getTimezoneOffset = jest.fn(() => 0);
-
     const moduleFixture: TestingModule = await Test.createTestingModule({
       imports: [AppModule],
     }).compile();


### PR DESCRIPTION
Resolves https://github.com/aqualinkorg/aqualink-app/issues/845

The timezone offset in both the actual nest app and the scripts is 0, but that is not the case in test. That was causing the tests to fail locally for anyone with no UTC time, while the app would appear to be working as expected. This change sets the timezone offset to 0 (UTC), for everyone, to match the nest app behavior.
