### PR TITLE
Replace deprecated ::set-output

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Get current date
         id: date
-        run: echo "::set-output name=date::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "date=$(date +'%Y-%m-%dT%H:%M:%S')" >> $GITHUB_OUTPUT
 
       - name: Comment PR
         uses: marocchino/sticky-pull-request-comment@v1

--- a/packages/website/src/routes/Surveys/New/Map.tsx
+++ b/packages/website/src/routes/Surveys/New/Map.tsx
@@ -11,6 +11,7 @@ import {
   setDiveLocation,
   diveLocationSelector,
 } from '../../../store/Survey/surveySlice';
+// REMOVE BEFORE MERGE
 
 const pinIcon = L.icon({
   iconUrl: marker,

--- a/packages/website/src/routes/Surveys/New/Map.tsx
+++ b/packages/website/src/routes/Surveys/New/Map.tsx
@@ -11,7 +11,6 @@ import {
   setDiveLocation,
   diveLocationSelector,
 } from '../../../store/Survey/surveySlice';
-// REMOVE BEFORE MERGE
 
 const pinIcon = L.icon({
   iconUrl: marker,


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/870

Replaces `::set-output` as stated here:
[github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)