### PR TITLE
Fix new sites would not backfill daily data 

### DIFF
--- a/packages/api/scripts/upload-hobo-data.ts
+++ b/packages/api/scripts/upload-hobo-data.ts
@@ -77,6 +77,7 @@ async function run() {
       ),
       dataUploadsRepository: connection.getRepository(DataUploads),
     },
+    dataSource,
   );
 
   logger.log('Finished uploading hobo data');

--- a/packages/api/scripts/upload-hui-data.ts
+++ b/packages/api/scripts/upload-hui-data.ts
@@ -321,7 +321,10 @@ async function run() {
 
   const backfillPromises = backfill
     ? sitesCreated.map(async (x) => {
-        await backfillSiteData(x.id);
+        await backfillSiteData({
+          siteId: x.id,
+          dataSource,
+        });
         return x.id;
       })
     : [];

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -6,7 +6,7 @@ import {
   ConflictException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { DataSource, Repository } from 'typeorm';
 import { omit } from 'lodash';
 import moment from 'moment';
 import Bluebird from 'bluebird';
@@ -87,6 +87,8 @@ export class SitesService {
 
     @InjectRepository(TimeSeries)
     private timeSeriesRepository: Repository<TimeSeries>,
+
+    private dataSource: DataSource,
   ) {}
 
   async create(
@@ -118,7 +120,10 @@ export class SitesService {
       .of(user)
       .add(site);
 
-    backfillSiteData(site.id);
+    backfillSiteData({
+      dataSource: this.dataSource,
+      siteId: site.id,
+    });
 
     const messageTemplate: SlackMessage = {
       channel: process.env.SLACK_BOT_CHANNEL as string,

--- a/packages/api/test/utils.ts
+++ b/packages/api/test/utils.ts
@@ -56,7 +56,7 @@ export const mockDeleteFileFalling = (app: INestApplication) => {
 export const mockBackfillSiteData = () => {
   jest
     .spyOn(backfillSiteData, 'backfillSiteData')
-    .mockImplementationOnce((props: number) => Promise.resolve());
+    .mockImplementationOnce(() => Promise.resolve());
 };
 
 export const mockGetSpotterData = () => {


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/876

Cause of the issue was that a new database connection was attempting to be created, in `backfillSiteData`, from the the nest context, which already had it's own.