### PR TITLE
Fix functions would not read SOFAR_API_TOKEN

### DIFF
--- a/packages/api/src/sensor-data/sensor-data.service.ts
+++ b/packages/api/src/sensor-data/sensor-data.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { SOFAR_API_TOKEN } from '../utils/constants';
 import { sofarSensor } from '../utils/sofar';
 
 @Injectable()
 export class SensorDataService {
   get(sensorId: string, startDate?: string, endDate?: string) {
-    return sofarSensor(sensorId, SOFAR_API_TOKEN, startDate, endDate);
+    return sofarSensor(
+      sensorId,
+      process.env.SOFAR_API_TOKEN,
+      startDate,
+      endDate,
+    );
   }
 }

--- a/packages/api/src/sensors/sensors.service.ts
+++ b/packages/api/src/sensors/sensors.service.ts
@@ -20,7 +20,6 @@ import { DailyData } from '../sites/daily-data.entity';
 import { Sources } from '../sites/sources.entity';
 import { SensorDataDto } from './dto/sensor-data.dto';
 import { SourceType } from '../sites/schemas/source-type.enum';
-import { SOFAR_API_TOKEN } from '../utils/constants';
 import { Metric } from '../time-series/metrics.enum';
 
 @Injectable()
@@ -57,7 +56,7 @@ export class SensorsService {
         if (site.sensorId === null) {
           console.warn(`Spotter for site ${site.id} appears null.`);
         }
-        const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+        const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
         return getSpotterData(site.sensorId!, sofarToken).then((data) => {
           return {
             id: site.id,

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -53,11 +53,6 @@ import { getTimeSeriesDefaultDates } from '../utils/dates';
 import { SourceType } from './schemas/source-type.enum';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { sendSlackMessage, SlackMessage } from '../utils/slack.utils';
-import {
-  SLACK_BOT_CHANNEL,
-  SLACK_BOT_TOKEN,
-  SOFAR_API_TOKEN,
-} from '../utils/constants';
 
 @Injectable()
 export class SitesService {
@@ -126,12 +121,15 @@ export class SitesService {
     backfillSiteData(site.id);
 
     const messageTemplate: SlackMessage = {
-      channel: SLACK_BOT_CHANNEL as string,
+      channel: process.env.SLACK_BOT_CHANNEL as string,
       text: `New site ${site.name} created with id=${site.id}, by ${user.fullName}`,
       mrkdwn: true,
     };
 
-    await sendSlackMessage(messageTemplate, SLACK_BOT_TOKEN as string);
+    await sendSlackMessage(
+      messageTemplate,
+      process.env.SLACK_BOT_TOKEN as string,
+    );
 
     return this.siteApplicationRepository.save({
       ...appParams,
@@ -353,7 +351,7 @@ export class SitesService {
         position: undefined,
       };
 
-    const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+    const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
     const spotterRaw = await getSpotterData(sensorId, sofarToken);
     const spotterData = spotterRaw
       ? {
@@ -400,7 +398,7 @@ export class SitesService {
       endDate,
     );
 
-    const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+    const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
     const { topTemperature, bottomTemperature } = await getSpotterData(
       site.sensorId,
       sofarToken,

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -8,8 +8,7 @@ try {
 export const envName = process.env.NODE_ENV || 'development';
 export const isTestEnv = envName === 'test';
 
-// Sofar API urls and token
-export const { SOFAR_API_TOKEN } = process.env;
+// Sofar API urls
 export const SOFAR_MARINE_URL =
   'https://api.sofarocean.com/marine-weather/v1/models/';
 export const SOFAR_WAVE_DATA_URL = 'https://api.sofarocean.com/api/wave-data';
@@ -55,7 +54,3 @@ export const sofarVariableIDs = {
 };
 
 export const STORM_GLASS_BASE_URL = 'https://api.stormglass.io/v2';
-
-export const { SLACK_BOT_TOKEN, SLACK_BOT_CHANNEL } = !isTestEnv
-  ? process.env
-  : { SLACK_BOT_TOKEN: undefined, SLACK_BOT_CHANNEL: undefined };

--- a/packages/api/src/utils/liveData.ts
+++ b/packages/api/src/utils/liveData.ts
@@ -3,7 +3,7 @@ import { Point } from 'geojson';
 import { isNil, omitBy, sortBy } from 'lodash';
 import moment from 'moment';
 import { Site } from '../sites/sites.entity';
-import { SofarModels, sofarVariableIDs, SOFAR_API_TOKEN } from './constants';
+import { SofarModels, sofarVariableIDs } from './constants';
 import { getLatestData, getSofarHindcastData, getSpotterData } from './sofar';
 import { SofarLiveData, ValueWithTimestamp } from './sofar.types';
 import { getDegreeHeatingDays } from '../workers/dailyData';
@@ -23,7 +23,7 @@ export const getLiveData = async (
 
   const now = new Date();
 
-  const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+  const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
   const [spotterRawData, degreeHeatingDays, satelliteTemperature] =
     await Promise.all([
       sensorId && isDeployed ? getSpotterData(sensorId, sofarToken) : undefined,

--- a/packages/api/src/utils/sofar.test.ts
+++ b/packages/api/src/utils/sofar.test.ts
@@ -1,4 +1,4 @@
-import { SofarModels, sofarVariableIDs, SOFAR_API_TOKEN } from './constants';
+import { SofarModels, sofarVariableIDs } from './constants';
 import { getSofarHindcastData, getSpotterData, sofarHindcast } from './sofar';
 import { ValueWithTimestamp } from './sofar.types';
 
@@ -21,7 +21,7 @@ test('It processes Sofar Spotter API for daily data.', async () => {
   jest.setTimeout(30000);
   const values = await getSpotterData(
     'SPOT-300434063450120',
-    SOFAR_API_TOKEN,
+    process.env.SOFAR_API_TOKEN,
     new Date('2020-09-02'),
   );
 

--- a/packages/api/src/utils/sofar.ts
+++ b/packages/api/src/utils/sofar.ts
@@ -5,9 +5,6 @@ import moment from 'moment';
 import axios from './retry-axios';
 import { getStartEndDate } from './dates';
 import {
-  SLACK_BOT_CHANNEL,
-  SLACK_BOT_TOKEN,
-  SOFAR_API_TOKEN,
   SOFAR_MARINE_URL,
   SOFAR_SENSOR_DATA_URL,
   SOFAR_WAVE_DATA_URL,
@@ -71,7 +68,7 @@ export async function sofarHindcast(
         longitude,
         start,
         end,
-        token: SOFAR_API_TOKEN,
+        token: process.env.SOFAR_API_TOKEN,
       },
     })
     .then((response) => {
@@ -119,12 +116,15 @@ export function sofarSensor(
         console.error(message);
         if ([401, 403].includes(error.response.status)) {
           const messageTemplate: SlackMessage = {
-            channel: SLACK_BOT_CHANNEL as string,
+            channel: process.env.SLACK_BOT_CHANNEL as string,
             text: message,
             mrkdwn: true,
           };
 
-          await sendSlackMessage(messageTemplate, SLACK_BOT_TOKEN as string);
+          await sendSlackMessage(
+            messageTemplate,
+            process.env.SLACK_BOT_TOKEN as string,
+          );
         }
       } else {
         console.error(`An error occurred accessing the Sofar API - ${error}`);

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -18,7 +18,6 @@ import { SourceType } from '../sites/schemas/source-type.enum';
 import { ExclusionDates } from '../sites/exclusion-dates.entity';
 import { excludeSpotterData } from './site.utils';
 import { getSources, refreshMaterializedView } from './time-series.utils';
-import { SOFAR_API_TOKEN } from './constants';
 import { Metric } from '../time-series/metrics.enum';
 
 const MAX_DISTANCE_FROM_SITE = 50;
@@ -147,7 +146,8 @@ export const addSpotterData = async (
             [],
           );
 
-          const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+          const sofarToken =
+            site.spotterApiToken || process.env.SOFAR_API_TOKEN;
           // Fetch spotter and wave data from sofar
           const spotterData = await getSpotterData(
             site.sensorId,

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -34,11 +34,7 @@ import {
   SofarDailyData,
   ValueWithTimestamp,
 } from '../utils/sofar.types';
-import {
-  SofarModels,
-  sofarVariableIDs,
-  SOFAR_API_TOKEN,
-} from '../utils/constants';
+import { SofarModels, sofarVariableIDs } from '../utils/constants';
 import { calculateAlertLevel } from '../utils/bleachingAlert';
 import { ExclusionDates } from '../sites/exclusion-dates.entity';
 import {
@@ -93,7 +89,7 @@ export async function getDailyData(
   const [NOAALongitude, NOAALatitude] = nearestNOAALocation
     ? (nearestNOAALocation as Point).coordinates
     : (polygon as Point).coordinates;
-  const sofarToken = site.spotterApiToken || SOFAR_API_TOKEN;
+  const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
 
   const [
     spotterRawData,


### PR DESCRIPTION
Fixes a bug where in some cases functions would not read `SOFAR_API_TOKEN`.

The issue was that `export const { SOFAR_API_TOKEN } = process.env;` in `constants.ts` would run before `process.env.SOFAR_API_TOKEN = functions.config().sofar_api.token;` in `cloud-functions/index.ts` causing imported `SOFAR_API_TOKEN` to be `undefined`.