### PR TITLE
Add spotter surface_temperature

### DIFF
--- a/packages/api/migration/1687182106885-AddSurfaceTemperatureMetric.ts
+++ b/packages/api/migration/1687182106885-AddSurfaceTemperatureMetric.ts
@@ -1,0 +1,87 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddSurfaceTemperatureMetric1687182106885
+  implements MigrationInterface
+{
+  name = 'AddSurfaceTemperatureMetric1687182106885';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // wrapping migration with DROP and CREATE of the materialized view.
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['MATERIALIZED_VIEW', 'latest_data', 'public'],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW IF EXISTS "latest_data"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "no_duplicate_data"`,
+    );
+    await queryRunner.query(
+      `ALTER TYPE "public"."time_series_metric_enum" RENAME TO "time_series_metric_enum_old"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."time_series_metric_enum" AS ENUM('temp_alert', 'temp_weekly_alert', 'dhw', 'satellite_temperature', 'air_temperature', 'top_temperature', 'bottom_temperature', 'sst_anomaly', 'surface_temperature', 'significant_wave_height', 'wave_mean_period', 'wave_peak_period', 'wave_mean_direction', 'wind_speed', 'wind_direction', 'barometric_pressure_top', 'barometric_pressure_top_diff', 'barometric_pressure_bottom', 'cholorophyll_rfu', 'cholorophyll_concentration', 'conductivity', 'water_depth', 'odo_saturation', 'odo_concentration', 'salinity', 'specific_conductance', 'tds', 'turbidity', 'total_suspended_solids', 'sonde_wiper_position', 'ph', 'ph_mv', 'sonde_battery_voltage', 'sonde_cable_power_voltage', 'pressure', 'precipitation', 'rh', 'wind_gust_speed', 'nitrogen_total', 'phosphorus_total', 'phosphorus', 'silicate', 'nitrate_plus_nitrite', 'ammonium')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ALTER COLUMN "metric" TYPE "public"."time_series_metric_enum" USING "metric"::"text"::"public"."time_series_metric_enum"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."time_series_metric_enum_old"`);
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "no_duplicate_data" UNIQUE ("metric", "source_id", "timestamp")`,
+    );
+
+    // wrapping migration with DROP and CREATE of the materialized view.
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "latest_data" AS SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL '7 days' OR type IN ('sonde') AND (timestamp >= current_date - INTERVAL '90 days') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'MATERIALIZED_VIEW',
+        'latest_data',
+        'SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL \'7 days\' OR type IN (\'sonde\') AND (timestamp >= current_date - INTERVAL \'90 days\') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC',
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // wrapping migration with DROP and CREATE of the materialized view.
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['MATERIALIZED_VIEW', 'latest_data', 'public'],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW IF EXISTS "latest_data"`);
+
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "no_duplicate_data"`,
+    );
+    await queryRunner.query(
+      `CREATE TYPE "public"."time_series_metric_enum_old" AS ENUM('air_temperature', 'ammonium', 'barometric_pressure_bottom', 'barometric_pressure_top', 'barometric_pressure_top_diff', 'bottom_temperature', 'cholorophyll_concentration', 'cholorophyll_rfu', 'conductivity', 'dhw', 'nitrate_plus_nitrite', 'nitrogen_total', 'odo_concentration', 'odo_saturation', 'ph', 'ph_mv', 'phosphorus', 'phosphorus_total', 'precipitation', 'pressure', 'rh', 'salinity', 'satellite_temperature', 'significant_wave_height', 'silicate', 'sonde_battery_voltage', 'sonde_cable_power_voltage', 'sonde_wiper_position', 'specific_conductance', 'sst_anomaly', 'tds', 'temp_alert', 'temp_weekly_alert', 'top_temperature', 'total_suspended_solids', 'turbidity', 'water_depth', 'wave_mean_direction', 'wave_mean_period', 'wave_peak_period', 'wind_direction', 'wind_gust_speed', 'wind_speed')`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ALTER COLUMN "metric" TYPE "public"."time_series_metric_enum_old" USING "metric"::"text"::"public"."time_series_metric_enum_old"`,
+    );
+    await queryRunner.query(`DROP TYPE "public"."time_series_metric_enum"`);
+    await queryRunner.query(
+      `ALTER TYPE "public"."time_series_metric_enum_old" RENAME TO "time_series_metric_enum"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "no_duplicate_data" UNIQUE ("timestamp", "metric", "source_id")`,
+    );
+
+    // wrapping migration with DROP and CREATE of the materialized view.
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "latest_data" AS SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL '7 days' OR type IN ('sonde') AND (timestamp >= current_date - INTERVAL '90 days') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'MATERIALIZED_VIEW',
+        'latest_data',
+        'SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL \'7 days\' OR type IN (\'sonde\') AND (timestamp >= current_date - INTERVAL \'90 days\') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC',
+      ],
+    );
+  }
+}

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -31,10 +31,7 @@ import {
   getSite,
   createSite,
 } from '../utils/site.utils';
-import {
-  getSpotterData,
-  getLatestData as getLatestDataSofar,
-} from '../utils/sofar';
+import { getSpotterData, sofarLatest } from '../utils/sofar';
 import { ExclusionDates } from './exclusion-dates.entity';
 import { DeploySpotterDto } from './dto/deploy-spotter.dto';
 import { ExcludeSpotterDatesDto } from './dto/exclude-spotter-dates.dto';
@@ -352,13 +349,23 @@ export class SitesService {
       };
 
     const sofarToken = site.spotterApiToken || process.env.SOFAR_API_TOKEN;
-    const spotterRaw = await getSpotterData(sensorId, sofarToken);
-    const spotterData = spotterRaw
+    const spotterLatest = await sofarLatest({ sensorId, token: sofarToken });
+
+    const lastTrack =
+      spotterLatest.track &&
+      spotterLatest.track.length &&
+      spotterLatest.track[spotterLatest.track.length - 1];
+
+    const spotterData = lastTrack
       ? {
-          longitude:
-            spotterRaw.longitude && getLatestDataSofar(spotterRaw.longitude),
-          latitude:
-            spotterRaw.latitude && getLatestDataSofar(spotterRaw.latitude),
+          longitude: {
+            value: lastTrack.longitude,
+            timestamp: lastTrack.timestamp,
+          },
+          latitude: {
+            value: lastTrack.latitude,
+            timestamp: lastTrack.timestamp,
+          },
         }
       : {};
 

--- a/packages/api/src/time-series/metrics.enum.ts
+++ b/packages/api/src/time-series/metrics.enum.ts
@@ -8,6 +8,7 @@ export enum Metric {
   TOP_TEMPERATURE = 'top_temperature',
   BOTTOM_TEMPERATURE = 'bottom_temperature',
   SST_ANOMALY = 'sst_anomaly',
+  SURFACE_TEMPERATURE = 'surface_temperature',
   SIGNIFICANT_WAVE_HEIGHT = 'significant_wave_height',
   WAVE_MEAN_PERIOD = 'wave_mean_period',
   WAVE_PEAK_PERIOD = 'wave_peak_period',

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -21,8 +21,6 @@ export const SOFAR_SENSOR_DATA_URL =
   'https://api.sofarocean.com/api/sensor-data';
 export const SOFAR_LATEST_DATA_URL =
   'https://api.sofarocean.com/api/latest-data';
-export const SOFAR_HISTORICAL_DATA_URL =
-  'https://api.sofarocean.com/api/wave-data';
 
 export enum SofarModels {
   NOAACoralReefWatch = 'NOAACoralReefWatch',

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -19,6 +19,10 @@ export const SOFAR_MARINE_URL =
 export const SOFAR_WAVE_DATA_URL = 'https://api.sofarocean.com/api/wave-data';
 export const SOFAR_SENSOR_DATA_URL =
   'https://api.sofarocean.com/api/sensor-data';
+export const SOFAR_LATEST_DATA_URL =
+  'https://api.sofarocean.com/api/latest-data';
+export const SOFAR_HISTORICAL_DATA_URL =
+  'https://api.sofarocean.com/api/wave-data';
 
 export enum SofarModels {
   NOAACoralReefWatch = 'NOAACoralReefWatch',

--- a/packages/api/src/utils/sofar.test.ts
+++ b/packages/api/src/utils/sofar.test.ts
@@ -1,5 +1,10 @@
 import { SofarModels, sofarVariableIDs } from './constants';
-import { getSofarHindcastData, getSpotterData, sofarHindcast } from './sofar';
+import {
+  getSofarHindcastData,
+  getSpotterData,
+  sofarHindcast,
+  sofarWaveData,
+} from './sofar';
 import { ValueWithTimestamp } from './sofar.types';
 
 test('It processes Sofar API for daily data.', async () => {
@@ -51,4 +56,24 @@ test('it process Sofar Hindcast API for wind-wave data', async () => {
   expect(new Date(values?.timestamp).getTime()).toBeLessThanOrEqual(
     now.getTime(),
   );
+});
+
+test('it process Sofar Wave Date API for surface temperature', async () => {
+  jest.setTimeout(30000);
+  const now = new Date();
+  const yesterdayDate = new Date(now);
+  yesterdayDate.setDate(now.getDate() - 1);
+  const today = now.toISOString();
+  const yesterday = yesterdayDate.toISOString();
+
+  const response = await sofarWaveData(
+    'SPOT-1576',
+    process.env.SOFAR_API_TOKEN,
+    yesterday,
+    today,
+  );
+
+  const values = response && response.data.surfaceTemp.length;
+
+  expect(values).toBeGreaterThan(0);
 });

--- a/packages/api/src/utils/sofar.types.ts
+++ b/packages/api/src/utils/sofar.types.ts
@@ -65,7 +65,7 @@ export interface SpotterData {
   longitude?: ValueWithTimestamp[];
 }
 
-export const DEFAULT_SPOTTER_DATA_VALUE = {
+export const DEFAULT_SPOTTER_DATA_VALUE: SpotterData = {
   topTemperature: [],
   bottomTemperature: [],
   significantWaveHeight: [],
@@ -77,4 +77,57 @@ export const DEFAULT_SPOTTER_DATA_VALUE = {
   barometerBottom: [],
   barometricTopDiff: [],
   surfaceTemperature: [],
+};
+
+export interface HindcastResponse {
+  variableID: string;
+  variableName: string;
+  dataCategory: string;
+  physicalUnit: string;
+  values: ValueWithTimestamp[];
+}
+
+export interface SofarWaveDateResponse {
+  spotterId: string;
+  waves: {
+    significantWaveHeight: number;
+    peakPeriod: number;
+    meanPeriod: number;
+    peakDirection: number;
+    peakDirectionalSpread: number;
+    meanDirection: number;
+    meanDirectionalSpread: number;
+    timestamp: string;
+    latitude: number;
+    longitude: number;
+  }[];
+  wind: {
+    speed: number;
+    direction: number;
+    seasurfaceId: number;
+    latitude: number;
+    longitude: number;
+    timestamp: string;
+  }[];
+  surfaceTemp: {
+    degrees: number;
+    latitude: number;
+    longitude: number;
+    timestamp: string;
+  }[];
+  barometerData: {
+    latitude: number;
+    longitude: number;
+    timestamp: string;
+    units: string;
+    value: number;
+  }[];
+}
+
+export const EMPTY_SOFAR_WAVE_RESPONSE: SofarWaveDateResponse = {
+  spotterId: '',
+  waves: [],
+  wind: [],
+  surfaceTemp: [],
+  barometerData: [],
 };

--- a/packages/api/src/utils/sofar.types.ts
+++ b/packages/api/src/utils/sofar.types.ts
@@ -25,6 +25,7 @@ export interface SofarDailyData {
   maxWindSpeed?: number;
   avgWindSpeed?: number;
   windDirection?: number;
+  surfaceTemperature?: number;
 }
 
 export interface SofarLiveData {
@@ -59,11 +60,12 @@ export interface SpotterData {
   barometerTop: ValueWithTimestamp[];
   barometerBottom: ValueWithTimestamp[];
   barometricTopDiff: ValueWithTimestamp[];
+  surfaceTemperature: ValueWithTimestamp[];
   latitude?: ValueWithTimestamp[];
   longitude?: ValueWithTimestamp[];
 }
 
-export const DEFAULT_SPOTTER_DATA_VALUE: SpotterData = {
+export const DEFAULT_SPOTTER_DATA_VALUE = {
   topTemperature: [],
   bottomTemperature: [],
   significantWaveHeight: [],
@@ -74,4 +76,5 @@ export const DEFAULT_SPOTTER_DATA_VALUE: SpotterData = {
   barometerTop: [],
   barometerBottom: [],
   barometricTopDiff: [],
+  surfaceTemperature: [],
 };

--- a/packages/api/src/utils/spotter-time-series.ts
+++ b/packages/api/src/utils/spotter-time-series.ts
@@ -191,6 +191,7 @@ export const addSpotterData = async (
             ['barometerTop', Metric.BAROMETRIC_PRESSURE_TOP],
             ['barometerBottom', Metric.BAROMETRIC_PRESSURE_BOTTOM],
             ['barometricTopDiff', Metric.BAROMETRIC_PRESSURE_TOP_DIFF],
+            ['surfaceTemperature', Metric.SURFACE_TEMPERATURE],
           ];
 
           // Save data to time_series

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -157,20 +157,12 @@ export async function getDailyData(
     ? mapValues(spotterRawData, (v) =>
         extractSofarValues(filterMetricDataByDate(excludedDates, v)),
       )
-    : {
-        topTemperature: [],
-        bottomTemperature: [],
-        significantWaveHeight: [],
-        waveMeanPeriod: [],
-        waveMeanDirection: [],
-        windSpeed: [],
-        windDirection: [],
-      };
+    : DEFAULT_SPOTTER_DATA_VALUE;
 
   const minBottomTemperature = getMin(spotterData.bottomTemperature);
   const maxBottomTemperature = getMax(spotterData.bottomTemperature);
   const avgBottomTemperature = getAverage(spotterData.bottomTemperature);
-
+  const surfaceTemperature = getAverage(spotterData.surfaceTemperature);
   const topTemperature = getAverage(spotterData.topTemperature);
 
   // Get satelliteTemperature
@@ -261,6 +253,7 @@ export async function getDailyData(
     maxWindSpeed,
     avgWindSpeed,
     windDirection,
+    surfaceTemperature,
   };
 }
 

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -153,11 +153,10 @@ export async function getDailyData(
     ).then((data) => data.map(({ value }) => value)),
   ]);
 
-  const spotterData = spotterRawData
-    ? mapValues(spotterRawData, (v) =>
-        extractSofarValues(filterMetricDataByDate(excludedDates, v)),
-      )
-    : DEFAULT_SPOTTER_DATA_VALUE;
+  const inputVal = spotterRawData || DEFAULT_SPOTTER_DATA_VALUE;
+  const spotterData = mapValues(inputVal, (v) =>
+    extractSofarValues(filterMetricDataByDate(excludedDates, v)),
+  );
 
   const minBottomTemperature = getMin(spotterData.bottomTemperature);
   const maxBottomTemperature = getMax(spotterData.bottomTemperature);

--- a/packages/api/test/mock/daily-data.mock.ts
+++ b/packages/api/test/mock/daily-data.mock.ts
@@ -139,6 +139,10 @@ export const getMockSpotterData = (
       value: random(900, 1100, true),
     })),
     barometricTopDiff: [],
+    surfaceTemperature: times(diffDays, (i) => ({
+      timestamp: start.clone().add(i, 'days').toISOString(),
+      value: random(900, 1100, true),
+    })),
   };
 };
 

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -81,6 +81,10 @@ const spotterConfig: Partial<Record<Metrics, SpotterConfig>> = {
     unit: 'm',
     title: 'Significant Wave Height',
   },
+  surfaceTemperature: {
+    unit: '°C',
+    title: 'Surface Temperature',
+  },
 };
 
 const MultipleSensorsCharts = ({

--- a/packages/website/src/common/SiteDetails/Sensor/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Sensor/__snapshots__/index.test.tsx.snap
@@ -38,7 +38,7 @@ exports[`Sensor Card should render with given state from Redux store 1`] = `
       classname="Sensor-content-10"
     >
       <div
-        class="Sensor-gridContainer-14"
+        style="display: grid; gap: 1rem; grid-template-areas: 'value0 image' 'spacer image' 'value1 image'; padding: 1rem;"
       >
         <div
           style="grid-area: value0;"
@@ -73,17 +73,21 @@ exports[`Sensor Card should render with given state from Redux store 1`] = `
           </mock-typography>
         </div>
         <div
-          style="grid-area: image;"
+          style="grid-area: spacer; display: inherit; min-height: 2em;"
+        />
+        <div
+          style="grid-area: image; position: relative;"
         >
           <img
             alt="sensor"
             height="150"
             src="sensor.svg"
+            style="position: absolute; bottom: 0px;"
             width="auto"
           />
         </div>
         <div
-          style="grid-area: value3; display: flex; align-items: flex-end;"
+          style="grid-area: value4; display: flex; align-items: flex-end;"
         />
       </div>
       <div

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -71,6 +71,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
     bottomTemperature,
     barometricPressureTop,
     barometricPressureTopDiff,
+    surfaceTemperature,
   } = data;
 
   const relativeTime =
@@ -95,6 +96,30 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
 
   const [alertText, clickable] = getApplicationTag(user, id);
 
+  const getGridTemplateAreas = () => {
+    if (barometricPressureTop && surfaceTemperature)
+      return "'value3 image' 'value0 image' 'value1 image' 'value2 value4'";
+    if (surfaceTemperature)
+      return "'value3 image' 'value0 image' 'value1 image'";
+    if (barometricPressureTop)
+      return "'value0 image' 'value1 image' 'value2 value4'";
+    return "'value0 image' 'spacer image' 'value1 image'";
+  };
+
+  const getImageHeight = () => {
+    if (barometricPressureTop && surfaceTemperature) return '150';
+    if (surfaceTemperature) return '150';
+    if (barometricPressureTop) return '135';
+    return '150';
+  };
+
+  const getSpaceDisplay = () => {
+    if (barometricPressureTop && surfaceTemperature) return 'none';
+    if (surfaceTemperature) return 'none';
+    if (barometricPressureTop) return 'none';
+    return 'inherit';
+  };
+
   return (
     <Card className={classes.root}>
       <CardHeader
@@ -111,7 +136,14 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
       />
 
       <CardContent className={classes.content}>
-        <div className={classes.gridContainer}>
+        <div
+          style={{
+            display: 'grid',
+            gap: '1rem',
+            gridTemplateAreas: getGridTemplateAreas(),
+            padding: '1rem',
+          }}
+        >
           {metrics.map(({ label, value }, index) => (
             <div style={{ gridArea: `value${index}` }} key={label}>
               <Typography
@@ -148,17 +180,45 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
               </Box>
             </div>
           )}
-          <div style={{ gridArea: 'image' }}>
+          <div
+            style={{
+              gridArea: 'spacer',
+              display: getSpaceDisplay(),
+              minHeight: '2em',
+            }}
+          />
+          {surfaceTemperature && (
+            <div style={{ gridArea: 'value3' }}>
+              <Typography
+                className={classes.contentTextTitles}
+                variant="subtitle2"
+              >
+                Surface Temperature
+              </Typography>
+              <Box
+                style={{
+                  display: 'flex',
+                  alignItems: 'flex-end',
+                }}
+              >
+                <Typography className={classes.contentTextValues} variant="h3">
+                  {`${formatNumber(surfaceTemperature?.value, 1)}°C`}
+                </Typography>
+              </Box>
+            </div>
+          )}
+          <div style={{ gridArea: 'image', position: 'relative' }}>
             <img
+              style={{ position: 'absolute', bottom: '0' }}
               alt="sensor"
               src={sensor}
-              height={barometricPressureTop ? '135' : '150'}
+              height={getImageHeight()}
               width="auto"
             />
           </div>
           <div
             style={{
-              gridArea: 'value3',
+              gridArea: 'value4',
               display: 'flex',
               alignItems: 'flex-end',
             }}
@@ -242,7 +302,7 @@ const styles = () =>
     content: {
       display: 'flex',
       flexDirection: 'column',
-      justifyContent: 'space-between',
+      justifyContent: 'flex-end',
       flexGrow: 1,
       padding: 0,
     },
@@ -252,7 +312,6 @@ const styles = () =>
       color: 'white',
       width: '100%',
       minHeight: 40,
-      marginTop: 32,
     },
     rejectedAlert: {
       fontSize: 11,
@@ -269,12 +328,6 @@ const styles = () =>
         color: 'inherit',
         textDecoration: 'none',
       },
-    },
-    gridContainer: {
-      display: 'grid',
-      gap: '1rem',
-      gridTemplateAreas: "'value0 image' 'value1 image' 'value2 value3'",
-      padding: '1rem',
     },
   });
 

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -202,7 +202,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                 }}
               >
                 <Typography className={classes.contentTextValues} variant="h3">
-                  {`${formatNumber(surfaceTemperature?.value, 1)}°C`}
+                  {`${formatNumber(surfaceTemperature.value, 1)}°C`}
                 </Typography>
               </Box>
             </div>

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -77,9 +77,15 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
   const relativeTime =
     (topTemperature?.timestamp && toRelativeTime(topTemperature.timestamp)) ||
     (bottomTemperature?.timestamp &&
-      toRelativeTime(bottomTemperature.timestamp));
+      toRelativeTime(bottomTemperature.timestamp)) ||
+    (surfaceTemperature?.timestamp &&
+      toRelativeTime(surfaceTemperature.timestamp));
 
-  const hasSpotter = Boolean(topTemperature?.value || bottomTemperature?.value);
+  const hasSpotter = Boolean(
+    topTemperature?.value ||
+      bottomTemperature?.value ||
+      surfaceTemperature?.value,
+  );
 
   const user = useSelector(userInfoSelector);
 

--- a/packages/website/src/common/SiteDetails/Sensor/index.tsx
+++ b/packages/website/src/common/SiteDetails/Sensor/index.tsx
@@ -199,7 +199,7 @@ const Sensor = ({ depth, id, data, classes }: SensorProps) => {
                 className={classes.contentTextTitles}
                 variant="subtitle2"
               >
-                Surface Temperature
+                SURFACE TEMP
               </Typography>
               <Box
                 style={{

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -88,6 +88,7 @@ export const metricsKeysList = [
   'barometric_pressure_bottom',
   'barometric_pressure_top_diff',
   'nitrate_plus_nitrite',
+  'surface_temperature',
 ] as const;
 
 export type MetricsKeys = typeof metricsKeysList[number];


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/861

- adds `surface_temperature` metric
- swaps `sofarSensor` with the more light `sofarLatest`, when looking for spotter position 
- show spotter surface temperature to spotter card and add relative chart, if the metric is available


![Screenshot from 2023-06-23 17-00-30](https://github.com/aqualinkorg/aqualink-app/assets/80451946/de5cbb14-a05c-452d-b174-9dc71e25a72b)

![Screenshot from 2023-06-23 16-54-42](https://github.com/aqualinkorg/aqualink-app/assets/80451946/bb84c746-5498-4b5d-9b0f-010e37d0c08a)
