### PR TITLE
Remove relative file paths on imports

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,2 +1,5 @@
 # Add singleQuote: true and trailingComma to web
 8a264fd6bf9e6099c245e612ae3826c4441f803d
+
+# Update import paths to use "baseUrl": "./src"
+4abb9848ea8ecd0b5f3c60e7af811483b7175b53

--- a/packages/website/src/common/Chart/CombinedCharts.tsx
+++ b/packages/website/src/common/Chart/CombinedCharts.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Box, createStyles, makeStyles, Typography } from '@material-ui/core';
 
+import { Site } from 'store/Sites/types';
+import { SurveyListItem } from 'store/Survey/types';
+import { convertSurveyDataToLocalTime } from 'helpers/dates';
 import ChartWithTooltip from './ChartWithTooltip';
 import MultipleSensorsCharts from './MultipleSensorsCharts';
-import { Site } from '../../store/Sites/types';
-import { convertSurveyDataToLocalTime } from '../../helpers/dates';
-import { SurveyListItem } from '../../store/Survey/types';
 import { standardDailyDataDataset } from './MultipleSensorsCharts/helpers';
 import LoadingSkeleton from '../LoadingSkeleton';
 import chartSkeletonImage from '../../assets/img/chart_skeleton.png';

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/AnalysisCard.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/AnalysisCard.tsx
@@ -15,10 +15,10 @@ import moment from 'moment';
 import { useSelector } from 'react-redux';
 import classNames from 'classnames';
 
-import { siteTimeSeriesDataLoadingSelector } from '../../../store/Sites/selectedSiteSlice';
+import { siteTimeSeriesDataLoadingSelector } from 'store/Sites/selectedSiteSlice';
+import { formatNumber } from 'helpers/numberUtils';
 import { calculateCardMetrics } from './helpers';
 import { CardColumn } from './types';
