### PR TITLE
Update condition where sonde card appears 

### DIFF
--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -48,6 +48,16 @@ import {
 import { parseLatestData } from '../../store/Sites/helpers';
 import HUICard from './HUICard';
 
+const sondeMetrics: (keyof LatestDataASSofarValue)[] = [
+  'odoConcentration',
+  'cholorophyllConcentration',
+  'ph',
+  'salinity',
+  'turbidity',
+];
+
+const MINIMUM_SONDE_METRICS_TO_SHOW_CARD = 3;
+
 const SiteDetails = ({
   site,
   selectedSurveyPointId,
@@ -97,7 +107,9 @@ const SiteDetails = ({
       const combinedArray = [...forecastData, ...latestData];
       const parsedData = parseLatestData(combinedArray);
       const hasSpotter = Boolean(parsedData.bottomTemperature);
-      const hasSonde = Boolean(parsedData.salinity);
+      const hasSonde =
+        sondeMetrics.filter((x) => Boolean(parsedData[x])).length >=
+        MINIMUM_SONDE_METRICS_TO_SHOW_CARD;
       const hasHUI = latestData.some((x) => x.source === 'hui');
 
       setHasSondeData(hasSonde);


### PR DESCRIPTION
This PR updates the condition where the sonde `WaterSamplingCard` card appears.
Changes the condition from "there is `salinity` in latest data" to "at least n # of `sondeMetrics` are in latest data"