### PR TITLE
Fix graphs' data would not show for selected dates

### DIFF
--- a/packages/api/migration/1687443367647-ExtendLatestDataInterval.ts
+++ b/packages/api/migration/1687443367647-ExtendLatestDataInterval.ts
@@ -1,0 +1,49 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class ExtendLatestDataInterval1687443367647
+  implements MigrationInterface
+{
+  name = 'ExtendLatestDataInterval1687443367647';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['MATERIALIZED_VIEW', 'latest_data', 'public'],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW "latest_data"`);
+
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "latest_data" AS SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL '7 days' OR type IN ('sonde') AND (timestamp >= current_date - INTERVAL '180 days') OR type IN ('hui') AND (timestamp >= current_date - INTERVAL '180 days') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'MATERIALIZED_VIEW',
+        'latest_data',
+        'SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL \'7 days\' OR type IN (\'sonde\') AND (timestamp >= current_date - INTERVAL \'180 days\') OR type IN (\'hui\') AND (timestamp >= current_date - INTERVAL \'180 days\') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC',
+      ],
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DELETE FROM "typeorm_metadata" WHERE "type" = $1 AND "name" = $2 AND "schema" = $3`,
+      ['MATERIALIZED_VIEW', 'latest_data', 'public'],
+    );
+    await queryRunner.query(`DROP MATERIALIZED VIEW "latest_data"`);
+
+    await queryRunner.query(
+      `CREATE MATERIALIZED VIEW "latest_data" AS SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL '7 days' OR type IN ('sonde') AND (timestamp >= current_date - INTERVAL '90 days') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC`,
+    );
+    await queryRunner.query(
+      `INSERT INTO "typeorm_metadata"("database", "schema", "table", "type", "name", "value") VALUES (DEFAULT, $1, DEFAULT, $2, $3, $4)`,
+      [
+        'public',
+        'MATERIALIZED_VIEW',
+        'latest_data',
+        'SELECT DISTINCT ON (metric, type, site_id, survey_point_id) "time_series"."id", metric, timestamp, value, type AS "source", site_id, survey_point_id FROM "time_series" "time_series" INNER JOIN "sources" "sources" ON "sources"."id" = "time_series"."source_id" WHERE timestamp >= current_date - INTERVAL \'7 days\' OR type IN (\'sonde\') AND (timestamp >= current_date - INTERVAL \'90 days\') ORDER BY metric, type, site_id, survey_point_id, timestamp DESC',
+      ],
+    );
+  }
+}

--- a/packages/api/src/time-series/latest-data.entity.ts
+++ b/packages/api/src/time-series/latest-data.entity.ts
@@ -33,7 +33,10 @@ import { Metric } from './metrics.enum';
         .where("timestamp >= current_date - INTERVAL '7 days'")
         // Look a bit further in the past for sonde data
         .orWhere(
-          "type IN ('sonde') AND (timestamp >= current_date - INTERVAL '90 days')",
+          "type IN ('sonde') AND (timestamp >= current_date - INTERVAL '180 days')",
+        )
+        .orWhere(
+          "type IN ('hui') AND (timestamp >= current_date - INTERVAL '180 days')",
         )
         .orderBy('metric, type, site_id, survey_point_id, timestamp', 'DESC')
     );

--- a/packages/website/src/helpers/dates.ts
+++ b/packages/website/src/helpers/dates.ts
@@ -278,3 +278,15 @@ export const generateHistoricalMonthlyMeanTimestamps = (
     };
   });
 };
+
+export const rangeOverlapWithRange = (
+  minDate1: string,
+  maxDate1: string,
+  minDate2: string,
+  maxDate2: string,
+) => {
+  return (
+    (minDate2 <= minDate1 && minDate1 <= maxDate2) ||
+    (minDate2 <= maxDate1 && maxDate1 <= maxDate2)
+  );
+};

--- a/packages/website/src/helpers/siteUtils.ts
+++ b/packages/website/src/helpers/siteUtils.ts
@@ -1,9 +1,13 @@
 import { LatLng } from 'leaflet';
-import { maxBy, meanBy } from 'lodash';
+import { maxBy, meanBy, snakeCase } from 'lodash';
 
 import {
+  DataRangeWithMetric,
+  MetricsKeys,
   Site,
+  Sources,
   SurveyPoints,
+  TimeSeriesDataRange,
   UpdateSiteNameFromListArgs,
 } from 'store/Sites/types';
 import type { TimeSeriesDataRequestParams } from 'store/Sites/types';
@@ -101,3 +105,20 @@ export const findSurveyPointFromList = (
       name: item.name || undefined,
     }))
     .find(({ id }) => id === pointId);
+
+export const getSourceRanges = (
+  dataRanges: TimeSeriesDataRange,
+  source: Sources,
+): DataRangeWithMetric[] => {
+  const result = Object.entries(dataRanges).map(([metric, sources]) => {
+    return (
+      sources[source]?.data.map((range) => ({
+        metric: snakeCase(metric) as MetricsKeys,
+        minDate: range.minDate,
+        maxDate: range.maxDate,
+      })) || []
+    );
+  });
+
+  return result.flat();
+};

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -197,6 +197,10 @@ export interface DataRange {
   maxDate: string;
 }
 
+export interface DataRangeWithMetric extends DataRange {
+  metric: MetricsKeys;
+}
+
 export type TimeSeriesSurveyPoint = Pick<SurveyPoints, 'id' | 'name'>;
 
 export type TimeSeries = Partial<


### PR DESCRIPTION
This PR changes the condition of showing graph data from: "source exists in latest data" to "source has data for selected dates range"

Also changes the latest data query to include sonde and hui data for 180 days (90 days before and no hui)