-import { formatNumber } from '../../../helpers/numberUtils';
 import type { Dataset } from '..';
 
 const rows = ['MAX', 'MEAN', 'MIN'];

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/Chart.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/Chart.tsx
@@ -13,21 +13,18 @@ import {
 import { Alert } from '@material-ui/lab';
 import { useSelector } from 'react-redux';
 
-import ChartWithTooltip from '../ChartWithTooltip';
-import DatePicker from '../../Datepicker';
-import {
-  convertToLocalTime,
-  displayTimeInLocalTimezone,
-} from '../../../helpers/dates';
-import { Site } from '../../../store/Sites/types';
+import { Site } from 'store/Sites/types';
 import {
   siteTimeSeriesDataLoadingSelector,
   siteTimeSeriesDataRangeLoadingSelector,
   siteTimeSeriesDataRangeSelector,
-} from '../../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
+import { surveyListSelector } from 'store/Survey/surveyListSlice';
+import { convertToLocalTime, displayTimeInLocalTimezone } from 'helpers/dates';
+import { filterSurveys } from 'helpers/surveys';
+import ChartWithTooltip from '../ChartWithTooltip';
+import DatePicker from '../../Datepicker';
 import { findChartPeriod, moreThanOneYear } from './helpers';
-import { surveyListSelector } from '../../../store/Survey/surveyListSlice';
-import { filterSurveys } from '../../../helpers/surveys';
 import { Dataset } from '..';
 
 const Chart = ({

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/ChartWithCard.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/ChartWithCard.tsx
@@ -2,12 +2,12 @@ import React from 'react';
 import classnames from 'classnames';
 import { Grid, GridProps, makeStyles, Theme } from '@material-ui/core';
 
+import { Site, TimeSeriesSurveyPoint } from 'store/Sites/types';
 import AnalysisCard from './AnalysisCard';
 import Chart from './Chart';
 import Header from './Header';
 import { AvailableRange, RangeValue } from './types';
 import type { Dataset } from '../index';
-import { Site, TimeSeriesSurveyPoint } from '../../../store/Sites/types';
 
 const ChartWithCard = ({
   areSurveysFiltered,

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
@@ -4,10 +4,10 @@ import { Button } from '@material-ui/core';
 import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { useSnackbar } from 'notistack';
-import { ValueWithTimestamp, MetricsKeys } from '../../../store/Sites/types';
+import { ValueWithTimestamp, MetricsKeys } from 'store/Sites/types';
+import { spotterPositionSelector } from 'store/Sites/selectedSiteSlice';
+import siteServices from 'services/siteServices';
 import DownloadCSVDialog from './DownloadCSVDialog';
-import { spotterPositionSelector } from '../../../store/Sites/selectedSiteSlice';
-import siteServices from '../../../services/siteServices';
 import { CSVColumnData } from './types';
 
 type CSVColumnNames =

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVDialog.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVDialog.tsx
@@ -12,7 +12,7 @@ import Tooltip from '@material-ui/core/Tooltip';
 import Typography from '@material-ui/core/Typography';
 import moment from 'moment';
 import React from 'react';
-import { ValueWithTimestamp } from '../../../store/Sites/types';
+import { ValueWithTimestamp } from 'store/Sites/types';
 
 export interface DownloadCSVDialogProps {
   open: boolean;

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/Header.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/Header.tsx
@@ -16,8 +16,8 @@ import grey from '@material-ui/core/colors/grey';
 import { Alert } from '@material-ui/lab';
 import isEmpty from 'lodash/isEmpty';
 
+import { TimeSeriesSurveyPoint } from 'store/Sites/types';
 import { AvailableRange, RangeButton, RangeValue } from './types';
-import { TimeSeriesSurveyPoint } from '../../../store/Sites/types';
 import { availableRangeString } from './helpers';
 
 const Header = ({

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/helpers.ts
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/helpers.ts
@@ -2,11 +2,15 @@ import { utcToZonedTime } from 'date-fns-tz';
 import { minBy, maxBy, meanBy, inRange, isNumber } from 'lodash';
 import moment from 'moment';
 import {
-  convertSofarDataToLocalTime,
-  findMarginalDate,
-  generateHistoricalMonthlyMeanTimestamps,
-} from '../../../helpers/dates';
-
+  DAILY_DATA_CURVE_COLOR,
+  HISTORICAL_MONTHLY_MEAN_COLOR,
+  HOBO_BOTTOM_DATA_CURVE_COLOR,
+  CHART_MIN_NUMBER_OF_POINTS,
+  SPOTTER_BOTTOM_DATA_CURVE_COLOR,
+  SPOTTER_TOP_DATA_CURVE_COLOR,
+  DAILY_DATA_FILL_COLOR_ABOVE_THRESHOLD,
+  DAILY_DATA_FILL_COLOR_BELOW_THRESHOLD,
+} from 'constants/charts';
 import {
   DailyData,
   DataRange,
@@ -16,19 +20,15 @@ import {
   ValueWithTimestamp,
   TimeSeriesData,
   Metrics,
-} from '../../../store/Sites/types';
+} from 'store/Sites/types';
+import {
+  convertSofarDataToLocalTime,
+  findMarginalDate,
+  generateHistoricalMonthlyMeanTimestamps,
+} from 'helpers/dates';
+
 import { CardColumn, OceanSenseDataset } from './types';
 import type { Dataset } from '../index';
-import {
-  DAILY_DATA_CURVE_COLOR,
-  HISTORICAL_MONTHLY_MEAN_COLOR,
-  HOBO_BOTTOM_DATA_CURVE_COLOR,
-  CHART_MIN_NUMBER_OF_POINTS,
-  SPOTTER_BOTTOM_DATA_CURVE_COLOR,
-  SPOTTER_TOP_DATA_CURVE_COLOR,
-  DAILY_DATA_FILL_COLOR_ABOVE_THRESHOLD,
-  DAILY_DATA_FILL_COLOR_BELOW_THRESHOLD,
-} from '../../../constants/charts';
 import {
   convertDailyToSofar,
   convertHistoricalMonthlyMeanToSofar,

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -5,6 +5,18 @@ import moment from 'moment';
 import { camelCase, isNaN, isNumber, snakeCase, sortBy } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import { utcToZonedTime, zonedTimeToUtc } from 'date-fns-tz';
+import { oceanSenseConfig } from 'constants/oceanSenseConfig';
+import { getPublicSondeMetrics, getSondeConfig } from 'constants/sondeConfig';
+import {
+  METLOG_DATA_COLOR,
+  OCEAN_SENSE_DATA_COLOR,
+  SONDE_DATA_COLOR,
+  SPOTTER_METRIC_DATA_COLOR,
+} from 'constants/charts';
+import {
+  getMetlogConfig,
+  getPublicMetlogMetrics,
+} from 'constants/metlogConfig';
 import {
   latestDataSelector,
   siteGranularDailyDataSelector,
@@ -14,13 +26,10 @@ import {
   siteTimeSeriesDataRangeSelector,
   siteTimeSeriesDataRequest,
   siteTimeSeriesDataSelector,
-} from '../../../store/Sites/selectedSiteSlice';
-import { Metrics, MetricsKeys, Site } from '../../../store/Sites/types';
-import {
-  isBefore,
-  setTimeZone,
-  subtractFromDate,
-} from '../../../helpers/dates';
+} from 'store/Sites/selectedSiteSlice';
+import { Metrics, MetricsKeys, Site } from 'store/Sites/types';
+import { useQueryParam } from 'hooks/useQueryParams';
+import { isBefore, setTimeZone, subtractFromDate } from 'helpers/dates';
 import {
   constructOceanSenseDatasets,
   findChartWidth,
@@ -30,23 +39,7 @@ import {
   localizedEndOfDay,
 } from './helpers';
 import { RangeValue } from './types';
-import { oceanSenseConfig } from '../../../constants/oceanSenseConfig';
-import {
-  getPublicSondeMetrics,
-  getSondeConfig,
-} from '../../../constants/sondeConfig';
-import { useQueryParam } from '../../../hooks/useQueryParams';
 import ChartWithCard from './ChartWithCard';
-import {
-  METLOG_DATA_COLOR,
-  OCEAN_SENSE_DATA_COLOR,
-  SONDE_DATA_COLOR,
-  SPOTTER_METRIC_DATA_COLOR,
-} from '../../../constants/charts';
-import {
-  getMetlogConfig,
-  getPublicMetlogMetrics,
-} from '../../../constants/metlogConfig';
 import DownloadCSVButton from './DownloadCSVButton';
 
 const DEFAULT_METRICS: MetricsKeys[] = [

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/types.ts
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/types.ts
@@ -1,4 +1,4 @@
-import { DataRange, ValueWithTimestamp } from '../../../store/Sites/types';
+import { DataRange, ValueWithTimestamp } from 'store/Sites/types';
 
 export type RangeValue = 'one_month' | 'one_year' | 'max' | 'custom';
 

--- a/packages/website/src/common/Chart/Tooltip/index.tsx
+++ b/packages/website/src/common/Chart/Tooltip/index.tsx
@@ -14,8 +14,8 @@ import { Link } from 'react-router-dom';
 import styled from '@material-ui/core/styles/styled';
 import { isNumber } from 'lodash';
 
-import { formatNumber } from '../../../helpers/numberUtils';
-import { displayTimeInLocalTimezone } from '../../../helpers/dates';
+import { formatNumber } from 'helpers/numberUtils';
+import { displayTimeInLocalTimezone } from 'helpers/dates';
 import { Dataset } from '..';
 
 export const TOOLTIP_WIDTH = 190;

--- a/packages/website/src/common/Chart/index.tsx
+++ b/packages/website/src/common/Chart/index.tsx
@@ -9,17 +9,13 @@ import React, {
 import { Line } from 'react-chartjs-2';
 import { useSelector } from 'react-redux';
 import { mergeWith, isEqual } from 'lodash';
-import type {
-  Metrics,
-  ValueWithTimestamp,
-  Sources,
-} from '../../store/Sites/types';
+import type { Metrics, ValueWithTimestamp, Sources } from 'store/Sites/types';
 import './plugins/backgroundPlugin';
 import 'chartjs-plugin-annotation';
-import { SurveyListItem } from '../../store/Survey/types';
-import { surveyDetailsSelector } from '../../store/Survey/surveySlice';
-import { Range } from '../../store/Sites/types';
-import { convertToLocalTime } from '../../helpers/dates';
+import { SurveyListItem } from 'store/Survey/types';
+import { surveyDetailsSelector } from 'store/Survey/surveySlice';
+import { Range } from 'store/Sites/types';
+import { convertToLocalTime } from 'helpers/dates';
 import { useProcessedChartData } from './utils';
 
 // An interface that describes all the possible options for displaying a dataset on a chart.

--- a/packages/website/src/common/Chart/utils.ts
+++ b/packages/website/src/common/Chart/utils.ts
@@ -10,20 +10,20 @@ import {
   minBy,
 } from 'lodash';
 import { ChartDataSets, ChartPoint } from 'chart.js';
-import type {
-  DailyData,
-  HistoricalMonthlyMeanData,
-  ValueWithTimestamp,
-} from '../../store/Sites/types';
-import { SurveyListItem } from '../../store/Survey/types';
 import {
   DEFAULT_SURVEY_CHART_POINT_COLOR,
   SELECTED_SURVEY_CHART_POINT_COLOR,
   SURVEY_CHART_POINT_BORDER_COLOR,
   Y_SPACING_PERCENTAGE,
-} from '../../constants/charts';
+} from 'constants/charts';
+import type {
+  DailyData,
+  HistoricalMonthlyMeanData,
+  ValueWithTimestamp,
+} from 'store/Sites/types';
+import { SurveyListItem } from 'store/Survey/types';
+import { sortByDate } from 'helpers/dates';
 import type { ChartProps, Dataset } from '.';
-import { sortByDate } from '../../helpers/dates';
 
 interface Context {
   chart?: Chart;

--- a/packages/website/src/common/DeleteButton/index.test.tsx
+++ b/packages/website/src/common/DeleteButton/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
+import { mockUser } from 'mocks/mockUser';
 import DeleteButton from '.';
-import { mockUser } from '../../mocks/mockUser';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/ErrorPage/index.test.tsx
+++ b/packages/website/src/common/ErrorPage/index.test.tsx
@@ -4,9 +4,9 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 
+import { mockUser } from 'mocks/mockUser';
+import { mockCollection } from 'mocks/mockCollection';
 import ErrorPage from '.';
-import { mockUser } from '../../mocks/mockUser';
-import { mockCollection } from '../../mocks/mockCollection';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/Forms/TextField.tsx
+++ b/packages/website/src/common/Forms/TextField.tsx
@@ -7,7 +7,7 @@ import {
   BaseTextFieldProps,
 } from '@material-ui/core';
 
-import { FormField } from '../../hooks/useFormField';
+import { FormField } from 'hooks/useFormField';
 
 const CustomTextfield = ({
   formField,

--- a/packages/website/src/common/MenuDrawer/index.tsx
+++ b/packages/website/src/common/MenuDrawer/index.tsx
@@ -14,12 +14,8 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import { Clear, GitHub } from '@material-ui/icons';
+import { GaAction, GaCategory, trackButtonClick } from 'utils/google-analytics';
 import ovioLogo from '../../assets/img/ovio_logo.png';
-import {
-  GaAction,
-  GaCategory,
-  trackButtonClick,
-} from '../../utils/google-analytics';
 
 const darkBlue = '#095877';
 

--- a/packages/website/src/common/NavBar/index.test.tsx
+++ b/packages/website/src/common/NavBar/index.test.tsx
@@ -4,9 +4,9 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { mockUser } from 'mocks/mockUser';
+import { mockCollection } from 'mocks/mockCollection';
 import HomePageNavBar from '.';
-import { mockUser } from '../../mocks/mockUser';
-import { mockCollection } from '../../mocks/mockCollection';
 
 jest.mock('../RegisterDialog', () => 'Mock-RegisterDialog');
 jest.mock('../SignInDialog', () => 'Mock-SignInDialog');

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -30,22 +30,22 @@ import { sortBy } from 'lodash';
 import { useSelector, useDispatch } from 'react-redux';
 import classNames from 'classnames';
 import LanguageIcon from '@material-ui/icons/Language';
+import { userInfoSelector, signOutUser } from 'store/User/userSlice';
+import {
+  clearCollection,
+  collectionDetailsSelector,
+} from 'store/Collection/collectionSlice';
+import {
+  unsetLatestData,
+  unsetSpotterPosition,
+  unsetSelectedSite,
+} from 'store/Sites/selectedSiteSlice';
+import { useGoogleTranslation } from 'utils/google-translate';
 import RegisterDialog from '../RegisterDialog';
 import SignInDialog from '../SignInDialog';
 import Search from '../Search';
 import RouteButtons from '../RouteButtons';
 import MenuDrawer from '../MenuDrawer';
-import { userInfoSelector, signOutUser } from '../../store/User/userSlice';
-import {
-  clearCollection,
-  collectionDetailsSelector,
-} from '../../store/Collection/collectionSlice';
-import {
-  unsetLatestData,
-  unsetSpotterPosition,
-  unsetSelectedSite,
-} from '../../store/Sites/selectedSiteSlice';
-import { useGoogleTranslation } from '../../utils/google-translate';
 
 const NavBar = ({
   searchLocation,

--- a/packages/website/src/common/NewSurveyPointDialog/index.test.tsx
+++ b/packages/website/src/common/NewSurveyPointDialog/index.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import NewSurveyPointDialog from '.';
 

--- a/packages/website/src/common/NewSurveyPointDialog/index.tsx
+++ b/packages/website/src/common/NewSurveyPointDialog/index.tsx
@@ -16,13 +16,13 @@ import { grey } from '@material-ui/core/colors';
 import CloseIcon from '@material-ui/icons/Close';
 import { useDispatch, useSelector } from 'react-redux';
 
-import { maxLengths } from '../../constants/names';
-import surveyServices from '../../services/surveyServices';
-import { userInfoSelector } from '../../store/User/userSlice';
-import siteServices from '../../services/siteServices';
-import { setSiteSurveyPoints } from '../../store/Sites/selectedSiteSlice';
-import { SurveyPoints } from '../../store/Sites/types';
-import { getAxiosErrorMessage } from '../../helpers/errors';
+import { maxLengths } from 'constants/names';
+import { userInfoSelector } from 'store/User/userSlice';
+import { setSiteSurveyPoints } from 'store/Sites/selectedSiteSlice';
+import { SurveyPoints } from 'store/Sites/types';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import siteServices from 'services/siteServices';
+import surveyServices from 'services/surveyServices';
 
 const NewSurveyPointDialog = ({
   open,

--- a/packages/website/src/common/RegisterDialog/index.test.tsx
+++ b/packages/website/src/common/RegisterDialog/index.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import RegisterDialog from '.';
 

--- a/packages/website/src/common/RegisterDialog/index.tsx
+++ b/packages/website/src/common/RegisterDialog/index.tsx
@@ -30,8 +30,8 @@ import {
   userLoadingSelector,
   userErrorSelector,
   clearError,
-} from '../../store/User/userSlice';
-import { UserRegisterParams } from '../../store/User/types';
+} from 'store/User/userSlice';
+import { UserRegisterParams } from 'store/User/types';
 import dialogStyles from '../styles/dialogStyles';
 import { RegisterFormFields } from '../types';
 

--- a/packages/website/src/common/Search/index.test.tsx
+++ b/packages/website/src/common/Search/index.test.tsx
@@ -4,8 +4,8 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { mockSite } from 'mocks/mockSite';
 import Search from '.';
-import { mockSite } from '../../mocks/mockSite';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -12,22 +12,16 @@ import SearchIcon from '@material-ui/icons/Search';
 import Autocomplete from '@material-ui/lab/Autocomplete';
 import { useHistory, useParams } from 'react-router-dom';
 
-import {
-  setSiteOnMap,
-  setSearchResult,
-} from '../../store/Homepage/homepageSlice';
-import type { Site } from '../../store/Sites/types';
-import {
-  sitesListSelector,
-  sitesRequest,
-} from '../../store/Sites/sitesListSlice';
-import { getSiteNameAndRegion } from '../../store/Sites/helpers';
-import mapServices from '../../services/mapServices';
+import { setSiteOnMap, setSearchResult } from 'store/Homepage/homepageSlice';
+import type { Site } from 'store/Sites/types';
+import { sitesListSelector, sitesRequest } from 'store/Sites/sitesListSlice';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
 import {
   unsetLatestData,
   unsetSpotterPosition,
   unsetSelectedSite,
-} from '../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
+import mapServices from 'services/mapServices';
 
 const siteAugmentedName = (site: Site) => {
   const { name, region } = getSiteNameAndRegion(site);

--- a/packages/website/src/common/SelectRange/index.tsx
+++ b/packages/website/src/common/SelectRange/index.tsx
@@ -10,7 +10,7 @@ import {
   MenuItem,
 } from '@material-ui/core';
 
-import { Range } from '../../store/Sites/types';
+import { Range } from 'store/Sites/types';
 
 const SelectRange = ({
   open,

--- a/packages/website/src/common/SignInDialog/index.test.tsx
+++ b/packages/website/src/common/SignInDialog/index.test.tsx
@@ -3,7 +3,7 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import SignInDialog from '.';
 

--- a/packages/website/src/common/SignInDialog/index.tsx
+++ b/packages/website/src/common/SignInDialog/index.tsx
@@ -33,8 +33,8 @@ import {
   userLoadingSelector,
   userErrorSelector,
   clearError,
-} from '../../store/User/userSlice';
-import { UserSignInParams } from '../../store/User/types';
+} from 'store/User/userSlice';
+import { UserSignInParams } from 'store/User/types';
 import dialogStyles from '../styles/dialogStyles';
 import { SignInFormFields } from '../types';
 

--- a/packages/website/src/common/SiteDetails/CoralBleaching/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/index.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { mockDailyData } from 'mocks/mockDailyData';
 import Bleaching from '.';
-import { mockDailyData } from '../../../mocks/mockDailyData';
 
 test('renders as expected', () => {
   const { container } = render(

--- a/packages/website/src/common/SiteDetails/CoralBleaching/index.tsx
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/index.tsx
@@ -10,12 +10,12 @@ import {
   Grid,
 } from '@material-ui/core';
 
-import type { DailyData } from '../../../store/Sites/types';
+import type { DailyData } from 'store/Sites/types';
+import { findIntervalByLevel } from 'helpers/bleachingAlertIntervals';
+import { toRelativeTime } from 'helpers/dates';
 import UpdateInfo from '../../UpdateInfo';
 
-import { findIntervalByLevel } from '../../../helpers/bleachingAlertIntervals';
 import { styles as incomingStyles } from '../styles';
-import { toRelativeTime } from '../../../helpers/dates';
 
 const Bleaching = ({ dailyData, classes }: BleachingProps) => {
   const relativeTime = toRelativeTime(dailyData.date);

--- a/packages/website/src/common/SiteDetails/FeaturedMedia/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/FeaturedMedia/index.test.tsx
@@ -3,8 +3,8 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
+import { mockUser } from 'mocks/mockUser';
 import FeaturedMedia from '.';
-import { mockUser } from '../../../mocks/mockUser';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/SiteDetails/FeaturedMedia/index.tsx
+++ b/packages/website/src/common/SiteDetails/FeaturedMedia/index.tsx
@@ -14,11 +14,11 @@ import {
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
+import { userInfoSelector } from 'store/User/userSlice';
+import { isAdmin } from 'helpers/user';
+import { convertOptionsToQueryParams } from 'helpers/video';
 import reefImage from '../../../assets/reef-image.jpg';
 import uploadIcon from '../../../assets/icon_upload.svg';
-import { isAdmin } from '../../../helpers/user';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { convertOptionsToQueryParams } from '../../../helpers/video';
 
 const playerOptions = {
   autoplay: 1,

--- a/packages/website/src/common/SiteDetails/HUICard/index.tsx
+++ b/packages/website/src/common/SiteDetails/HUICard/index.tsx
@@ -11,13 +11,13 @@ import {
 } from '@material-ui/core';
 import React from 'react';
 import WarningIcon from '@material-ui/icons/Warning';
-import { toRelativeTime } from '../../../helpers/dates';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { LatestDataASSofarValue, Metrics } from '../../../store/Sites/types';
+import { LatestDataASSofarValue, Metrics } from 'store/Sites/types';
+import { toRelativeTime } from 'helpers/dates';
+import { formatNumber } from 'helpers/numberUtils';
+import { colors } from 'layout/App/theme';
 import UpdateInfo from '../../UpdateInfo';
 import { styles as incomingStyles } from '../styles';
 import { Extends } from '../../types';
-import { colors } from '../../../layout/App/theme';
 
 type HUICardMetrics = Extends<
   Metrics,

--- a/packages/website/src/common/SiteDetails/Map/SurveyPointPopup/index.tsx
+++ b/packages/website/src/common/SiteDetails/Map/SurveyPointPopup/index.tsx
@@ -9,7 +9,7 @@ import {
 } from '@material-ui/core';
 import { Popup } from 'react-leaflet';
 
-import { SurveyPoints } from '../../../../store/Sites/types';
+import { SurveyPoints } from 'store/Sites/types';
 import Link from '../../../Link';
 
 const SurveyPointPopup = ({

--- a/packages/website/src/common/SiteDetails/Map/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Map/index.test.tsx
@@ -4,8 +4,8 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { mockUser } from 'mocks/mockUser';
 import Map from '.';
-import { mockUser } from '../../../mocks/mockUser';
 
 jest.mock('react-leaflet');
 

--- a/packages/website/src/common/SiteDetails/Map/index.tsx
+++ b/packages/website/src/common/SiteDetails/Map/index.tsx
@@ -6,27 +6,24 @@ import './plugins/leaflet-tilelayer-subpixel-fix';
 import { withStyles, WithStyles, createStyles } from '@material-ui/core';
 import { some } from 'lodash';
 
-import SurveyPointPopup from './SurveyPointPopup';
+import { mapConstants } from 'constants/maps';
 import {
   Site,
   Position,
   SpotterPosition,
   SurveyPoints,
   Point,
-} from '../../../store/Sites/types';
-import { samePosition } from '../../../helpers/map';
+} from 'store/Sites/types';
+import { siteDraftSelector, setSiteDraft } from 'store/Sites/selectedSiteSlice';
+import { userInfoSelector } from 'store/User/userSlice';
+import { samePosition } from 'helpers/map';
+import { isManager } from 'helpers/user';
+import SurveyPointPopup from './SurveyPointPopup';
 
 import marker from '../../../assets/marker.png';
 import buoy from '../../../assets/buoy-marker.svg';
-import {
-  siteDraftSelector,
-  setSiteDraft,
-} from '../../../store/Sites/selectedSiteSlice';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { isManager } from '../../../helpers/user';
 import pointIcon from '../../../assets/alerts/pin_nostress@2x.png';
 import selectedPointIcon from '../../../assets/alerts/pin_warning@2x.png';
-import { mapConstants } from '../../../constants/maps';
 
 const pinIcon = L.icon({
   iconUrl: marker,

--- a/packages/website/src/common/SiteDetails/OceanSenseMetrics/index.tsx
+++ b/packages/website/src/common/SiteDetails/OceanSenseMetrics/index.tsx
@@ -16,19 +16,19 @@ import { grey } from '@material-ui/core/colors';
 import { useSelector } from 'react-redux';
 import { last } from 'lodash';
 
+import {
+  siteLatestOceanSenseDataLoadingSelector,
+  siteLatestOceanSenseDataSelector,
+} from 'store/Sites/selectedSiteSlice';
+import { OceanSenseData, OceanSenseKeys } from 'store/Sites/types';
+import { formatNumber } from 'helpers/numberUtils';
+import { toRelativeTime } from 'helpers/dates';
 import UpdateInfo from '../../UpdateInfo';
 import { ReactComponent as AcidityIcon } from '../../../assets/acidity.svg';
 import { ReactComponent as ConductivityIcon } from '../../../assets/conductivuty.svg';
 import { ReactComponent as PressureIcon } from '../../../assets/pressure.svg';
 import { ReactComponent as DissolvedOxygenIcon } from '../../../assets/dissolved_oxygen.svg';
 import { ReactComponent as OrpIcon } from '../../../assets/orp.svg';
-import {
-  siteLatestOceanSenseDataLoadingSelector,
-  siteLatestOceanSenseDataSelector,
-} from '../../../store/Sites/selectedSiteSlice';
-import { OceanSenseData, OceanSenseKeys } from '../../../store/Sites/types';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { toRelativeTime } from '../../../helpers/dates';
 
 interface Metric {
   label: string;

--- a/packages/website/src/common/SiteDetails/Satellite/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Satellite/index.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { parseLatestData } from 'store/Sites/helpers';
+import { mockLatestData } from 'mocks/mockLatestData';
 import Satellite from '.';
-import { mockLatestData } from '../../../mocks/mockLatestData';
-import { parseLatestData } from '../../../store/Sites/helpers';
 
 test('renders as expected', () => {
   const data = parseLatestData(mockLatestData);

--- a/packages/website/src/common/SiteDetails/Satellite/index.tsx
+++ b/packages/website/src/common/SiteDetails/Satellite/index.tsx
@@ -12,17 +12,17 @@ import {
   Box,
 } from '@material-ui/core';
 
-import { dhwColorCode } from '../../../assets/colorCode';
-import { formatNumber } from '../../../helpers/numberUtils';
-import satellite from '../../../assets/satellite.svg';
+import { LatestDataASSofarValue } from 'store/Sites/types';
+import { formatNumber } from 'helpers/numberUtils';
 import {
   dhwColorFinder,
   degreeHeatingWeeksCalculator,
-} from '../../../helpers/degreeHeatingWeeks';
+} from 'helpers/degreeHeatingWeeks';
+import { toRelativeTime } from 'helpers/dates';
+import { dhwColorCode } from '../../../assets/colorCode';
+import satellite from '../../../assets/satellite.svg';
 import { styles as incomingStyles } from '../styles';
 import UpdateInfo from '../../UpdateInfo';
-import { toRelativeTime } from '../../../helpers/dates';
-import { LatestDataASSofarValue } from '../../../store/Sites/types';
 
 const Satellite = ({ maxMonthlyMean, data, classes }: SatelliteProps) => {
   const { dhw, satelliteTemperature, sstAnomaly } = data;

--- a/packages/website/src/common/SiteDetails/Sensor/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.test.tsx
@@ -4,11 +4,11 @@ import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { parseLatestData } from 'store/Sites/helpers';
+import { mockUser } from 'mocks/mockUser';
+import { mockSite } from 'mocks/mockSite';
+import { mockLatestData } from 'mocks/mockLatestData';
 import Sensor from '.';
-import { mockUser } from '../../../mocks/mockUser';
-import { mockSite } from '../../../mocks/mockSite';
-import { mockLatestData } from '../../../mocks/mockLatestData';
-import { parseLatestData } from '../../../store/Sites/helpers';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -16,16 +16,16 @@ import { Link } from 'react-router-dom';
 import ArrowUpwardIcon from '@material-ui/icons/ArrowUpward';
 import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import RemoveIcon from '@material-ui/icons/Remove';
-import UpdateInfo from '../../UpdateInfo';
-import { findAdministeredSite } from '../../../helpers/findAdministeredSite';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { toRelativeTime } from '../../../helpers/dates';
-import { User } from '../../../store/User/types';
+import { User } from 'store/User/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { LatestDataASSofarValue } from 'store/Sites/types';
+import { findAdministeredSite } from 'helpers/findAdministeredSite';
+import { formatNumber } from 'helpers/numberUtils';
+import { toRelativeTime } from 'helpers/dates';
+import { isAdmin } from 'helpers/user';
 import sensor from '../../../assets/sensor.svg';
 import { styles as incomingStyles } from '../styles';
-import { isAdmin } from '../../../helpers/user';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { LatestDataASSofarValue } from '../../../store/Sites/types';
+import UpdateInfo from '../../UpdateInfo';
 
 /**
  * Get the sensor application tag message and clickability for a user/site combination.

--- a/packages/website/src/common/SiteDetails/Surveys/PointSelector/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/PointSelector/index.tsx
@@ -16,10 +16,10 @@ import {
 import { Create, DeleteOutline } from '@material-ui/icons';
 import { Link } from 'react-router-dom';
 
-import { SurveyPoints } from '../../../../store/Sites/types';
+import { SurveyPoints } from 'store/Sites/types';
+import { maxLengths } from 'constants/names';
 import EditDialog, { Action } from '../../../Dialog';
 import CustomLink from '../../../Link';
-import { maxLengths } from '../../../../constants/names';
 
 const PointSelector = ({
   siteId,

--- a/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.test.tsx
@@ -3,9 +3,9 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { mockUser } from 'mocks/mockUser';
+import { mockSurveyList } from 'mocks/mockSurveyList';
 import SurveyCard from '.';
-import { mockUser } from '../../../../mocks/mockUser';
-import { mockSurveyList } from '../../../../mocks/mockSurveyList';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/SurveyCard/index.tsx
@@ -11,16 +11,16 @@ import {
 import { Link } from 'react-router-dom';
 import moment from 'moment';
 import { useDispatch, useSelector } from 'react-redux';
-import { formatNumber } from '../../../../helpers/numberUtils';
-import { SurveyListItem } from '../../../../store/Survey/types';
+import { SurveyListItem } from 'store/Survey/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { surveysRequest } from 'store/Survey/surveyListSlice';
+import { formatNumber } from 'helpers/numberUtils';
+import surveyServices from 'services/surveyServices';
 import incomingStyles from '../styles';
 import CustomLink from '../../../Link';
 import LoadingSkeleton from '../../../LoadingSkeleton';
 import pointImageSkeleton from '../../../../assets/img/loading-image.svg';
 import DeleteButton from '../../../DeleteButton';
-import { userInfoSelector } from '../../../../store/User/userSlice';
-import { surveysRequest } from '../../../../store/Survey/surveyListSlice';
-import surveyServices from '../../../../services/surveyServices';
 
 const SurveyCard = ({
   pointId,

--- a/packages/website/src/common/SiteDetails/Surveys/Timeline/Desktop.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/Timeline/Desktop.tsx
@@ -11,10 +11,10 @@ import { makeStyles, Theme, Typography } from '@material-ui/core';
 import classNames from 'classnames';
 import grey from '@material-ui/core/colors/grey';
 
+import { displayTimeInLocalTimezone } from 'helpers/dates';
 import AddButton from '../AddButton';
 import SurveyCard from '../SurveyCard';
 import LoadingSkeleton from '../../../LoadingSkeleton';
-import { displayTimeInLocalTimezone } from '../../../../helpers/dates';
 import incomingStyles from '../styles';
 import { TimelineProps } from './types';
 

--- a/packages/website/src/common/SiteDetails/Surveys/Timeline/Tablet.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/Timeline/Tablet.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import { Grid, makeStyles, Typography } from '@material-ui/core';
 
+import { displayTimeInLocalTimezone } from 'helpers/dates';
 import AddButton from '../AddButton';
 import SurveyCard from '../SurveyCard';
 import incomingStyles from '../styles';
-import { displayTimeInLocalTimezone } from '../../../../helpers/dates';
 import { TimelineProps } from './types';
 import LoadingSkeleton from '../../../LoadingSkeleton';
 

--- a/packages/website/src/common/SiteDetails/Surveys/Timeline/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/Timeline/index.test.tsx
@@ -4,8 +4,8 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { mockSurveyList } from 'mocks/mockSurveyList';
 import Timeline from '.';
-import { mockSurveyList } from '../../../../mocks/mockSurveyList';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/SiteDetails/Surveys/Timeline/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/Timeline/index.tsx
@@ -7,9 +7,9 @@ import {
   Hidden,
 } from '@material-ui/core';
 
-import { surveyListSelector } from '../../../../store/Survey/surveyListSlice';
-import { filterSurveys } from '../../../../helpers/surveys';
-import { SurveyMedia } from '../../../../store/Survey/types';
+import { surveyListSelector } from 'store/Survey/surveyListSlice';
+import { SurveyMedia } from 'store/Survey/types';
+import { filterSurveys } from 'helpers/surveys';
 import TimelineDesktop from './Desktop';
 import TimelineTablet from './Tablet';
 import { TimelineProps } from './types';

--- a/packages/website/src/common/SiteDetails/Surveys/Timeline/types.ts
+++ b/packages/website/src/common/SiteDetails/Surveys/Timeline/types.ts
@@ -1,4 +1,4 @@
-import { SurveyListItem } from '../../../../store/Survey/types';
+import { SurveyListItem } from 'store/Survey/types';
 
 export interface TimelineProps {
   siteId?: number;

--- a/packages/website/src/common/SiteDetails/Surveys/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/index.test.tsx
@@ -4,10 +4,10 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { mockUser } from 'mocks/mockUser';
+import { mockSurveyList } from 'mocks/mockSurveyList';
+import { mockSite } from 'mocks/mockSite';
 import Surveys from '.';
-import { mockUser } from '../../../mocks/mockUser';
-import { mockSurveyList } from '../../../mocks/mockSurveyList';
-import { mockSite } from '../../../mocks/mockSite';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/common/SiteDetails/Surveys/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/index.tsx
@@ -14,24 +14,24 @@ import {
 } from '@material-ui/core';
 import { useDispatch, useSelector } from 'react-redux';
 
-import Timeline from './Timeline';
-import PointSelector from './PointSelector';
-import { setSiteSurveyPoints } from '../../../store/Sites/selectedSiteSlice';
-import { userInfoSelector } from '../../../store/User/userSlice';
+import observationOptions from 'constants/uploadDropdowns';
+import { setSiteSurveyPoints } from 'store/Sites/selectedSiteSlice';
+import { userInfoSelector } from 'store/User/userSlice';
 import {
   surveysRequest,
   updateSurveyPointName,
-} from '../../../store/Survey/surveyListSlice';
-import { setSelectedPoi } from '../../../store/Survey/surveySlice';
-import observationOptions from '../../../constants/uploadDropdowns';
-import { SurveyMedia } from '../../../store/Survey/types';
-import siteServices from '../../../services/siteServices';
-import { Site } from '../../../store/Sites/types';
-import { isAdmin } from '../../../helpers/user';
+} from 'store/Survey/surveyListSlice';
+import { setSelectedPoi } from 'store/Survey/surveySlice';
+import { SurveyMedia } from 'store/Survey/types';
+import { Site } from 'store/Sites/types';
+import { useBodyLength } from 'hooks/useBodyLength';
+import { isAdmin } from 'helpers/user';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import siteServices from 'services/siteServices';
+import surveyServices from 'services/surveyServices';
+import PointSelector from './PointSelector';
+import Timeline from './Timeline';
 import DeleteSurveyPointDialog, { Action } from '../../Dialog';
-import { useBodyLength } from '../../../hooks/useBodyLength';
-import surveyServices from '../../../services/surveyServices';
-import { getAxiosErrorMessage } from '../../../helpers/errors';
 
 const Surveys = ({ site }: SurveysProps) => {
   const classes = useStyles();

--- a/packages/website/src/common/SiteDetails/Surveys/styles.ts
+++ b/packages/website/src/common/SiteDetails/Surveys/styles.ts
@@ -1,4 +1,4 @@
-import theme from '../../../layout/App/theme';
+import theme from 'layout/App/theme';
 
 const styles = {
   dateWrapper: {

--- a/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
+++ b/packages/website/src/common/SiteDetails/WaterSampling/index.tsx
@@ -12,19 +12,16 @@ import {
 } from '@material-ui/core';
 import moment from 'moment';
 
+import { getSondeConfig, SondeMetricsKeys } from 'constants/sondeConfig';
+import { TimeSeriesData } from 'store/Sites/types';
+import { timeSeriesRequest } from 'store/Sites/helpers';
+import { formatNumber } from 'helpers/numberUtils';
+import requests from 'helpers/requests';
+import { colors } from 'layout/App/theme';
+import siteServices from 'services/siteServices';
 import { styles as incomingStyles } from '../styles';
 import { calculateSondeDataMeanValues } from './utils';
-import { TimeSeriesData } from '../../../store/Sites/types';
-import { timeSeriesRequest } from '../../../store/Sites/helpers';
-import { formatNumber } from '../../../helpers/numberUtils';
-import {
-  getSondeConfig,
-  SondeMetricsKeys,
-} from '../../../constants/sondeConfig';
 import UpdateInfo from '../../UpdateInfo';
-import requests from '../../../helpers/requests';
-import siteServices from '../../../services/siteServices';
-import { colors } from '../../../layout/App/theme';
 
 const CARD_BACKGROUND_COLOR = colors.greenCardColor;
 const METRICS: SondeMetricsKeys[] = [

--- a/packages/website/src/common/SiteDetails/WaterSampling/utils.ts
+++ b/packages/website/src/common/SiteDetails/WaterSampling/utils.ts
@@ -1,6 +1,6 @@
 import { mapValues, meanBy, pick, map, camelCase } from 'lodash';
-import { SondeMetricsKeys } from '../../../constants/sondeConfig';
-import { TimeSeriesData } from '../../../store/Sites/types';
+import { SondeMetricsKeys } from 'constants/sondeConfig';
+import { TimeSeriesData } from 'store/Sites/types';
 
 export const calculateSondeDataMeanValues = (
   metrics: SondeMetricsKeys[],

--- a/packages/website/src/common/SiteDetails/Waves/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.test.tsx
@@ -2,9 +2,9 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { parseLatestData } from 'store/Sites/helpers';
+import { mockLatestData } from 'mocks/mockLatestData';
 import Waves from '.';
-import { mockLatestData } from '../../../mocks/mockLatestData';
-import { parseLatestData } from '../../../store/Sites/helpers';
 
 test('renders as expected', () => {
   const data = parseLatestData(mockLatestData);

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -11,10 +11,10 @@ import {
 import classNames from 'classnames';
 import { isNil } from 'lodash';
 
+import type { LatestDataASSofarValue } from 'store/Sites/types';
+import { formatNumber } from 'helpers/numberUtils';
+import { toRelativeTime } from 'helpers/dates';
 import UpdateInfo from '../../UpdateInfo';
-import type { LatestDataASSofarValue } from '../../../store/Sites/types';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { toRelativeTime } from '../../../helpers/dates';
 import waves from '../../../assets/waves.svg';
 import arrow from '../../../assets/directioncircle.svg';
 import wind from '../../../assets/wind.svg';

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -12,6 +12,24 @@ import classNames from 'classnames';
 import times from 'lodash/times';
 
 import { useDispatch, useSelector } from 'react-redux';
+import { oceanSenseConfig } from 'constants/oceanSenseConfig';
+import type { Site, LatestDataASSofarValue } from 'store/Sites/types';
+import { SurveyListItem, SurveyPoint } from 'store/Survey/types';
+import {
+  forecastDataRequest,
+  forecastDataSelector,
+  latestDataRequest,
+  latestDataSelector,
+  spotterPositionRequest,
+  spotterPositionSelector,
+  unsetForecastData,
+  unsetLatestData,
+  unsetSpotterPosition,
+} from 'store/Sites/selectedSiteSlice';
+import { parseLatestData } from 'store/Sites/helpers';
+import { getMiddlePoint } from 'helpers/map';
+import { formatNumber } from 'helpers/numberUtils';
+import { displayTimeInLocalTimezone, sortByDate } from 'helpers/dates';
 import Map from './Map';
 import SketchFab from './SketchFab';
 import FeaturedMedia from './FeaturedMedia';
@@ -24,28 +42,10 @@ import Surveys from './Surveys';
 import CardWithTitle from './CardWithTitle';
 import { Value } from './CardWithTitle/types';
 import CombinedCharts from '../Chart/CombinedCharts';
-import type { Site, LatestDataASSofarValue } from '../../store/Sites/types';
-import { getMiddlePoint } from '../../helpers/map';
-import { formatNumber } from '../../helpers/numberUtils';
-import { SurveyListItem, SurveyPoint } from '../../store/Survey/types';
-import { displayTimeInLocalTimezone, sortByDate } from '../../helpers/dates';
-import { oceanSenseConfig } from '../../constants/oceanSenseConfig';
 import WaterSamplingCard from './WaterSampling';
 import { styles as incomingStyles } from './styles';
 import LoadingSkeleton from '../LoadingSkeleton';
 import playIcon from '../../assets/play-icon.svg';
-import {
-  forecastDataRequest,
-  forecastDataSelector,
-  latestDataRequest,
-  latestDataSelector,
-  spotterPositionRequest,
-  spotterPositionSelector,
-  unsetForecastData,
-  unsetLatestData,
-  unsetSpotterPosition,
-} from '../../store/Sites/selectedSiteSlice';
-import { parseLatestData } from '../../store/Sites/helpers';
 import HUICard from './HUICard';
 
 const sondeMetrics: (keyof LatestDataASSofarValue)[] = [

--- a/packages/website/src/common/SiteDetails/styles.ts
+++ b/packages/website/src/common/SiteDetails/styles.ts
@@ -1,4 +1,4 @@
-import theme from '../../layout/App/theme';
+import theme from 'layout/App/theme';
 
 const MD_MID_POINT = 1100;
 const SM_MID_POINT = 780;

--- a/packages/website/src/common/SurveyForm/index.tsx
+++ b/packages/website/src/common/SurveyForm/index.tsx
@@ -25,9 +25,9 @@ import {
 import DateFnsUtils from '@date-io/date-fns';
 import { useForm, Controller } from 'react-hook-form';
 
-import { diveLocationSelector } from '../../store/Survey/surveySlice';
-import { SurveyData, SurveyState } from '../../store/Survey/types';
-import { setTimeZone } from '../../helpers/dates';
+import { diveLocationSelector } from 'store/Survey/surveySlice';
+import { SurveyData, SurveyState } from 'store/Survey/types';
+import { setTimeZone } from 'helpers/dates';
 
 interface SurveyFormFields {
   diveDate: string;

--- a/packages/website/src/common/SurveyPointSelector/index.tsx
+++ b/packages/website/src/common/SurveyPointSelector/index.tsx
@@ -11,9 +11,9 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import AddIcon from '@material-ui/icons/Add';
 import classNames from 'classnames';
-import { siteDetailsSelector } from '../../store/Sites/selectedSiteSlice';
+import { siteDetailsSelector } from 'store/Sites/selectedSiteSlice';
+import { SurveyPoints } from 'store/Sites/types';
 import NewSurveyPointDialog from '../NewSurveyPointDialog';
-import { SurveyPoints } from '../../store/Sites/types';
 
 function SurveyPointSelector({
   handleSurveyPointChange,

--- a/packages/website/src/common/styles/dialogStyles.ts
+++ b/packages/website/src/common/styles/dialogStyles.ts
@@ -1,4 +1,4 @@
-import theme from '../../layout/App/theme';
+import theme from 'layout/App/theme';
 
 const styles = {
   closeButton: {

--- a/packages/website/src/constants/metlogConfig.ts
+++ b/packages/website/src/constants/metlogConfig.ts
@@ -1,4 +1,4 @@
-import { MetricsKeys } from '../store/Sites/types';
+import { MetricsKeys } from 'store/Sites/types';
 
 interface MetlogConfig {
   title: string;

--- a/packages/website/src/constants/sondeConfig.ts
+++ b/packages/website/src/constants/sondeConfig.ts
@@ -1,4 +1,4 @@
-import { MetricsKeys } from '../store/Sites/types';
+import { MetricsKeys } from 'store/Sites/types';
 
 interface SondeConfig {
   title: string;

--- a/packages/website/src/helpers/dates.ts
+++ b/packages/website/src/helpers/dates.ts
@@ -8,8 +8,8 @@ import {
   HistoricalMonthlyMeanData,
   Range,
   ValueWithTimestamp,
-} from '../store/Sites/types';
-import { SurveyListItem } from '../store/Survey/types';
+} from 'store/Sites/types';
+import { SurveyListItem } from 'store/Survey/types';
 
 type DateString = string | null | undefined;
 

--- a/packages/website/src/helpers/findAdministeredSite.ts
+++ b/packages/website/src/helpers/findAdministeredSite.ts
@@ -1,5 +1,5 @@
-import { User } from '../store/User/types';
-import { Site } from '../store/Sites/types';
+import { User } from 'store/User/types';
+import { Site } from 'store/Sites/types';
 
 export const findAdministeredSite = (
   user: User | null,

--- a/packages/website/src/helpers/map.ts
+++ b/packages/website/src/helpers/map.ts
@@ -2,18 +2,13 @@ import { isEqual, mean, meanBy, minBy } from 'lodash';
 import L, { LatLng, LatLngBounds, Polygon as LeafletPolygon } from 'leaflet';
 import { makeStyles } from '@material-ui/core';
 
-import type {
-  Point,
-  SurveyPoints,
-  Polygon,
-  Position,
-} from '../store/Sites/types';
+import type { Point, SurveyPoints, Polygon, Position } from 'store/Sites/types';
+import { CollectionDetails } from 'store/Collection/types';
 import { spotter } from '../assets/spotter';
 import { spotterSelected } from '../assets/spotterSelected';
 import { spotterAnimation } from '../assets/spotterAnimation';
 import { hobo } from '../assets/hobo';
 import { hoboSelected } from '../assets/hoboSelected';
-import { CollectionDetails } from '../store/Collection/types';
 
 /**
  * Get the middle point of a polygon (average of all points). Returns the point itself if input isn't a polygon.

--- a/packages/website/src/helpers/siteUtils.ts
+++ b/packages/website/src/helpers/siteUtils.ts
@@ -5,8 +5,8 @@ import {
   Site,
   SurveyPoints,
   UpdateSiteNameFromListArgs,
-} from '../store/Sites/types';
-import type { TimeSeriesDataRequestParams } from '../store/Sites/types';
+} from 'store/Sites/types';
+import type { TimeSeriesDataRequestParams } from 'store/Sites/types';
 import requests from './requests';
 
 export const longDHW = (dhw: number | null): string =>

--- a/packages/website/src/helpers/surveyMedia.ts
+++ b/packages/website/src/helpers/surveyMedia.ts
@@ -1,5 +1,5 @@
 import { groupBy, sortBy } from 'lodash';
-import type { SurveyMedia } from '../store/Survey/types';
+import type { SurveyMedia } from 'store/Survey/types';
 
 export const getFeaturedMedia = (surveyMedia: SurveyMedia[]) => {
   const media = surveyMedia.find((mediaItem) => mediaItem.featured);

--- a/packages/website/src/helpers/surveys.ts
+++ b/packages/website/src/helpers/surveys.ts
@@ -4,7 +4,7 @@ import {
   SurveyListState,
   Observations,
   SurveyListItem,
-} from '../store/Survey/types';
+} from 'store/Survey/types';
 import { sortByDate } from './dates';
 
 export const filterSurveys = (

--- a/packages/website/src/helpers/user.ts
+++ b/packages/website/src/helpers/user.ts
@@ -1,5 +1,5 @@
-import { User } from '../store/User/types';
-import { CollectionDetails } from '../store/Collection/types';
+import { User } from 'store/User/types';
+import { CollectionDetails } from 'store/Collection/types';
 
 export const isAdmin = (user: User | null, siteId: number): boolean => {
   return user

--- a/packages/website/src/hooks/useFormField.ts
+++ b/packages/website/src/hooks/useFormField.ts
@@ -1,6 +1,6 @@
 import { useEffect, useReducer } from 'react';
 
-import validators from '../helpers/validators';
+import validators from 'helpers/validators';
 
 export interface FormField {
   value: string;

--- a/packages/website/src/hooks/useSiteRequest.ts
+++ b/packages/website/src/hooks/useSiteRequest.ts
@@ -5,7 +5,7 @@ import {
   siteDetailsSelector,
   siteLoadingSelector,
   siteRequest,
-} from '../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
 
 export const useSiteRequest = (siteId: string) => {
   const dispatch = useDispatch();

--- a/packages/website/src/layout/App/ErrorBoundary.tsx
+++ b/packages/website/src/layout/App/ErrorBoundary.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/prefer-stateless-function */
 import React, { Component, PropsWithChildren } from 'react';
-import ErrorPage from '../../common/ErrorPage';
+import ErrorPage from 'common/ErrorPage';
 
 interface ErrorBoundaryState {
   hasError: boolean;

--- a/packages/website/src/layout/App/index.tsx
+++ b/packages/website/src/layout/App/index.tsx
@@ -8,6 +8,8 @@ import {
 } from 'react-router-dom';
 import { useDispatch } from 'react-redux';
 
+import { getSelf } from 'store/User/userSlice';
+import { useGATagManager } from 'utils/google-analytics';
 import NotFound from '../../routes/NotFound';
 import ErrorBoundary from './ErrorBoundary';
 import LandingPage from '../../routes/Landing';
@@ -24,9 +26,7 @@ import theme from './theme';
 import 'leaflet/dist/leaflet.css';
 import './App.css';
 import '../../assets/css/bootstrap.css';
-import { getSelf } from '../../store/User/userSlice';
 import app from '../../firebase';
-import { useGATagManager } from '../../utils/google-analytics';
 import Terms from '../../routes/Terms';
 
 function App() {

--- a/packages/website/src/mocks/mockCollection.ts
+++ b/packages/website/src/mocks/mockCollection.ts
@@ -1,4 +1,4 @@
-import { CollectionDetails } from '../store/Collection/types';
+import { CollectionDetails } from 'store/Collection/types';
 import { mockSite } from './mockSite';
 import { mockUser } from './mockUser';
 

--- a/packages/website/src/mocks/mockDailyData.ts
+++ b/packages/website/src/mocks/mockDailyData.ts
@@ -1,4 +1,4 @@
-import { DailyData } from '../store/Sites/types';
+import { DailyData } from 'store/Sites/types';
 
 const now = new Date();
 const minutesAgo = 5;

--- a/packages/website/src/mocks/mockDataRange.ts
+++ b/packages/website/src/mocks/mockDataRange.ts
@@ -1,4 +1,4 @@
-import { TimeSeriesDataRange } from '../store/Sites/types';
+import { TimeSeriesDataRange } from 'store/Sites/types';
 
 export const mockDataRange: TimeSeriesDataRange = {
   bottomTemperature: {

--- a/packages/website/src/mocks/mockLatestData.ts
+++ b/packages/website/src/mocks/mockLatestData.ts
@@ -1,4 +1,4 @@
-import { LatestData } from '../store/Sites/types';
+import { LatestData } from 'store/Sites/types';
 
 const aDayAgo = new Date(
   new Date().setDate(new Date().getDate() - 1),

--- a/packages/website/src/mocks/mockLiveData.ts
+++ b/packages/website/src/mocks/mockLiveData.ts
@@ -1,4 +1,4 @@
-import { LiveData } from '../store/Sites/types';
+import { LiveData } from 'store/Sites/types';
 
 const now = new Date();
 const minutesAgo = 5;

--- a/packages/website/src/mocks/mockSite.ts
+++ b/packages/website/src/mocks/mockSite.ts
@@ -1,4 +1,4 @@
-import { CollectionMetrics, Point, Site } from '../store/Sites/types';
+import { CollectionMetrics, Point, Site } from 'store/Sites/types';
 import { mockUser } from './mockUser';
 
 const now = new Date();

--- a/packages/website/src/mocks/mockSurvey.ts
+++ b/packages/website/src/mocks/mockSurvey.ts
@@ -1,4 +1,4 @@
-import { SurveyState } from '../store/Survey/types';
+import { SurveyState } from 'store/Survey/types';
 
 export const mockSurvey: SurveyState = {
   comments: 'No comments',

--- a/packages/website/src/mocks/mockSurveyList.ts
+++ b/packages/website/src/mocks/mockSurveyList.ts
@@ -1,4 +1,4 @@
-import { SurveyListItem } from '../store/Survey/types';
+import { SurveyListItem } from 'store/Survey/types';
 
 export const mockSurveyList: SurveyListItem = {
   comments: 'No comments',

--- a/packages/website/src/mocks/mockSurveyPoint.ts
+++ b/packages/website/src/mocks/mockSurveyPoint.ts
@@ -1,4 +1,4 @@
-import { SurveyPoints } from '../store/Sites/types';
+import { SurveyPoints } from 'store/Sites/types';
 
 export const mockSurveyPoint: SurveyPoints = {
   id: 1,

--- a/packages/website/src/mocks/mockUser.ts
+++ b/packages/website/src/mocks/mockUser.ts
@@ -1,4 +1,4 @@
-import { User } from '../store/User/types';
+import { User } from 'store/User/types';
 
 export const mockUser: User = {
   id: 1,

--- a/packages/website/src/routes/About/index.test.tsx
+++ b/packages/website/src/routes/About/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import About from '.';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
-jest.mock('../../common/Footer', () => 'Mock-Footer');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/Footer', () => 'Mock-Footer');
 
 const mockStore = configureStore([]);
 describe('About', () => {

--- a/packages/website/src/routes/About/index.tsx
+++ b/packages/website/src/routes/About/index.tsx
@@ -8,8 +8,8 @@ import {
 } from '@material-ui/core';
 import classNames from 'classnames';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 
 import peter from '../../assets/img/peter.jpg';
 import lyndon from '../../assets/img/LYNDON1.jpg';

--- a/packages/website/src/routes/Buoy/index.test.tsx
+++ b/packages/website/src/routes/Buoy/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import Buoy from '.';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
-jest.mock('../../common/Footer', () => 'Mock-Footer');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/Footer', () => 'Mock-Footer');
 
 const mockStore = configureStore([]);
 describe('Buoy', () => {

--- a/packages/website/src/routes/Buoy/index.tsx
+++ b/packages/website/src/routes/Buoy/index.tsx
@@ -7,8 +7,8 @@ import {
   Theme,
 } from '@material-ui/core';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 
 import fullDiagramBuoy from '../../assets/img/fulldiag3_1.svg';
 import fullDiagramInfra from '../../assets/img/fulldiag3.svg';

--- a/packages/website/src/routes/Dashboard/Content.tsx
+++ b/packages/website/src/routes/Dashboard/Content.tsx
@@ -1,18 +1,18 @@
 import React from 'react';
 import { Container, Grid, LinearProgress } from '@material-ui/core';
 import { useSelector } from 'react-redux';
-import Header from './Header';
-import Map from './Map';
-import Info from './Info';
-import Table from './Table';
-import FullScreenMessage from '../../common/FullScreenMessage';
 import {
   collectionDetailsSelector,
   collectionErrorSelector,
   collectionLoadingSelector,
-} from '../../store/Collection/collectionSlice';
+} from 'store/Collection/collectionSlice';
+import FullScreenMessage from 'common/FullScreenMessage';
+import Banner from 'common/Banner';
+import Header from './Header';
+import Map from './Map';
+import Info from './Info';
+import Table from './Table';
 import Tracker from '../Tracker';
-import Banner from '../../common/Banner';
 
 const bannerMessage = `You have not saved any sites yet. \
 Follow the instructions on this page and come back \

--- a/packages/website/src/routes/Dashboard/Header/EditNameForm.tsx
+++ b/packages/website/src/routes/Dashboard/Header/EditNameForm.tsx
@@ -15,11 +15,11 @@ import CheckIcon from '@material-ui/icons/Check';
 import ClearIcon from '@material-ui/icons/Clear';
 import { useDispatch } from 'react-redux';
 
-import TextField from '../../../common/Forms/TextField';
-import { useFormField } from '../../../hooks/useFormField';
-import { User } from '../../../store/User/types';
-import collectionServices from '../../../services/collectionServices';
-import { setName } from '../../../store/Collection/collectionSlice';
+import { User } from 'store/User/types';
+import { setName } from 'store/Collection/collectionSlice';
+import { useFormField } from 'hooks/useFormField';
+import TextField from 'common/Forms/TextField';
+import collectionServices from 'services/collectionServices';
 
 const EditNameForm = ({
   collectionId,

--- a/packages/website/src/routes/Dashboard/Header/index.tsx
+++ b/packages/website/src/routes/Dashboard/Header/index.tsx
@@ -14,10 +14,10 @@ import EditIcon from '@material-ui/icons/Edit';
 import { Link } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 
+import { CollectionDetails } from 'store/Collection/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { isCollectionOwner } from 'helpers/user';
 import EditNameForm from './EditNameForm';
-import { CollectionDetails } from '../../../store/Collection/types';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { isCollectionOwner } from '../../../helpers/user';
 
 const Header = ({ collection, classes }: HeaderProps) => {
   const signedInUser = useSelector(userInfoSelector);

--- a/packages/website/src/routes/Dashboard/Info/BarChart.tsx
+++ b/packages/website/src/routes/Dashboard/Info/BarChart.tsx
@@ -11,9 +11,9 @@ import {
 } from '@material-ui/core';
 import { groupBy, maxBy, times, reverse } from 'lodash';
 
-import { findIntervalByLevel } from '../../../helpers/bleachingAlertIntervals';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { CollectionDetails } from '../../../store/Collection/types';
+import { CollectionDetails } from 'store/Collection/types';
+import { findIntervalByLevel } from 'helpers/bleachingAlertIntervals';
+import { formatNumber } from 'helpers/numberUtils';
 
 const percentageCalculator = (count: number, max?: number) => {
   // Max width should be 80%

--- a/packages/website/src/routes/Dashboard/Info/Header.tsx
+++ b/packages/website/src/routes/Dashboard/Info/Header.tsx
@@ -11,7 +11,7 @@ import {
 import EmailIcon from '@material-ui/icons/Email';
 import classNames from 'classnames';
 
-import { User } from '../../../store/User/types';
+import { User } from 'store/User/types';
 
 const Header = ({ user, nSites, classes }: HeaderProps) => (
   <>

--- a/packages/website/src/routes/Dashboard/Info/index.tsx
+++ b/packages/website/src/routes/Dashboard/Info/index.tsx
@@ -7,7 +7,7 @@ import {
   Theme,
 } from '@material-ui/core';
 
-import { CollectionDetails } from '../../../store/Collection/types';
+import { CollectionDetails } from 'store/Collection/types';
 import Header from './Header';
 import BarChart from './BarChart';
 

--- a/packages/website/src/routes/Dashboard/Map/index.tsx
+++ b/packages/website/src/routes/Dashboard/Map/index.tsx
@@ -10,9 +10,9 @@ import {
 } from '@material-ui/core';
 import { LatLng } from 'leaflet';
 
+import { CollectionDetails } from 'store/Collection/types';
+import { getCollectionCenterAndBounds } from 'helpers/map';
 import Map from '../../HomeMap/Map';
-import { getCollectionCenterAndBounds } from '../../../helpers/map';
-import { CollectionDetails } from '../../../store/Collection/types';
 
 const DashboardMap = ({ collection, classes }: DashboardMapProps) => {
   const theme = useTheme();

--- a/packages/website/src/routes/Dashboard/collection.ts
+++ b/packages/website/src/routes/Dashboard/collection.ts
@@ -1,6 +1,6 @@
 import { sampleSize } from 'lodash';
 
-import { Site } from '../../store/Sites/types';
+import { Site } from 'store/Sites/types';
 
 export const createCollection = (sites: Site[], nSites: number): Collection => {
   const sample = sampleSize(sites, nSites);

--- a/packages/website/src/routes/Dashboard/index.tsx
+++ b/packages/website/src/routes/Dashboard/index.tsx
@@ -8,19 +8,16 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import { RouteComponentProps, useLocation } from 'react-router-dom';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
-import {
-  userInfoSelector,
-  userLoadingSelector,
-} from '../../store/User/userSlice';
+import { userInfoSelector, userLoadingSelector } from 'store/User/userSlice';
 import {
   collectionDetailsSelector,
   collectionRequest,
-} from '../../store/Collection/collectionSlice';
-import Delayed from '../../common/Delayed';
+} from 'store/Collection/collectionSlice';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
+import Delayed from 'common/Delayed';
+import FullScreenMessage from 'common/FullScreenMessage';
 import DashboardContent from './Content';
-import FullScreenMessage from '../../common/FullScreenMessage';
 
 // This will be removed when the idea of public collections will be introduced.
 // For now only this static one is being used.

--- a/packages/website/src/routes/Drones/index.test.tsx
+++ b/packages/website/src/routes/Drones/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import Drones from '.';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
-jest.mock('../../common/Footer', () => 'Mock-Footer');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/Footer', () => 'Mock-Footer');
 
 const mockStore = configureStore([]);
 describe('Drones', () => {

--- a/packages/website/src/routes/Drones/index.tsx
+++ b/packages/website/src/routes/Drones/index.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Box } from '@material-ui/core';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 
 import ghbttn from '../../assets/img/ghbttn.png';
 import f4 from '../../assets/img/f4.png';

--- a/packages/website/src/routes/Faq/index.test.tsx
+++ b/packages/website/src/routes/Faq/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import Faq from '.';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
-jest.mock('../../common/Footer', () => 'Mock-Footer');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/Footer', () => 'Mock-Footer');
 
 const mockStore = configureStore([]);
 describe('Faq', () => {

--- a/packages/website/src/routes/Faq/index.tsx
+++ b/packages/website/src/routes/Faq/index.tsx
@@ -7,8 +7,8 @@ import {
   CardMedia,
 } from '@material-ui/core';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 
 const Faq = ({ classes }: FaqProps) => {
   return (

--- a/packages/website/src/routes/HomeMap/Map/Legend/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Legend/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { withStyles, WithStyles, createStyles, Theme } from '@material-ui/core';
 import classNames from 'classnames';
 
-import CustomLegend from '../../../../common/Legend';
+import CustomLegend from 'common/Legend';
 import {
   dhwColorCode,
   surfaceTempColorCode,

--- a/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
@@ -1,18 +1,18 @@
 import { Marker, useLeaflet } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
-import { Site } from '../../../../store/Sites/types';
+import { Site } from 'store/Sites/types';
 import {
   siteOnMapSelector,
   setSiteOnMap,
   setSearchResult,
-} from '../../../../store/Homepage/homepageSlice';
-import { useMarkerIcon } from '../../../../helpers/map';
-import { hasDeployedSpotter } from '../../../../helpers/siteUtils';
+} from 'store/Homepage/homepageSlice';
+import { useMarkerIcon } from 'helpers/map';
+import { hasDeployedSpotter } from 'helpers/siteUtils';
 import {
   alertColorFinder,
   alertIconFinder,
-} from '../../../../helpers/bleachingAlertIntervals';
+} from 'helpers/bleachingAlertIntervals';
 import Popup from '../Popup';
 
 // To make sure we can see all the sites all the time, and especially

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -3,18 +3,18 @@ import { LayerGroup, useLeaflet } from 'react-leaflet';
 import MarkerClusterGroup from 'react-leaflet-markercluster';
 import React, { useCallback, useEffect } from 'react';
 import L from 'leaflet';
-import { sitesToDisplayListSelector } from '../../../../store/Sites/sitesListSlice';
-import { Site } from '../../../../store/Sites/types';
-import { siteOnMapSelector } from '../../../../store/Homepage/homepageSlice';
+import { sitesToDisplayListSelector } from 'store/Sites/sitesListSlice';
+import { Site } from 'store/Sites/types';
+import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import 'leaflet/dist/leaflet.css';
 import 'react-leaflet-markercluster/dist/styles.min.css';
+import { CollectionDetails } from 'store/Collection/types';
 import {
   findIntervalByLevel,
   findMaxLevel,
   getColorByLevel,
   Interval,
-} from '../../../../helpers/bleachingAlertIntervals';
-import { CollectionDetails } from '../../../../store/Collection/types';
+} from 'helpers/bleachingAlertIntervals';
 import SiteMarker from './SiteMarker';
 
 const clusterIcon = (cluster: any) => {

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.test.tsx
@@ -4,8 +4,8 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
 import { BrowserRouter as Router } from 'react-router-dom';
+import { mockSite } from 'mocks/mockSite';
 import Popup from '.';
-import { mockSite } from '../../../../mocks/mockSite';
 
 jest.mock('react-leaflet', () => ({
   __esModule: true,

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -17,18 +17,14 @@ import { Popup as LeafletPopup, useLeaflet } from 'react-leaflet';
 import { useSelector } from 'react-redux';
 
 import type { LatLngTuple } from 'leaflet';
-import type { Site } from '../../../../store/Sites/types';
-import { getSiteNameAndRegion } from '../../../../store/Sites/helpers';
-import { colors } from '../../../../layout/App/theme';
-import { formatNumber } from '../../../../helpers/numberUtils';
-import { dhwColorFinder } from '../../../../helpers/degreeHeatingWeeks';
-import { siteOnMapSelector } from '../../../../store/Homepage/homepageSlice';
-import { maxLengths } from '../../../../constants/names';
-import {
-  GaCategory,
-  GaAction,
-  trackButtonClick,
-} from '../../../../utils/google-analytics';
+import type { Site } from 'store/Sites/types';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
+import { maxLengths } from 'constants/names';
+import { formatNumber } from 'helpers/numberUtils';
+import { dhwColorFinder } from 'helpers/degreeHeatingWeeks';
+import { colors } from 'layout/App/theme';
+import { GaCategory, GaAction, trackButtonClick } from 'utils/google-analytics';
 
 const Popup = ({ site, classes, autoOpen }: PopupProps) => {
   const { map } = useLeaflet();

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -13,15 +13,15 @@ import {
 import { Alert } from '@material-ui/lab';
 import MyLocationIcon from '@material-ui/icons/MyLocation';
 
-import { sitesListLoadingSelector } from '../../../store/Sites/sitesListSlice';
+import { sitesListLoadingSelector } from 'store/Sites/sitesListSlice';
+import { searchResultSelector } from 'store/Homepage/homepageSlice';
+import { CollectionDetails } from 'store/Collection/types';
+import { MapLayerName } from 'store/Homepage/types';
+import { mapConstants } from 'constants/maps';
 import { SiteMarkers } from './Markers';
 import { SofarLayers } from './sofarLayers';
 import Legend from './Legend';
 import AlertLevelLegend from './alertLevelLegend';
-import { searchResultSelector } from '../../../store/Homepage/homepageSlice';
-import { CollectionDetails } from '../../../store/Collection/types';
-import { MapLayerName } from '../../../store/Homepage/types';
-import { mapConstants } from '../../../constants/maps';
 
 const accessToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 

--- a/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
+++ b/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { LayersControl, TileLayer } from 'react-leaflet';
-import { MapLayerName } from '../../../store/Homepage/types';
+import { MapLayerName } from 'store/Homepage/types';
 
 type SofarLayerDefinition = {
   name: MapLayerName;

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -16,18 +16,14 @@ import { Link } from 'react-router-dom';
 import classNames from 'classnames';
 
 import { Alert } from '@material-ui/lab';
-import Chart from '../../../../common/Chart';
-import { formatNumber } from '../../../../helpers/numberUtils';
-import { Site } from '../../../../store/Sites/types';
-import { getSiteNameAndRegion } from '../../../../store/Sites/helpers';
-import { standardDailyDataDataset } from '../../../../common/Chart/MultipleSensorsCharts/helpers';
-import {
-  GaAction,
-  GaCategory,
-  trackButtonClick,
-} from '../../../../utils/google-analytics';
-import Chip from '../../../../common/Chip';
-import LoadingSkeleton from '../../../../common/LoadingSkeleton';
+import { Site } from 'store/Sites/types';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { formatNumber } from 'helpers/numberUtils';
+import Chart from 'common/Chart';
+import { standardDailyDataDataset } from 'common/Chart/MultipleSensorsCharts/helpers';
+import Chip from 'common/Chip';
+import LoadingSkeleton from 'common/LoadingSkeleton';
+import { GaAction, GaCategory, trackButtonClick } from 'utils/google-analytics';
 import featuredImageLoading from '../../../../assets/img/loading-image.svg';
 import chartLoading from '../../../../assets/img/chart_skeleton.png';
 

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.test.tsx
@@ -4,8 +4,8 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import configureStore from 'redux-mock-store';
 import { Provider } from 'react-redux';
 
+import { mockSite } from 'mocks/mockSite';
 import SelectedSiteCard from '.';
-import { mockSite } from '../../../../mocks/mockSite';
 
 jest.mock('react-chartjs-2', () => ({
   Line: () => 'Mock-Line',

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
@@ -10,10 +10,10 @@ import {
   siteDetailsSelector,
   siteErrorSelector,
   siteLoadingSelector,
-} from '../../../../store/Sites/selectedSiteSlice';
-import { surveyListSelector } from '../../../../store/Survey/surveyListSlice';
-import { sortByDate } from '../../../../helpers/dates';
-import LoadingSkeleton from '../../../../common/LoadingSkeleton';
+} from 'store/Sites/selectedSiteSlice';
+import { surveyListSelector } from 'store/Survey/surveyListSlice';
+import { sortByDate } from 'helpers/dates';
+import LoadingSkeleton from 'common/LoadingSkeleton';
 import SelectedSiteCardContent from './CardContent';
 
 const featuredSiteId = process.env.REACT_APP_FEATURED_SITE_ID || '';

--- a/packages/website/src/routes/HomeMap/SiteTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/body.tsx
@@ -14,19 +14,19 @@ import {
 import ErrorIcon from '@material-ui/icons/Error';
 import React, { useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { TableRow as Row } from '../../../store/Homepage/types';
-import { constructTableData } from '../../../store/Sites/helpers';
-import { colors } from '../../../layout/App/theme';
-import { dhwColorFinder } from '../../../helpers/degreeHeatingWeeks';
-import { formatNumber } from '../../../helpers/numberUtils';
-import { sitesToDisplayListSelector } from '../../../store/Sites/sitesListSlice';
+import { TableRow as Row } from 'store/Homepage/types';
+import { constructTableData } from 'store/Sites/helpers';
+import { sitesToDisplayListSelector } from 'store/Sites/sitesListSlice';
 import {
   siteOnMapSelector,
   setSiteOnMap,
   setSearchResult,
-} from '../../../store/Homepage/homepageSlice';
+} from 'store/Homepage/homepageSlice';
+import { dhwColorFinder } from 'helpers/degreeHeatingWeeks';
+import { formatNumber } from 'helpers/numberUtils';
+import { alertColorFinder } from 'helpers/bleachingAlertIntervals';
+import { colors } from 'layout/App/theme';
 import { getComparator, Order, OrderKeys, stableSort } from './utils';
-import { alertColorFinder } from '../../../helpers/bleachingAlertIntervals';
 import { Collection } from '../../Dashboard/collection';
 
 const SCROLLT_TIMEOUT = 500;

--- a/packages/website/src/routes/HomeMap/SiteTable/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/index.test.tsx
@@ -3,9 +3,9 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
+import { mockSite } from 'mocks/mockSite';
+import { mockUser } from 'mocks/mockUser';
 import SiteTable from '.';
-import { mockSite } from '../../../mocks/mockSite';
-import { mockUser } from '../../../mocks/mockUser';
 
 jest.mock('./SelectedSiteCard', () => 'Mock-SelectedSiteCard');
 

--- a/packages/website/src/routes/HomeMap/SiteTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/index.tsx
@@ -19,21 +19,21 @@ import {
 import { useDispatch, useSelector } from 'react-redux';
 import classNames from 'classnames';
 import { ArrowDownward, ArrowUpward } from '@material-ui/icons';
-import SelectedSiteCard from './SelectedSiteCard';
-import SiteTableBody from './body';
-import { getOrderKeysFriendlyString, Order, OrderKeys } from './utils';
 import {
   filterSitesWithSpotter,
   sitesListLoadingSelector,
-} from '../../../store/Sites/sitesListSlice';
-import EnhancedTableHead from './tableHead';
-import { useWindowSize } from '../../../hooks/useWindowSize';
+} from 'store/Sites/sitesListSlice';
 import {
   siteOnMapSelector,
   setWithSpotterOnly,
   withSpotterOnlySelector,
-} from '../../../store/Homepage/homepageSlice';
-import { getSiteNameAndRegion } from '../../../store/Sites/helpers';
+} from 'store/Homepage/homepageSlice';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { useWindowSize } from 'hooks/useWindowSize';
+import SelectedSiteCard from './SelectedSiteCard';
+import SiteTableBody from './body';
+import { getOrderKeysFriendlyString, Order, OrderKeys } from './utils';
+import EnhancedTableHead from './tableHead';
 import { Collection } from '../../Dashboard/collection';
 
 const SMALL_HEIGHT = 720;

--- a/packages/website/src/routes/HomeMap/SiteTable/utils.ts
+++ b/packages/website/src/routes/HomeMap/SiteTable/utils.ts
@@ -1,5 +1,5 @@
 import { startCase } from 'lodash';
-import type { TableRow } from '../../../store/Homepage/types';
+import type { TableRow } from 'store/Homepage/types';
 
 export type Order = 'asc' | 'desc';
 

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
+import { mockSite } from 'mocks/mockSite';
 import Homepage from '.';
-import { mockSite } from '../../mocks/mockSite';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
 jest.mock('./Map', () => 'Mock-Map');
 jest.mock('./SiteTable', () => 'Mock-SiteTable');
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -10,18 +10,15 @@ import {
   WithStyles,
 } from '@material-ui/core';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
-import HomepageNavBar from '../../common/NavBar';
-import HomepageMap from './Map';
-import SiteTable from './SiteTable';
-import {
-  sitesRequest,
-  sitesListSelector,
-} from '../../store/Sites/sitesListSlice';
-import { siteRequest } from '../../store/Sites/selectedSiteSlice';
-import { siteOnMapSelector } from '../../store/Homepage/homepageSlice';
+import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
+import { siteRequest } from 'store/Sites/selectedSiteSlice';
+import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 
-import { surveysRequest } from '../../store/Survey/surveyListSlice';
-import { findSiteById, findInitialSitePosition } from '../../helpers/siteUtils';
+import { surveysRequest } from 'store/Survey/surveyListSlice';
+import { findSiteById, findInitialSitePosition } from 'helpers/siteUtils';
+import HomepageNavBar from 'common/NavBar';
+import SiteTable from './SiteTable';
+import HomepageMap from './Map';
 
 enum QueryParamKeys {
   SITE_ID = 'site_id',

--- a/packages/website/src/routes/Landing/index.test.tsx
+++ b/packages/website/src/routes/Landing/index.test.tsx
@@ -4,9 +4,9 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { mockUser } from 'mocks/mockUser';
+import { mockCollection } from 'mocks/mockCollection';
 import LandingPage from '.';
-import { mockUser } from '../../mocks/mockUser';
-import { mockCollection } from '../../mocks/mockCollection';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/routes/Landing/index.tsx
+++ b/packages/website/src/routes/Landing/index.tsx
@@ -18,16 +18,12 @@ import ArrowDownwardIcon from '@material-ui/icons/ArrowDownward';
 import { Link } from 'react-router-dom';
 
 import classNames from 'classnames';
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
+import { GaAction, GaCategory, trackButtonClick } from 'utils/google-analytics';
 import Card from './Card';
 import landingPageImage from '../../assets/img/landing-page/header.jpg';
 import { cardTitles } from './titles';
-import {
-  GaAction,
-  GaCategory,
-  trackButtonClick,
-} from '../../utils/google-analytics';
 
 interface LandingPageButton {
   label: string;

--- a/packages/website/src/routes/RegisterSite/LocationMap/index.tsx
+++ b/packages/website/src/routes/RegisterSite/LocationMap/index.tsx
@@ -3,8 +3,8 @@ import { Map, TileLayer, Marker } from 'react-leaflet';
 import L, { LeafletEvent } from 'leaflet';
 import { withStyles, WithStyles, createStyles, Theme } from '@material-ui/core';
 
+import { mapConstants } from 'constants/maps';
 import marker from '../../../assets/marker.png';
-import { mapConstants } from '../../../constants/maps';
 
 const pinIcon = L.icon({
   iconUrl: marker,

--- a/packages/website/src/routes/RegisterSite/index.test.tsx
+++ b/packages/website/src/routes/RegisterSite/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
+import { mockUser } from 'mocks/mockUser';
 import Apply from '.';
-import { mockUser } from '../../mocks/mockUser';
 
 const mockStore = configureStore([]);
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
 jest.mock('./LocationMap', () => 'Mock-LocationMap');
 
 describe('Site registration page', () => {

--- a/packages/website/src/routes/RegisterSite/index.tsx
+++ b/packages/website/src/routes/RegisterSite/index.tsx
@@ -21,14 +21,14 @@ import {
 import Alert from '@material-ui/lab/Alert';
 import { useSelector, useDispatch } from 'react-redux';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
-import RegisterDialog from '../../common/RegisterDialog';
-import SignInDialog from '../../common/SignInDialog';
+import { userInfoSelector, getSelf } from 'store/User/userSlice';
+import validators from 'helpers/validators';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
+import RegisterDialog from 'common/RegisterDialog';
+import SignInDialog from 'common/SignInDialog';
+import siteServices from 'services/siteServices';
 import LocationMap from './LocationMap';
-import { userInfoSelector, getSelf } from '../../store/User/userSlice';
-import siteServices from '../../services/siteServices';
-import validators from '../../helpers/validators';
 
 interface FormElement {
   id: string;

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/CollectionButton/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/CollectionButton/index.tsx
@@ -16,11 +16,11 @@ import {
   userCollectionLoadingSelector,
   userErrorSelector,
   userInfoSelector,
-} from '../../../../../store/User/userSlice';
-import { belongsToCollection } from '../../../../../helpers/siteUtils';
+} from 'store/User/userSlice';
+import { belongsToCollection } from 'helpers/siteUtils';
+import collectionServices from 'services/collectionServices';
 import { ReactComponent as WatchIcon } from '../../../../../assets/watch.svg';
 import { ReactComponent as UnWatchIcon } from '../../../../../assets/unwatch.svg';
-import collectionServices from '../../../../../services/collectionServices';
 
 const CollectionButton = ({
   siteId,

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/EditForm/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/EditForm/index.tsx
@@ -13,14 +13,11 @@ import Alert from '@material-ui/lab/Alert';
 import { useDispatch, useSelector } from 'react-redux';
 import { find } from 'lodash';
 
-import TextField from '../../../../../common/Forms/TextField';
-import { Site, SiteUpdateParams } from '../../../../../store/Sites/types';
-import { getSiteNameAndRegion } from '../../../../../store/Sites/helpers';
-import {
-  siteDraftSelector,
-  setSiteDraft,
-} from '../../../../../store/Sites/selectedSiteSlice';
-import { useFormField } from '../../../../../hooks/useFormField';
+import { Site, SiteUpdateParams } from 'store/Sites/types';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { siteDraftSelector, setSiteDraft } from 'store/Sites/selectedSiteSlice';
+import { useFormField } from 'hooks/useFormField';
+import TextField from 'common/Forms/TextField';
 
 const NUMERIC_FIELD_STEP = 1 / 10 ** 15;
 

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/ExclusionDatesDialog/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/ExclusionDatesDialog/index.tsx
@@ -18,15 +18,15 @@ import {
 import DateFnsUtils from '@date-io/date-fns';
 import { useDispatch } from 'react-redux';
 
-import Dialog, { Action } from '../../../../../common/Dialog';
-import { setTimeZone } from '../../../../../helpers/dates';
-import siteServices from '../../../../../services/siteServices';
 import {
   clearTimeSeriesData,
   clearTimeSeriesDataRange,
   setSelectedSite,
   siteRequest,
-} from '../../../../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
+import { setTimeZone } from 'helpers/dates';
+import Dialog, { Action } from 'common/Dialog';
+import siteServices from 'services/siteServices';
 import ConfirmationDialog from './ConfirmationDialog';
 
 const ExclusionDatesDialog = ({

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.test.tsx
@@ -3,10 +3,10 @@ import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import SiteNavBar from '.';
 
-import { mockSite } from '../../../../mocks/mockSite';
-import { mockUser } from '../../../../mocks/mockUser';
+import { mockSite } from 'mocks/mockSite';
+import { mockUser } from 'mocks/mockUser';
+import SiteNavBar from '.';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.tsx
@@ -17,26 +17,23 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Link } from 'react-router-dom';
 import ArrowBack from '@material-ui/icons/ArrowBack';
 
-import EditForm from './EditForm';
-import ExclusionDatesDialog from './ExclusionDatesDialog';
 import {
   setSelectedSite,
   setSiteData,
   setSiteDraft,
-} from '../../../../store/Sites/selectedSiteSlice';
-import { Site, SiteUpdateParams } from '../../../../store/Sites/types';
-import { getSiteNameAndRegion } from '../../../../store/Sites/helpers';
-import siteServices from '../../../../services/siteServices';
+} from 'store/Sites/selectedSiteSlice';
+import { Site, SiteUpdateParams } from 'store/Sites/types';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
 import {
   setAdministeredSiteName,
   userInfoSelector,
-} from '../../../../store/User/userSlice';
-import { displayTimeInLocalTimezone } from '../../../../helpers/dates';
+} from 'store/User/userSlice';
+import { sitesListSelector, setSiteName } from 'store/Sites/sitesListSlice';
+import { displayTimeInLocalTimezone } from 'helpers/dates';
+import siteServices from 'services/siteServices';
+import EditForm from './EditForm';
+import ExclusionDatesDialog from './ExclusionDatesDialog';
 import CollectionButton from './CollectionButton';
-import {
-  sitesListSelector,
-  setSiteName,
-} from '../../../../store/Sites/sitesListSlice';
 
 const SiteNavBar = ({
   hasDailyData,

--- a/packages/website/src/routes/SiteRoutes/Site/index.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.test.tsx
@@ -4,26 +4,23 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
+import { mockSite } from 'mocks/mockSite';
+import { mockUser } from 'mocks/mockUser';
+import { mockSurveyList } from 'mocks/mockSurveyList';
+import { mockCollection } from 'mocks/mockCollection';
+import { mockDataRange } from 'mocks/mockDataRange';
+import { mockSurvey } from 'mocks/mockSurvey';
 import Site from '.';
-import { mockSite } from '../../../mocks/mockSite';
-import { mockUser } from '../../../mocks/mockUser';
-import { mockSurveyList } from '../../../mocks/mockSurveyList';
-import { mockCollection } from '../../../mocks/mockCollection';
-import { mockDataRange } from '../../../mocks/mockDataRange';
-import { mockSurvey } from '../../../mocks/mockSurvey';
 
 const mockStore = configureStore([]);
 
 window.scrollTo = jest.fn();
 
-jest.mock('../../../common/SiteDetails/Map', () => 'Mock-Map');
-jest.mock(
-  '../../../common/SiteDetails/FeaturedMedia',
-  () => 'Mock-FeaturedMedia',
-);
+jest.mock('common/SiteDetails/Map', () => 'Mock-Map');
+jest.mock('common/SiteDetails/FeaturedMedia', () => 'Mock-FeaturedMedia');
 
 jest.mock(
-  '../../../common/Chart/MultipleSensorsCharts',
+  'common/Chart/MultipleSensorsCharts',
   () => 'Mock-MultipleSensorsCharts',
 );
 

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -10,11 +10,6 @@ import { Alert } from '@material-ui/lab';
 import { useSelector, useDispatch } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import classNames from 'classnames';
-import NotFoundPage from '../../NotFound/index';
-import SiteNavBar from '../../../common/NavBar';
-import SiteFooter from '../../../common/Footer';
-import SiteDetails from '../../../common/SiteDetails';
-import SiteInfo from './SiteInfo';
 import {
   siteDetailsSelector,
   siteRequest,
@@ -26,22 +21,27 @@ import {
   spotterPositionRequest,
   spotterPositionSelector,
   siteLoadingSelector,
-} from '../../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
 import {
   surveysRequest,
   surveyListSelector,
-} from '../../../store/Survey/surveyListSlice';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { isAdmin } from '../../../helpers/user';
-import { findAdministeredSite } from '../../../helpers/findAdministeredSite';
-import { User } from '../../../store/User/types';
-import { localizedEndOfDay } from '../../../common/Chart/MultipleSensorsCharts/helpers';
-import { sortByDate, subtractFromDate } from '../../../helpers/dates';
-import { oceanSenseConfig } from '../../../constants/oceanSenseConfig';
-import { useQueryParam } from '../../../hooks/useQueryParams';
-import { findSurveyPointFromList } from '../../../helpers/siteUtils';
-import LoadingSkeleton from '../../../common/LoadingSkeleton';
-import { Site as SiteType } from '../../../store/Sites/types';
+} from 'store/Survey/surveyListSlice';
+import { userInfoSelector } from 'store/User/userSlice';
+import { User } from 'store/User/types';
+import { oceanSenseConfig } from 'constants/oceanSenseConfig';
+import { Site as SiteType } from 'store/Sites/types';
+import { useQueryParam } from 'hooks/useQueryParams';
+import { isAdmin } from 'helpers/user';
+import { findAdministeredSite } from 'helpers/findAdministeredSite';
+import { sortByDate, subtractFromDate } from 'helpers/dates';
+import { findSurveyPointFromList } from 'helpers/siteUtils';
+import SiteNavBar from 'common/NavBar';
+import SiteFooter from 'common/Footer';
+import SiteDetails from 'common/SiteDetails';
+import { localizedEndOfDay } from 'common/Chart/MultipleSensorsCharts/helpers';
+import LoadingSkeleton from 'common/LoadingSkeleton';
+import SiteInfo from './SiteInfo';
+import NotFoundPage from '../../NotFound/index';
 
 const getAlertMessage = (
   user: User | null,

--- a/packages/website/src/routes/SiteRoutes/SiteApplication/Form/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SiteApplication/Form/index.tsx
@@ -15,10 +15,7 @@ import {
 } from '@material-ui/pickers';
 import DateFnsUtils from '@date-io/date-fns';
 import moment from 'moment';
-import {
-  SiteApplication,
-  SiteApplyParams,
-} from '../../../../store/Sites/types';
+import { SiteApplication, SiteApplyParams } from 'store/Sites/types';
 
 interface SiteApplicationFormFields {
   siteName: string;

--- a/packages/website/src/routes/SiteRoutes/SiteApplication/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SiteApplication/index.tsx
@@ -15,28 +15,28 @@ import { useSelector, useDispatch } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { AxiosError } from 'axios';
 
-import { AgreementsChecked } from './types';
-import Obligations from './Obligations';
-import Agreements from './Agreements';
-import SignInDialog from '../../../common/SignInDialog';
-import RegisterDialog from '../../../common/RegisterDialog';
-import Form from './Form';
-import NavBar from '../../../common/NavBar';
-import Footer from '../../../common/Footer';
-import { getSiteNameAndRegion } from '../../../store/Sites/helpers';
-import siteServices from '../../../services/siteServices';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
 import {
   userInfoSelector,
   getSelf,
   userLoadingSelector,
-} from '../../../store/User/userSlice';
+} from 'store/User/userSlice';
 import {
   siteDetailsSelector,
   siteLoadingSelector,
   siteRequest,
-} from '../../../store/Sites/selectedSiteSlice';
-import { SiteApplication, SiteApplyParams } from '../../../store/Sites/types';
-import { isAdmin } from '../../../helpers/user';
+} from 'store/Sites/selectedSiteSlice';
+import { SiteApplication, SiteApplyParams } from 'store/Sites/types';
+import { isAdmin } from 'helpers/user';
+import SignInDialog from 'common/SignInDialog';
+import RegisterDialog from 'common/RegisterDialog';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
+import siteServices from 'services/siteServices';
+import { AgreementsChecked } from './types';
+import Obligations from './Obligations';
+import Agreements from './Agreements';
+import Form from './Form';
 
 const Apply = ({ match, classes }: ApplyProps) => {
   const dispatch = useDispatch();

--- a/packages/website/src/routes/SiteRoutes/SitesList/index.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/SitesList/index.test.tsx
@@ -4,8 +4,8 @@ import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
 
+import { mockSite } from 'mocks/mockSite';
 import SitesList from '.';
-import { mockSite } from '../../../mocks/mockSite';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
@@ -11,10 +11,7 @@ import {
 } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 
-import {
-  sitesListSelector,
-  sitesRequest,
-} from '../../../store/Sites/sitesListSlice';
+import { sitesListSelector, sitesRequest } from 'store/Sites/sitesListSlice';
 
 const SitesList = ({ classes }: SitesListProps) => {
   const sitesList = useSelector(sitesListSelector);

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/EditForm.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/EditForm.tsx
@@ -10,8 +10,8 @@ import {
 import Alert from '@material-ui/lab/Alert';
 import { find } from 'lodash';
 
-import { FormField } from '../../../../hooks/useFormField';
-import TextField from '../../../../common/Forms/TextField';
+import { FormField } from 'hooks/useFormField';
+import TextField from 'common/Forms/TextField';
 
 const NUMERIC_FIELD_STEP = 1 / 10 ** 15;
 

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/Info.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/Info.tsx
@@ -10,15 +10,15 @@ import {
 } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 
-import { Site } from '../../../../store/Sites/types';
-import { surveyListSelector } from '../../../../store/Survey/surveyListSlice';
-import { getSiteNameAndRegion } from '../../../../store/Sites/helpers';
-import { filterSurveys } from '../../../../helpers/surveys';
-import { displayTimeInLocalTimezone } from '../../../../helpers/dates';
-import { siteTimeSeriesDataSelector } from '../../../../store/Sites/selectedSiteSlice';
-import { formatNumber } from '../../../../helpers/numberUtils';
-import { isAdmin } from '../../../../helpers/user';
-import { userInfoSelector } from '../../../../store/User/userSlice';
+import { Site } from 'store/Sites/types';
+import { surveyListSelector } from 'store/Survey/surveyListSlice';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { siteTimeSeriesDataSelector } from 'store/Sites/selectedSiteSlice';
+import { userInfoSelector } from 'store/User/userSlice';
+import { filterSurveys } from 'helpers/surveys';
+import { displayTimeInLocalTimezone } from 'helpers/dates';
+import { formatNumber } from 'helpers/numberUtils';
+import { isAdmin } from 'helpers/user';
 import SurveyInfo from './SurveyInfo';
 
 const Info = ({ site, pointId, onEditButtonClick, classes }: InfoProps) => {

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/Map.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/Map.tsx
@@ -7,9 +7,9 @@ import {
   Theme,
 } from '@material-ui/core';
 
-import { Site } from '../../../../store/Sites/types';
-import Map from '../../../../common/SiteDetails/Map';
-import { FormField } from '../../../../hooks/useFormField';
+import { Site } from 'store/Sites/types';
+import { FormField } from 'hooks/useFormField';
+import Map from 'common/SiteDetails/Map';
 
 const SurveyPointMap = ({
   site,

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/SurveyInfo.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/SurveyInfo.tsx
@@ -8,8 +8,8 @@ import {
   Theme,
 } from '@material-ui/core';
 
-import { SurveyListItem } from '../../../../store/Survey/types';
-import { findImagesAtSurveyPoint } from '../../../../helpers/surveys';
+import { SurveyListItem } from 'store/Survey/types';
+import { findImagesAtSurveyPoint } from 'helpers/surveys';
 
 const SurveyInfo = ({ surveys, pointId, classes }: SurveyInfoProps) => {
   const nSurveys = surveys.length;

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/InfoCard/index.tsx
@@ -16,14 +16,14 @@ import CloseIcon from '@material-ui/icons/Close';
 import { useSelector, useDispatch } from 'react-redux';
 import { every } from 'lodash';
 
+import { Site } from 'store/Sites/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { setSiteSurveyPoints } from 'store/Sites/selectedSiteSlice';
+import { useFormField } from 'hooks/useFormField';
+import surveyServices from 'services/surveyServices';
 import EditForm from './EditForm';
 import Info from './Info';
 import Map from './Map';
-import { Site } from '../../../../store/Sites/types';
-import { useFormField } from '../../../../hooks/useFormField';
-import { userInfoSelector } from '../../../../store/User/userSlice';
-import surveyServices from '../../../../services/surveyServices';
-import { setSiteSurveyPoints } from '../../../../store/Sites/selectedSiteSlice';
 
 const InfoCard = ({ site, pointId, bgColor, classes }: InfoCardProps) => {
   const user = useSelector(userInfoSelector);

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/SurveyHistory/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/SurveyHistory/index.tsx
@@ -11,10 +11,10 @@ import {
 } from '@material-ui/core';
 import { useSelector } from 'react-redux';
 
-import TimeLine from '../../../../common/SiteDetails/Surveys/Timeline';
-import { Site } from '../../../../store/Sites/types';
-import { userInfoSelector } from '../../../../store/User/userSlice';
-import { isAdmin } from '../../../../helpers/user';
+import { Site } from 'store/Sites/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { isAdmin } from 'helpers/user';
+import TimeLine from 'common/SiteDetails/Surveys/Timeline';
 
 const SurveyHistory = ({
   site,

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/index.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/index.test.tsx
@@ -4,13 +4,13 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
 
-import { mockSite } from '../../../mocks/mockSite';
-import { mockUser } from '../../../mocks/mockUser';
+import { mockSite } from 'mocks/mockSite';
+import { mockUser } from 'mocks/mockUser';
 
+import { mockSurveyList } from 'mocks/mockSurveyList';
+import { mockDataRange } from 'mocks/mockDataRange';
+import { mockCollection } from 'mocks/mockCollection';
 import SurveyPoint from '.';
-import { mockSurveyList } from '../../../mocks/mockSurveyList';
-import { mockDataRange } from '../../../mocks/mockDataRange';
-import { mockCollection } from '../../../mocks/mockCollection';
 
 jest.mock('./InfoCard/Map', () => 'Mock-Map');
 

--- a/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SurveyPoint/index.tsx
@@ -2,12 +2,6 @@ import React, { useEffect } from 'react';
 import { LinearProgress } from '@material-ui/core';
 import { RouteComponentProps } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import NavBar from '../../../common/NavBar';
-import Footer from '../../../common/Footer';
-import BackButton from './BackButton';
-import InfoCard from './InfoCard';
-import MultipleSensorsCharts from '../../../common/Chart/MultipleSensorsCharts';
-import SurveyHistory from './SurveyHistory';
 import {
   clearTimeSeriesData,
   clearTimeSeriesDataRange,
@@ -19,11 +13,17 @@ import {
   siteTimeSeriesDataRangeLoadingSelector,
   siteTimeSeriesDataRangeRequest,
   siteTimeSeriesDataRangeSelector,
-} from '../../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
 import {
   surveyListLoadingSelector,
   surveysRequest,
-} from '../../../store/Survey/surveyListSlice';
+} from 'store/Survey/surveyListSlice';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
+import MultipleSensorsCharts from 'common/Chart/MultipleSensorsCharts';
+import BackButton from './BackButton';
+import InfoCard from './InfoCard';
+import SurveyHistory from './SurveyHistory';
 
 const BG_COLOR = 'rgb(245, 246, 246)';
 

--- a/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/FileList.tsx
@@ -17,12 +17,12 @@ import FileIcon from '@material-ui/icons/InsertDriveFileOutlined';
 import classNames from 'classnames';
 
 import { useSelector } from 'react-redux';
-import { pluralize } from '../../../helpers/stringUtils';
 import {
   uploadsErrorSelector,
   uploadsInProgressSelector,
   uploadsResponseSelector,
-} from '../../../store/uploads/uploadsSlice';
+} from 'store/uploads/uploadsSlice';
+import { pluralize } from 'helpers/stringUtils';
 
 const CIRCULAR_PROGRESS_SIZE = 36;
 

--- a/packages/website/src/routes/SiteRoutes/UploadData/Header.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Header.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from '@testing-library/react';
+import { mockSite } from 'mocks/mockSite';
 import Header from './Header';
-import { mockSite } from '../../../mocks/mockSite';
 
 test('renders as expected', () => {
   const { container } = render(<Header site={mockSite} />);

--- a/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
@@ -8,7 +8,7 @@ import {
 } from '@material-ui/core';
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { Link } from 'react-router-dom';
-import { Site } from '../../../store/Sites/types';
+import { Site } from 'store/Sites/types';
 
 function downloadFile(url: string, fileName: string) {
   fetch(url, {

--- a/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/HistoryTable.tsx
@@ -16,10 +16,10 @@ import { grey } from '@material-ui/core/colors';
 import { startCase } from 'lodash';
 import { Link } from 'react-router-dom';
 import moment from 'moment';
-import { Site, SiteUploadHistory } from '../../../store/Sites/types';
-import requests from '../../../helpers/requests';
-import { pluralize } from '../../../helpers/stringUtils';
-import DeleteButton from '../../../common/DeleteButton';
+import { Site, SiteUploadHistory } from 'store/Sites/types';
+import requests from 'helpers/requests';
+import { pluralize } from 'helpers/stringUtils';
+import DeleteButton from 'common/DeleteButton';
 
 const tableHeaderTitles = [
   'NAME',

--- a/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Selectors.tsx
@@ -15,9 +15,9 @@ import AddIcon from '@material-ui/icons/Add';
 import { Link } from 'react-router-dom';
 
 import { useSelector } from 'react-redux';
-import { Site, Sources } from '../../../store/Sites/types';
-import NewSurveyPointDialog from '../../../common/NewSurveyPointDialog';
-import { uploadsTargetSelector } from '../../../store/uploads/uploadsSlice';
+import { Site, Sources } from 'store/Sites/types';
+import { uploadsTargetSelector } from 'store/uploads/uploadsSlice';
+import NewSurveyPointDialog from 'common/NewSurveyPointDialog';
 
 interface SelectOption {
   id: number;

--- a/packages/website/src/routes/SiteRoutes/UploadData/UploadWarnings.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/UploadWarnings.tsx
@@ -17,7 +17,7 @@ import CloseIcon from '@material-ui/icons/Close';
 import WarningIcon from '@material-ui/icons/Warning';
 import { yellow } from '@material-ui/core/colors';
 
-import { UploadTimeSeriesResult } from '../../../services/uploadServices';
+import { UploadTimeSeriesResult } from 'services/uploadServices';
 
 const YELLOW = yellow[600];
 

--- a/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/index.tsx
@@ -4,21 +4,9 @@ import { Link, RouteComponentProps, useHistory } from 'react-router-dom';
 import { DropzoneProps } from 'react-dropzone';
 import { useDispatch, useSelector } from 'react-redux';
 import { Alert } from '@material-ui/lab';
-import NavBar from '../../../common/NavBar';
-import Header from './Header';
-import Selectors from './Selectors';
-import DropZone from './DropZone';
-import FileList from './FileList';
-import HistoryTable from './HistoryTable';
-import UploadButton from './UploadButton';
-import { useSiteRequest } from '../../../hooks/useSiteRequest';
-import { SiteUploadHistory, Sources } from '../../../store/Sites/types';
-import uploadServices from '../../../services/uploadServices';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import siteServices from '../../../services/siteServices';
-import { setSelectedSite } from '../../../store/Sites/selectedSiteSlice';
-import { getAxiosErrorMessage } from '../../../helpers/errors';
-import StatusSnackbar from '../../../common/StatusSnackbar';
+import { SiteUploadHistory, Sources } from 'store/Sites/types';
+import { userInfoSelector } from 'store/User/userSlice';
+import { setSelectedSite } from 'store/Sites/selectedSiteSlice';
 import {
   addUploadsFiles,
   clearUploadsError,
@@ -31,8 +19,20 @@ import {
   uploadsFilesSelector,
   uploadsInProgressSelector,
   uploadsTargetSelector,
-} from '../../../store/uploads/uploadsSlice';
-import InfoWithAction from '../../../common/InfoWithAction';
+} from 'store/uploads/uploadsSlice';
+import { useSiteRequest } from 'hooks/useSiteRequest';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import NavBar from 'common/NavBar';
+import StatusSnackbar from 'common/StatusSnackbar';
+import InfoWithAction from 'common/InfoWithAction';
+import uploadServices from 'services/uploadServices';
+import siteServices from 'services/siteServices';
+import Header from './Header';
+import Selectors from './Selectors';
+import DropZone from './DropZone';
+import FileList from './FileList';
+import HistoryTable from './HistoryTable';
+import UploadButton from './UploadButton';
 
 const UploadData = ({ match }: RouteComponentProps<{ id: string }>) => {
   const classes = useStyles();

--- a/packages/website/src/routes/SiteRoutes/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/index.tsx
@@ -1,16 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { Switch, Route, useHistory } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import Site from './Site';
-import SiteApplication from './SiteApplication';
-import SitesList from './SitesList';
-import Surveys from '../Surveys';
-import SurveyPoint from './SurveyPoint';
-import UploadData from './UploadData';
-import StatusSnackbar from '../../common/StatusSnackbar';
-import UploadWarnings from './UploadData/UploadWarnings';
-import { UploadTimeSeriesResult } from '../../services/uploadServices';
-import { setSelectedSite } from '../../store/Sites/selectedSiteSlice';
+import { setSelectedSite } from 'store/Sites/selectedSiteSlice';
 import {
   clearUploadsError,
   clearUploadsFiles,
@@ -20,7 +11,16 @@ import {
   uploadsInProgressSelector,
   uploadsResponseSelector,
   uploadsTargetSelector,
-} from '../../store/uploads/uploadsSlice';
+} from 'store/uploads/uploadsSlice';
+import StatusSnackbar from 'common/StatusSnackbar';
+import { UploadTimeSeriesResult } from 'services/uploadServices';
+import Site from './Site';
+import SiteApplication from './SiteApplication';
+import SitesList from './SitesList';
+import Surveys from '../Surveys';
+import SurveyPoint from './SurveyPoint';
+import UploadData from './UploadData';
+import UploadWarnings from './UploadData/UploadWarnings';
 
 const SiteRoutes = () => {
   const dispatch = useDispatch();

--- a/packages/website/src/routes/Surveys/New/Form.tsx
+++ b/packages/website/src/routes/Surveys/New/Form.tsx
@@ -2,13 +2,13 @@ import React, { useCallback } from 'react';
 import { Grid, Collapse, IconButton } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import { useSelector, useDispatch } from 'react-redux';
-import { SurveyData, SurveyState } from '../../../store/Survey/types';
+import { SurveyData, SurveyState } from 'store/Survey/types';
 import {
   surveyErrorSelector,
   surveyAddRequest,
-} from '../../../store/Survey/surveySlice';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import Form from '../../../common/SurveyForm';
+} from 'store/Survey/surveySlice';
+import { userInfoSelector } from 'store/User/userSlice';
+import Form from 'common/SurveyForm';
 
 const SurveyForm = ({ siteId, timeZone, changeTab }: SurveyFormProps) => {
   const user = useSelector(userInfoSelector);

--- a/packages/website/src/routes/Surveys/New/Map.tsx
+++ b/packages/website/src/routes/Surveys/New/Map.tsx
@@ -4,13 +4,13 @@ import { useDispatch, useSelector } from 'react-redux';
 import L from 'leaflet';
 import { withStyles, WithStyles, createStyles } from '@material-ui/core';
 
-import { Site } from '../../../store/Sites/types';
+import { Site } from 'store/Sites/types';
 
-import marker from '../../../assets/marker.png';
 import {
   setDiveLocation,
   diveLocationSelector,
-} from '../../../store/Survey/surveySlice';
+} from 'store/Survey/surveySlice';
+import marker from '../../../assets/marker.png';
 
 const pinIcon = L.icon({
   iconUrl: marker,

--- a/packages/website/src/routes/Surveys/New/MediaCard.tsx
+++ b/packages/website/src/routes/Surveys/New/MediaCard.tsx
@@ -14,10 +14,10 @@ import {
   Tooltip,
 } from '@material-ui/core';
 import { DeleteOutlineOutlined } from '@material-ui/icons';
-import observationOptions from '../../../constants/uploadDropdowns';
-import { SurveyPoints } from '../../../store/Sites/types';
+import observationOptions from 'constants/uploadDropdowns';
+import { SurveyPoints } from 'store/Sites/types';
+import SurveyPointSelector from 'common/SurveyPointSelector';
 import { ReactComponent as StarIcon } from '../../../assets/starIcon.svg';
-import SurveyPointSelector from '../../../common/SurveyPointSelector';
 
 const MediaCard = ({
   preview,

--- a/packages/website/src/routes/Surveys/New/UploadMedia.tsx
+++ b/packages/website/src/routes/Surveys/New/UploadMedia.tsx
@@ -18,13 +18,13 @@ import CloseIcon from '@material-ui/icons/Close';
 import Dropzone, { FileRejection } from 'react-dropzone';
 import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router-dom';
+import { userInfoSelector } from 'store/User/userSlice';
+import { surveyDetailsSelector } from 'store/Survey/surveySlice';
+import { SurveyMediaData } from 'store/Survey/types';
+import { SurveyPoints } from 'store/Sites/types';
+import surveyServices from 'services/surveyServices';
+import uploadServices from 'services/uploadServices';
 import MediaCard from './MediaCard';
-import uploadServices from '../../../services/uploadServices';
-import surveyServices from '../../../services/surveyServices';
-import { userInfoSelector } from '../../../store/User/userSlice';
-import { surveyDetailsSelector } from '../../../store/Survey/surveySlice';
-import { SurveyMediaData } from '../../../store/Survey/types';
-import { SurveyPoints } from '../../../store/Sites/types';
 
 const maxUploadSize = 40 * 1000 * 1000; // 40mb
 

--- a/packages/website/src/routes/Surveys/New/index.tsx
+++ b/packages/website/src/routes/Surveys/New/index.tsx
@@ -11,7 +11,7 @@ import {
 } from '@material-ui/core';
 import SwipeableViews from 'react-swipeable-views';
 
-import type { Site } from '../../../store/Sites/types';
+import type { Site } from 'store/Sites/types';
 import Map from './Map';
 import Form from './Form';
 import UploadMedia from './UploadMedia';

--- a/packages/website/src/routes/Surveys/View/MediaDetails/MediaPointName.tsx
+++ b/packages/website/src/routes/Surveys/View/MediaDetails/MediaPointName.tsx
@@ -11,7 +11,7 @@ import {
   Theme,
 } from '@material-ui/core';
 import classNames from 'classnames';
-import SurveyPointSelector from '../../../../common/SurveyPointSelector';
+import SurveyPointSelector from 'common/SurveyPointSelector';
 
 const MediaPointName = ({
   pointName,

--- a/packages/website/src/routes/Surveys/View/MediaDetails/SliderCard.tsx
+++ b/packages/website/src/routes/Surveys/View/MediaDetails/SliderCard.tsx
@@ -22,18 +22,16 @@ import StarBorderIcon from '@material-ui/icons/StarBorder';
 import EditIcon from '@material-ui/icons/Edit';
 import CancelIcon from '@material-ui/icons/Cancel';
 import { useSelector } from 'react-redux';
-import observationOptions, {
-  findOption,
-} from '../../../../constants/uploadDropdowns';
+import observationOptions, { findOption } from 'constants/uploadDropdowns';
 import {
   Observations,
   SurveyMedia,
   SurveyMediaUpdateRequestData,
-} from '../../../../store/Survey/types';
+} from 'store/Survey/types';
 import {
   surveyLoadingSelector,
   surveyMediaEditLoadingSelector,
-} from '../../../../store/Survey/surveySlice';
+} from 'store/Survey/surveySlice';
 
 const SliderCard = ({
   media,

--- a/packages/website/src/routes/Surveys/View/MediaDetails/index.test.tsx
+++ b/packages/website/src/routes/Surveys/View/MediaDetails/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
+import { SurveyMedia } from 'store/Survey/types';
+import { getSurveyPointsByName } from 'helpers/surveyMedia';
+import { mockUser } from 'mocks/mockUser';
+import { mockSurvey } from 'mocks/mockSurvey';
+import { mockSite } from 'mocks/mockSite';
 import MediaDetails from '.';
-import { mockUser } from '../../../../mocks/mockUser';
-import { mockSurvey } from '../../../../mocks/mockSurvey';
-import { mockSite } from '../../../../mocks/mockSite';
-import { getSurveyPointsByName } from '../../../../helpers/surveyMedia';
-import { SurveyMedia } from '../../../../store/Survey/types';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/routes/Surveys/View/MediaDetails/index.tsx
+++ b/packages/website/src/routes/Surveys/View/MediaDetails/index.tsx
@@ -11,22 +11,22 @@ import Slider from 'react-slick';
 import 'slick-carousel/slick/slick.css';
 import 'slick-carousel/slick/slick-theme.css';
 
-import { SurveyMediaUpdateRequestData } from '../../../../store/Survey/types';
+import { SurveyMediaUpdateRequestData } from 'store/Survey/types';
+import {
+  selectedSurveyPointSelector,
+  surveyMediaEditRequest,
+} from 'store/Survey/surveySlice';
+import { userInfoSelector } from 'store/User/userSlice';
 import {
   getNumberOfImages,
   getNumberOfVideos,
   getSurveyPointsByName,
-} from '../../../../helpers/surveyMedia';
-import {
-  selectedSurveyPointSelector,
-  surveyMediaEditRequest,
-} from '../../../../store/Survey/surveySlice';
-import { userInfoSelector } from '../../../../store/User/userSlice';
-import { isAdmin } from '../../../../helpers/user';
+} from 'helpers/surveyMedia';
+import { isAdmin } from 'helpers/user';
+import { ArrayElement } from 'utils/types';
 import SliderCard from './SliderCard';
 import MediaCount from './MediaCount';
 import MediaPointName from './MediaPointName';
-import { ArrayElement } from '../../../../utils/types';
 
 const carouselSettings = {
   dots: true,

--- a/packages/website/src/routes/Surveys/View/ObservationBox.tsx
+++ b/packages/website/src/routes/Surveys/View/ObservationBox.tsx
@@ -11,12 +11,12 @@ import {
 import { useSelector } from 'react-redux';
 import { some } from 'lodash';
 
-import { DailyData } from '../../../store/Sites/types';
-import { formatNumber } from '../../../helpers/numberUtils';
+import { DailyData } from 'store/Sites/types';
 import {
   siteTimeSeriesDataLoadingSelector,
   siteTimeSeriesDataSelector,
-} from '../../../store/Sites/selectedSiteSlice';
+} from 'store/Sites/selectedSiteSlice';
+import { formatNumber } from 'helpers/numberUtils';
 import { getCardTemperatureValues } from './utils';
 
 const ObservationBox = ({

--- a/packages/website/src/routes/Surveys/View/SurveyDetails.tsx
+++ b/packages/website/src/routes/Surveys/View/SurveyDetails.tsx
@@ -7,14 +7,14 @@ import {
   Typography,
 } from '@material-ui/core';
 
+import type { Site } from 'store/Sites/types';
+import type { SurveyState } from 'store/Survey/types';
+import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { displayTimeInLocalTimezone } from 'helpers/dates';
 import {
   getNumberOfImages,
   getNumberOfSurveyPoints,
-} from '../../../helpers/surveyMedia';
-import { displayTimeInLocalTimezone } from '../../../helpers/dates';
-import type { Site } from '../../../store/Sites/types';
-import type { SurveyState } from '../../../store/Survey/types';
-import { getSiteNameAndRegion } from '../../../store/Sites/helpers';
+} from 'helpers/surveyMedia';
 import ObservationBox from './ObservationBox';
 
 const SurveyDetails = ({ site, survey, classes }: SurveyDetailsProps) => {

--- a/packages/website/src/routes/Surveys/View/index.tsx
+++ b/packages/website/src/routes/Surveys/View/index.tsx
@@ -24,24 +24,24 @@ import {
   surveyLoadingSelector,
   surveyErrorSelector,
   surveyMediaEditLoadingSelector,
-} from '../../../store/Survey/surveySlice';
-import SurveyDetails from './SurveyDetails';
-import SurveyMediaDetails from './MediaDetails';
-import ChartWithTooltip from '../../../common/Chart/ChartWithTooltip';
-import type { Site } from '../../../store/Sites/types';
+} from 'store/Survey/surveySlice';
+import type { Site } from 'store/Sites/types';
 import {
   surveyListLoadingSelector,
   surveyListSelector,
   surveysRequest,
-} from '../../../store/Survey/surveyListSlice';
-import { siteTimeSeriesDataRequest } from '../../../store/Sites/selectedSiteSlice';
+} from 'store/Survey/surveyListSlice';
+import { siteTimeSeriesDataRequest } from 'store/Sites/selectedSiteSlice';
 import {
   displayTimeInLocalTimezone,
   convertSurveyDataToLocalTime,
   isBetween,
-} from '../../../helpers/dates';
-import { standardDailyDataDataset } from '../../../common/Chart/MultipleSensorsCharts/helpers';
-import { getSurveyPointsByName } from '../../../helpers/surveyMedia';
+} from 'helpers/dates';
+import { getSurveyPointsByName } from 'helpers/surveyMedia';
+import ChartWithTooltip from 'common/Chart/ChartWithTooltip';
+import { standardDailyDataDataset } from 'common/Chart/MultipleSensorsCharts/helpers';
+import SurveyDetails from './SurveyDetails';
+import SurveyMediaDetails from './MediaDetails';
 
 const SurveyViewPage = ({ site, surveyId, classes }: SurveyViewPageProps) => {
   const dispatch = useDispatch();

--- a/packages/website/src/routes/Surveys/View/utils.ts
+++ b/packages/website/src/routes/Surveys/View/utils.ts
@@ -1,12 +1,5 @@
-import {
-  getSofarDataClosestToDate,
-  sameDay,
-} from '../../../common/Chart/utils';
-import {
-  DailyData,
-  ValueWithTimestamp,
-  TimeSeries,
-} from '../../../store/Sites/types';
+import { DailyData, ValueWithTimestamp, TimeSeries } from 'store/Sites/types';
+import { getSofarDataClosestToDate, sameDay } from 'common/Chart/utils';
 
 const getSensorValue = (data?: ValueWithTimestamp[], date?: string | null) =>
   date && data?.[0]

--- a/packages/website/src/routes/Surveys/index.tsx
+++ b/packages/website/src/routes/Surveys/index.tsx
@@ -16,9 +16,9 @@ import {
   siteLoadingSelector,
   siteErrorSelector,
   siteRequest,
-} from '../../store/Sites/selectedSiteSlice';
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+} from 'store/Sites/selectedSiteSlice';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 import NewSurvey from './New';
 import SurveyViewPage from './View';
 

--- a/packages/website/src/routes/Terms/index.test.tsx
+++ b/packages/website/src/routes/Terms/index.test.tsx
@@ -4,9 +4,9 @@ import { BrowserRouter as Router } from 'react-router-dom';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 
+import { mockUser } from 'mocks/mockUser';
+import { mockCollection } from 'mocks/mockCollection';
 import Terms from '.';
-import { mockUser } from '../../mocks/mockUser';
-import { mockCollection } from '../../mocks/mockCollection';
 
 const mockStore = configureStore([]);
 

--- a/packages/website/src/routes/Terms/index.tsx
+++ b/packages/website/src/routes/Terms/index.tsx
@@ -6,8 +6,8 @@ import {
   Container,
 } from '@material-ui/core';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 
 const Terms = ({ classes }: TermsProps) => {
   return (

--- a/packages/website/src/routes/Tracker/index.test.tsx
+++ b/packages/website/src/routes/Tracker/index.test.tsx
@@ -3,12 +3,12 @@ import { Provider } from 'react-redux';
 import { render } from '@testing-library/react';
 import configureStore from 'redux-mock-store';
 import { BrowserRouter as Router } from 'react-router-dom';
-import { mockUser } from '../../mocks/mockUser';
+import { mockUser } from 'mocks/mockUser';
 
 import Tracker from '.';
 
-jest.mock('../../common/NavBar', () => 'Mock-NavBar');
-jest.mock('../../common/Footer', () => 'Mock-Footer');
+jest.mock('common/NavBar', () => 'Mock-NavBar');
+jest.mock('common/Footer', () => 'Mock-Footer');
 
 const mockStore = configureStore([]);
 describe('Tracker', () => {

--- a/packages/website/src/routes/Tracker/index.tsx
+++ b/packages/website/src/routes/Tracker/index.tsx
@@ -12,11 +12,11 @@ import {
 } from '@material-ui/core';
 import { Link } from 'react-router-dom';
 
-import NavBar from '../../common/NavBar';
-import Footer from '../../common/Footer';
+import { useImageAspectRatio } from 'hooks/useImageAspectRatio';
+import { isPositiveNumber } from 'helpers/numberUtils';
+import NavBar from 'common/NavBar';
+import Footer from 'common/Footer';
 import FootPrintImage from './FootPrintImage';
-import { useImageAspectRatio } from '../../hooks/useImageAspectRatio';
-import { isPositiveNumber } from '../../helpers/numberUtils';
 
 import hero from '../../assets/img/tracker-page/hero.png';
 import image1 from '../../assets/img/tracker-page/image1.png';

--- a/packages/website/src/services/collectionServices.ts
+++ b/packages/website/src/services/collectionServices.ts
@@ -1,9 +1,9 @@
-import requests from '../helpers/requests';
 import {
   CollectionDetailsResponse,
   CollectionSummary,
   CollectionUpdateParams,
-} from '../store/Collection/types';
+} from 'store/Collection/types';
+import requests from 'helpers/requests';
 
 const createCollection = (
   name: string,

--- a/packages/website/src/services/mapServices.ts
+++ b/packages/website/src/services/mapServices.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import type { MapboxGeolocationData } from '../store/Homepage/types';
+import type { MapboxGeolocationData } from 'store/Homepage/types';
 
 const { REACT_APP_MAPBOX_ACCESS_TOKEN: mapboxToken } = process.env;
 const mapboxBaseUrl = 'https://api.mapbox.com/geocoding/v5/mapbox.places/';

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -1,6 +1,4 @@
 import { AxiosRequestConfig } from 'axios';
-import requests from '../helpers/requests';
-import { constructTimeSeriesDataRequestUrl } from '../helpers/siteUtils';
 import {
   DailyData,
   LiveData,
@@ -24,7 +22,9 @@ import {
   LatestData,
   SiteSketchFab,
   ForecastData,
-} from '../store/Sites/types';
+} from 'store/Sites/types';
+import requests from 'helpers/requests';
+import { constructTimeSeriesDataRequestUrl } from 'helpers/siteUtils';
 
 const getSite = (id: string) =>
   requests.send<Site>({

--- a/packages/website/src/services/surveyServices.ts
+++ b/packages/website/src/services/surveyServices.ts
@@ -6,9 +6,9 @@ import type {
   SurveyMediaUpdateRequestData,
   SurveyPointUpdateParams,
   SurveyMedia,
-} from '../store/Survey/types';
-import requests from '../helpers/requests';
-import { SurveyPoints } from '../store/Sites/types';
+} from 'store/Survey/types';
+import { SurveyPoints } from 'store/Sites/types';
+import requests from 'helpers/requests';
 
 const getSurvey = (siteId: string, surveyId: string) =>
   requests.send<SurveyState>({

--- a/packages/website/src/services/uploadServices.ts
+++ b/packages/website/src/services/uploadServices.ts
@@ -1,4 +1,4 @@
-import requests from '../helpers/requests';
+import requests from 'helpers/requests';
 
 export interface UploadTimeSeriesResult {
   file: string;

--- a/packages/website/src/services/userServices.ts
+++ b/packages/website/src/services/userServices.ts
@@ -1,7 +1,7 @@
+import { User } from 'store/User/types';
+import type { Site } from 'store/Sites/types';
+import requests from 'helpers/requests';
 import app from '../firebase';
-import requests from '../helpers/requests';
-import { User } from '../store/User/types';
-import type { Site } from '../store/Sites/types';
 
 const createUser = (email: string, password: string) =>
   app && app.auth().createUserWithEmailAndPassword(email, password);

--- a/packages/website/src/store/Collection/collectionSlice.ts
+++ b/packages/website/src/store/Collection/collectionSlice.ts
@@ -1,9 +1,9 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import collectionServices from 'services/collectionServices';
 import { CollectionState, CollectionRequestParams } from './types';
 import type { CreateAsyncThunkTypes, RootState } from '../configure';
-import collectionServices from '../../services/collectionServices';
 import { constructCollection } from './utils';
-import { getAxiosErrorMessage } from '../../helpers/errors';
 
 const collectionInitialState: CollectionState = {
   loading: false,

--- a/packages/website/src/store/Sites/helpers.ts
+++ b/packages/website/src/store/Sites/helpers.ts
@@ -9,9 +9,9 @@ import {
   union,
   isString,
 } from 'lodash';
-import { isBefore } from '../../helpers/dates';
-import { longDHW } from '../../helpers/siteUtils';
-import siteServices from '../../services/siteServices';
+import { isBefore } from 'helpers/dates';
+import { longDHW } from 'helpers/siteUtils';
+import siteServices from 'services/siteServices';
 
 import type { TableRow } from '../Homepage/types';
 import {

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -1,5 +1,7 @@
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 import { sortBy } from 'lodash';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import siteServices from 'services/siteServices';
 import type {
   OceanSenseData,
   OceanSenseDataRequestParams,
@@ -10,13 +12,11 @@ import type {
   TimeSeriesDataRequestParams,
 } from './types';
 import type { RootState, CreateAsyncThunkTypes } from '../configure';
-import siteServices from '../../services/siteServices';
 import {
   mapOceanSenseData,
   mapTimeSeriesDataRanges,
   timeSeriesRequest,
 } from './helpers';
-import { getAxiosErrorMessage } from '../../helpers/errors';
 
 const selectedSiteInitialState: SelectedSiteState = {
   draft: null,

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -1,17 +1,14 @@
 import { sortBy } from 'lodash';
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
-import siteServices from '../../services/siteServices';
-import {
-  hasDeployedSpotter,
-  setSiteNameFromList,
-} from '../../helpers/siteUtils';
+import { hasDeployedSpotter, setSiteNameFromList } from 'helpers/siteUtils';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import siteServices from 'services/siteServices';
 import type {
   SitesListState,
   SitesRequestData,
   UpdateSiteNameFromListArgs,
 } from './types';
 import type { CreateAsyncThunkTypes, RootState } from '../configure';
-import { getAxiosErrorMessage } from '../../helpers/errors';
 
 const sitesListInitialState: SitesListState = {
   loading: false,

--- a/packages/website/src/store/Survey/surveyListSlice.ts
+++ b/packages/website/src/store/Survey/surveyListSlice.ts
@@ -1,11 +1,11 @@
 import { sortBy } from 'lodash';
 import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit';
 
+import { getAxiosErrorMessage } from 'helpers/errors';
+import surveyServices from 'services/surveyServices';
 import { SurveyListState } from './types';
 
 import type { RootState, CreateAsyncThunkTypes } from '../configure';
-import surveyServices from '../../services/surveyServices';
-import { getAxiosErrorMessage } from '../../helpers/errors';
 
 const surveyListInitialState: SurveyListState = {
   list: [],

--- a/packages/website/src/store/Survey/surveySlice.ts
+++ b/packages/website/src/store/Survey/surveySlice.ts
@@ -4,6 +4,8 @@ import {
   PayloadAction,
   combineReducers,
 } from '@reduxjs/toolkit';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import surveyServices from 'services/surveyServices';
 import {
   SelectedSurveyState,
   SurveyState,
@@ -12,8 +14,6 @@ import {
   SurveyMedia,
 } from './types';
 import type { RootState, CreateAsyncThunkTypes } from '../configure';
-import surveyServices from '../../services/surveyServices';
-import { getAxiosErrorMessage } from '../../helpers/errors';
 
 const selectedSurveyInitialState: SelectedSurveyState = {
   loading: true,

--- a/packages/website/src/store/User/helpers.ts
+++ b/packages/website/src/store/User/helpers.ts
@@ -1,5 +1,5 @@
-import { isManager } from '../../helpers/user';
-import userServices from '../../services/userServices';
+import { isManager } from 'helpers/user';
+import userServices from 'services/userServices';
 import { User } from './types';
 import { CollectionSummary } from '../Collection/types';
 

--- a/packages/website/src/store/User/userSlice.ts
+++ b/packages/website/src/store/User/userSlice.ts
@@ -6,6 +6,11 @@ import {
   AsyncThunk,
 } from '@reduxjs/toolkit';
 
+import { isManager } from 'helpers/user';
+import { setSiteNameFromList } from 'helpers/siteUtils';
+import { getAxiosErrorMessage, getFirebaseErrorMessage } from 'helpers/errors';
+import userServices from 'services/userServices';
+import collectionServices from 'services/collectionServices';
 import type {
   PasswordResetParams,
   User,
@@ -15,16 +20,8 @@ import type {
   CreateUserCollectionRequestParams,
 } from './types';
 import type { RootState, CreateAsyncThunkTypes } from '../configure';
-import { isManager } from '../../helpers/user';
-import userServices from '../../services/userServices';
-import collectionServices from '../../services/collectionServices';
 import { constructUserObject } from './helpers';
-import { setSiteNameFromList } from '../../helpers/siteUtils';
 import { UpdateSiteNameFromListArgs } from '../Sites/types';
-import {
-  getAxiosErrorMessage,
-  getFirebaseErrorMessage,
-} from '../../helpers/errors';
 
 const userInitialState: UserState = {
   userInfo: null,

--- a/packages/website/src/store/uploads/types.ts
+++ b/packages/website/src/store/uploads/types.ts
@@ -1,4 +1,4 @@
-import { UploadTimeSeriesResult } from '../../services/uploadServices';
+import { UploadTimeSeriesResult } from 'services/uploadServices';
 import { Sources } from '../Sites/types';
 
 export interface UploadsSliceState {

--- a/packages/website/src/store/uploads/uploadsSlice.ts
+++ b/packages/website/src/store/uploads/uploadsSlice.ts
@@ -1,7 +1,7 @@
 import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { uniqBy } from 'lodash';
-import { getAxiosErrorMessage } from '../../helpers/errors';
-import uploadServices from '../../services/uploadServices';
+import { getAxiosErrorMessage } from 'helpers/errors';
+import uploadServices from 'services/uploadServices';
 import type { CreateAsyncThunkTypes, RootState } from '../configure';
 import { UploadsSliceState } from './types';
 

--- a/packages/website/tsconfig.json
+++ b/packages/website/tsconfig.json
@@ -7,6 +7,7 @@
     "src/custom.d.ts"
   ],
   "compilerOptions": {
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+    "baseUrl": "./src"
   }
 }


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/871

Basically adds:
```
"compilerOptions": {
    ...
    "baseUrl": "./src"
  }
```
to `tsconfig.json` to enable us to import directly from `src` instead of using relative paths 
(eg. `../../../store/Survey/surveySlice` => `store/Survey/surveySlice`)