### PR TITLE
Fix missing data from CSV download

### DIFF
--- a/packages/api/migration/1689588980336-AddQueryTimeout.ts
+++ b/packages/api/migration/1689588980336-AddQueryTimeout.ts
@@ -4,7 +4,7 @@ export class AddQueryTimeout1689588980336 implements MigrationInterface {
   name = 'AddQueryTimeout1689588980336';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
-    await queryRunner.query('SET statement_timeout = 40000;');
+    await queryRunner.query('SET statement_timeout = 60000;');
   }
 
   public async down(queryRunner: QueryRunner): Promise<void> {

--- a/packages/api/migration/1689588980336-AddQueryTimeout.ts
+++ b/packages/api/migration/1689588980336-AddQueryTimeout.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddQueryTimeout1689588980336 implements MigrationInterface {
+  name = 'AddQueryTimeout1689588980336';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('SET statement_timeout = 40000;');
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query('SET statement_timeout = 0;');
+  }
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -121,6 +121,8 @@
     "@types/passport-strategy": "^0.2.35",
     "@types/sharp": "^0.30.4",
     "@types/supertest": "^2.0.8",
+    "@types/ungap__structured-clone": "^0.3.0",
+    "@ungap/structured-clone": "^1.2.0",
     "faker": "^4.1.0",
     "firebase-admin": "^11.9.0",
     "firebase-functions": "^3.8.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -83,6 +83,7 @@
     "class-transformer": "^0.3.1",
     "class-validator": "^0.14.0",
     "csv-parse": "^4.15.1",
+    "csv-stringify": "^6.4.0",
     "express": "^4.17.1",
     "firebase-admin": "^11.9.0",
     "geo-tz": "^6.0.0",

--- a/packages/api/src/pipes/parse-metric-array.pipe.ts
+++ b/packages/api/src/pipes/parse-metric-array.pipe.ts
@@ -16,7 +16,7 @@ export class MetricArrayPipe
     value: string,
     metadata: ArgumentMetadata,
   ): Promise<string[]> {
-    if (!value || value.trim() === '') {
+    if (!value) {
       return this.options.defaultArray;
     }
 

--- a/packages/api/src/pipes/parse-metric-array.pipe.ts
+++ b/packages/api/src/pipes/parse-metric-array.pipe.ts
@@ -1,0 +1,51 @@
+import {
+  Injectable,
+  PipeTransform,
+  BadRequestException,
+  ParseArrayPipe,
+  ArgumentMetadata,
+} from '@nestjs/common';
+
+@Injectable()
+export class MetricArrayPipe
+  implements PipeTransform<string, Promise<string[]>>
+{
+  constructor(private readonly options: UniqueSubsetArrayOptions) {}
+
+  async transform(
+    value: string,
+    metadata: ArgumentMetadata,
+  ): Promise<string[]> {
+    if (!value || value.trim() === '') {
+      return this.options.defaultArray;
+    }
+
+    const parseArrayPipe = new ParseArrayPipe({
+      items: String,
+      separator: ',',
+    });
+    const parsedArray = (await parseArrayPipe.transform(
+      value,
+      metadata,
+    )) as string[];
+
+    const isSubset = parsedArray.every((item) =>
+      this.options.predefinedSet.includes(item),
+    );
+    if (!isSubset) {
+      throw new BadRequestException('Invalid array. Unknown elements');
+    }
+
+    const uniqueArray = [...new Set(parsedArray)];
+    if (uniqueArray.length !== parsedArray.length) {
+      throw new BadRequestException('Invalid array. Elements are not unique');
+    }
+
+    return uniqueArray;
+  }
+}
+
+interface UniqueSubsetArrayOptions {
+  predefinedSet: string[];
+  defaultArray: string[];
+}

--- a/packages/api/src/pipes/parse-metric-array.pipe.ts
+++ b/packages/api/src/pipes/parse-metric-array.pipe.ts
@@ -7,15 +7,10 @@ import {
 } from '@nestjs/common';
 
 @Injectable()
-export class MetricArrayPipe
-  implements PipeTransform<string, Promise<string[]>>
-{
+export class MetricArrayPipe implements PipeTransform<any, Promise<string[]>> {
   constructor(private readonly options: UniqueSubsetArrayOptions) {}
 
-  async transform(
-    value: string,
-    metadata: ArgumentMetadata,
-  ): Promise<string[]> {
+  async transform(value: any, metadata: ArgumentMetadata): Promise<string[]> {
     if (!value) {
       return this.options.defaultArray;
     }

--- a/packages/api/src/sensors/sensors.service.ts
+++ b/packages/api/src/sensors/sensors.service.ts
@@ -111,14 +111,14 @@ export class SensorsService {
 
     const site = await getSiteFromSensorId(sensorId, this.siteRepository);
 
-    const data = await getDataQuery(
-      this.timeSeriesRepository,
-      site.id,
-      metrics as Metric[],
-      startDate,
-      endDate,
-      false,
-    );
+    const data = await getDataQuery({
+      timeSeriesRepository: this.timeSeriesRepository,
+      siteId: site.id,
+      metrics: metrics as Metric[],
+      start: startDate,
+      end: endDate,
+      hourly: false,
+    });
 
     return groupByMetricAndSource(data);
   }

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -177,7 +177,9 @@ export class TimeSeriesController {
     );
     const filename = `${surveyPointDataRangeDto.source}_example.csv`;
     res.set({
-      'Content-Disposition': `attachment; filename=${encodeURIComponent(filename)}`,
+      'Content-Disposition': `attachment; filename=${encodeURIComponent(
+        filename,
+      )}`,
     });
     return file.pipe(res);
   }

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -173,4 +173,37 @@ export class TimeSeriesController {
     );
     return file.pipe(res);
   }
+
+  @ApiOperation({
+    summary: 'Returns specified time series data for a specified site as csv',
+  })
+  @ApiQuery({ name: 'start', example: '2021-05-18T10:20:28.017Z' })
+  @ApiQuery({ name: 'end', example: '2021-05-18T10:20:28.017Z' })
+  @ApiQuery({
+    name: 'metrics',
+    example: [Metric.BOTTOM_TEMPERATURE, Metric.TOP_TEMPERATURE],
+  })
+  @ApiQuery({ name: 'hourly', example: false, required: false })
+  @Header('Content-Type', 'text/csv')
+  @Get('sites/:siteId/csv')
+  findSiteDataCsv(
+    @Param() siteDataDto: SiteDataDto,
+    @Query(
+      'metrics',
+      new DefaultValuePipe(Object.values(Metric)),
+      ParseArrayPipe,
+    )
+    metrics: Metric[],
+    @Query('start', ParseDatePipe) startDate?: string,
+    @Query('end', ParseDatePipe) endDate?: string,
+    @Query('hourly', ParseBoolPipe) hourly?: boolean,
+  ) {
+    return this.timeSeriesService.findSiteDataCsv(
+      siteDataDto,
+      metrics,
+      startDate,
+      endDate,
+      hourly,
+    );
+  }
 }

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -11,6 +11,7 @@ import {
   Body,
   Res,
   Header,
+  BadRequestException,
 } from '@nestjs/common';
 import { FilesInterceptor } from '@nestjs/platform-express';
 import { ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
@@ -175,7 +176,9 @@ export class TimeSeriesController {
       surveyPointDataRangeDto,
     );
     res.set({
-      'Content-Disposition': `attachment; filename=${surveyPointDataRangeDto.source}_example.csv`,
+      'Content-Disposition': `attachment; filename=${encodeURIComponent(
+        `${surveyPointDataRangeDto.source}_example.csv`,
+      )}`,
     });
     return file.pipe(res);
   }
@@ -207,6 +210,11 @@ export class TimeSeriesController {
     @Query('end', ParseDatePipe) endDate?: string,
     @Query('hourly', ParseBoolPipe) hourly?: boolean,
   ) {
+    if (startDate && endDate && startDate > endDate) {
+      throw new BadRequestException(
+        `Invalid Dates: start date can't be after end date`,
+      );
+    }
     return this.timeSeriesService.findSiteDataCsv(
       res,
       siteDataDto,

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -174,6 +174,9 @@ export class TimeSeriesController {
     const file = this.timeSeriesService.getSampleUploadFiles(
       surveyPointDataRangeDto,
     );
+    res.set({
+      'Content-Disposition': `attachment; filename=${surveyPointDataRangeDto.source}_example.csv`,
+    });
     return file.pipe(res);
   }
 
@@ -190,6 +193,7 @@ export class TimeSeriesController {
   @Header('Content-Type', 'text/csv')
   @Get('sites/:siteId/csv')
   findSiteDataCsv(
+    @Res() res: Response,
     @Param() siteDataDto: SiteDataDto,
     @Query(
       'metrics',
@@ -204,6 +208,7 @@ export class TimeSeriesController {
     @Query('hourly', ParseBoolPipe) hourly?: boolean,
   ) {
     return this.timeSeriesService.findSiteDataCsv(
+      res,
       siteDataDto,
       metrics,
       startDate,

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -4,8 +4,6 @@ import {
   Param,
   Query,
   ParseBoolPipe,
-  ParseArrayPipe,
-  DefaultValuePipe,
   Post,
   UseInterceptors,
   UseGuards,
@@ -34,6 +32,7 @@ import { SourceType } from '../sites/schemas/source-type.enum';
 import { fileFilter } from '../utils/uploads/upload-sheet-data';
 import { SampleUploadFilesDto } from './dto/sample-upload-files.dto';
 import { Metric } from './metrics.enum';
+import { MetricArrayPipe } from '../pipes/parse-metric-array.pipe';
 
 const MAX_FILE_COUNT = 10;
 const MAX_FILE_SIZE_MB = 10;
@@ -60,8 +59,10 @@ export class TimeSeriesController {
     @Param() surveyPointDataDto: SurveyPointDataDto,
     @Query(
       'metrics',
-      new DefaultValuePipe(Object.values(Metric)),
-      ParseArrayPipe,
+      new MetricArrayPipe({
+        predefinedSet: Object.values(Metric),
+        defaultArray: Object.values(Metric),
+      }),
     )
     metrics: Metric[],
     @Query('start', ParseDatePipe) startDate?: string,
@@ -93,8 +94,10 @@ export class TimeSeriesController {
     @Param() siteDataDto: SiteDataDto,
     @Query(
       'metrics',
-      new DefaultValuePipe(Object.values(Metric)),
-      ParseArrayPipe,
+      new MetricArrayPipe({
+        predefinedSet: Object.values(Metric),
+        defaultArray: Object.values(Metric),
+      }),
     )
     metrics: Metric[],
     @Query('start', ParseDatePipe) startDate?: string,
@@ -190,8 +193,10 @@ export class TimeSeriesController {
     @Param() siteDataDto: SiteDataDto,
     @Query(
       'metrics',
-      new DefaultValuePipe(Object.values(Metric)),
-      ParseArrayPipe,
+      new MetricArrayPipe({
+        predefinedSet: Object.values(Metric),
+        defaultArray: Object.values(Metric),
+      }),
     )
     metrics: Metric[],
     @Query('start', ParseDatePipe) startDate?: string,

--- a/packages/api/src/time-series/time-series.controller.ts
+++ b/packages/api/src/time-series/time-series.controller.ts
@@ -175,10 +175,9 @@ export class TimeSeriesController {
     const file = this.timeSeriesService.getSampleUploadFiles(
       surveyPointDataRangeDto,
     );
+    const filename = `${surveyPointDataRangeDto.source}_example.csv`;
     res.set({
-      'Content-Disposition': `attachment; filename=${encodeURIComponent(
-        `${surveyPointDataRangeDto.source}_example.csv`,
-      )}`,
+      'Content-Disposition': `attachment; filename=${encodeURIComponent(filename)}`,
     });
     return file.pipe(res);
   }

--- a/packages/api/src/time-series/time-series.service.ts
+++ b/packages/api/src/time-series/time-series.service.ts
@@ -177,7 +177,11 @@ export class TimeSeriesService {
     )}_${moment(endDate).format(DATE_FORMAT)}.csv`;
 
     res
-      .set({ 'Content-Disposition': `attachment; filename=${fileName}` })
+      .set({
+        'Content-Disposition': `attachment; filename=${encodeURIComponent(
+          fileName,
+        )}`,
+      })
       .send(stringify(rows, { header: true }));
   }
 

--- a/packages/api/src/time-series/time-series.service.ts
+++ b/packages/api/src/time-series/time-series.service.ts
@@ -10,6 +10,7 @@ import {
   NotFoundException,
 } from '@nestjs/common';
 import { join } from 'path';
+// https://github.com/adaltas/node-csv/issues/372
 // eslint-disable-next-line import/no-unresolved
 import { stringify } from 'csv-stringify/sync';
 import { SiteDataDto } from './dto/site-data.dto';

--- a/packages/api/src/time-series/time-series.spec.ts
+++ b/packages/api/src/time-series/time-series.spec.ts
@@ -4,6 +4,7 @@ import { max, min, union } from 'lodash';
 import moment from 'moment';
 import { join } from 'path';
 import { readFileSync } from 'fs';
+import * as structuredClone from '@ungap/structured-clone';
 import { TestService } from '../../test/test.service';
 import { athensSite, californiaSite } from '../../test/mock/site.mock';
 import { athensSurveyPointPiraeus } from '../../test/mock/survey-point.mock';
@@ -13,6 +14,9 @@ import {
   NOAAMetrics,
   spotterMetrics,
 } from '../../test/mock/time-series.mock';
+
+// https://github.com/jsdom/jsdom/issues/3363
+global.structuredClone = structuredClone.default as any;
 
 type StringDateRange = [string, string];
 
@@ -158,5 +162,15 @@ export const timeSeriesTests = () => {
     expect(rsp.status).toBe(200);
     expect(rsp.headers['content-type']).toMatch(/^text\/csv/);
     expect(rsp.text).toMatch(expectedData);
+  });
+
+  it('GET sites/:siteId/csv fetch data as csv', async () => {
+    const rsp = await request(app.getHttpServer())
+      .get(`/time-series/sites/${californiaSite.id}/csv`)
+      .query({ hourly: true })
+      .set('Accept', 'text/csv');
+
+    expect(rsp.status).toBe(200);
+    expect(rsp.headers['content-type']).toMatch(/^text\/csv/);
   });
 };

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -78,16 +78,30 @@ export const groupByMetricAndSource = <T extends TimeSeriesGroupable>(
     .toJSON();
 };
 
-export const getDataQuery = (
-  timeSeriesRepository: Repository<TimeSeries>,
-  siteId: number,
-  metrics: Metric[],
-  start?: string,
-  end?: string,
-  hourly?: boolean,
-  surveyPointId?: number,
-): Promise<TimeSeriesData[]> => {
-  const { endDate, startDate } = getTimeSeriesDefaultDates(start, end);
+interface GetDataQueryParams {
+  timeSeriesRepository: Repository<TimeSeries>;
+  siteId: number;
+  metrics: Metric[];
+  start?: string;
+  end?: string;
+  hourly?: boolean;
+  surveyPointId?: number;
+  csv?: boolean;
+}
+
+export const getDataQuery = ({
+  timeSeriesRepository,
+  siteId,
+  metrics,
+  start,
+  end,
+  hourly,
+  surveyPointId,
+  csv = false,
+}: GetDataQueryParams): Promise<TimeSeriesData[]> => {
+  const { endDate, startDate } = csv
+    ? { startDate: start, endDate: end }
+    : getTimeSeriesDefaultDates(start, end);
 
   const surveyPointCondition = surveyPointId
     ? `(source.survey_point_id = ${surveyPointId} OR source.survey_point_id is NULL)`

--- a/packages/api/src/utils/time-series.utils.ts
+++ b/packages/api/src/utils/time-series.utils.ts
@@ -103,9 +103,13 @@ export const getDataQuery = ({
     ? { startDate: start, endDate: end }
     : getTimeSeriesDefaultDates(start, end);
 
-  const surveyPointCondition = surveyPointId
-    ? `(source.survey_point_id = ${surveyPointId} OR source.survey_point_id is NULL)`
-    : `1=1`;
+  const { sql: surveyPointConditionSql, params: surveyPointConditionParams } =
+    surveyPointId
+      ? {
+          sql: 'AND (source.survey_point_id = :surveyPointId OR source.survey_point_id IS NULL)',
+          params: { surveyPointId },
+        }
+      : { sql: '', params: {} };
 
   const mainQuery = timeSeriesRepository
     .createQueryBuilder('time_series')
@@ -119,8 +123,8 @@ export const getDataQuery = ({
     .innerJoin(
       'time_series.source',
       'source',
-      `source.site_id = :siteId AND ${surveyPointCondition}`,
-      { siteId },
+      `source.site_id = :siteId ${surveyPointConditionSql}`,
+      { siteId, ...surveyPointConditionParams },
     )
     .leftJoin('source.surveyPoint', 'surveyPoint')
     .addSelect('surveyPoint.id', 'surveyPointId')

--- a/packages/api/test/jest.json
+++ b/packages/api/test/jest.json
@@ -22,5 +22,9 @@
   "transform": {
     "\\.ts$": "ts-jest"
   },
-  "globalSetup": "./test/global-setup.js"
+  "globalSetup": "./test/global-setup.js",
+  "moduleNameMapper": {
+    "^csv-stringify/sync":
+      "<rootDir>/../../node_modules/csv-stringify/dist/cjs/sync.cjs"
+  }
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -30,7 +30,6 @@
     "chartjs-plugin-annotation": "^0.5.7",
     "classnames": "^2.2.6",
     "date-fns-tz": "^1.1.3",
-    "download-csv": "^1.1.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",
     "enzyme-to-json": "^3.4.4",

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
@@ -1,72 +1,16 @@
 import React, { useState } from 'react';
-import downloadCsv from 'download-csv';
 import { Button } from '@material-ui/core';
-import moment from 'moment';
 import { useSelector } from 'react-redux';
 import { useSnackbar } from 'notistack';
-import { ValueWithTimestamp, MetricsKeys } from 'store/Sites/types';
+import { MetricsKeys } from 'store/Sites/types';
 import { spotterPositionSelector } from 'store/Sites/selectedSiteSlice';
-import siteServices from 'services/siteServices';
+import { downloadCsvFile } from 'utils/utils';
+import { constructTimeSeriesDataCsvRequestUrl } from 'helpers/siteUtils';
+import moment from 'moment';
 import DownloadCSVDialog from './DownloadCSVDialog';
 import { CSVColumnData } from './types';
 
-type CSVColumnNames =
-  | 'spotterBottomTemp'
-  | 'spotterTopTemp'
-  | 'hoboTemp'
-  | 'oceanSensePH'
-  | 'oceanSenseEC'
-  | 'oceanSensePRESS'
-  | 'oceanSenseDO'
-  | 'oceanSenseORP'
-  | 'dailySST';
-
-interface CSVRow extends Partial<Record<CSVColumnNames, number>> {
-  timestamp: string;
-}
-
 const DATE_FORMAT = 'YYYY_MM_DD';
-
-/**
- * Construct CSV data to pass into download-csv.
- * This function is designed with the 'builder' pattern, where a chain function and result function is returned.
- * Call the chained() function to add a new column to the CSV, or the result() function to return the final csv object.
- * @param columnName - The name of the new column. 'timestamp' is reserved.
- * @param data - The data corresponding to the new column. Obj array of timestamp and value.
- * @param existingData - Should only used by chained() and never directly. Stores the in-progress CSV object.
- */
-function constructCSVData(
-  columnName: CSVColumnNames,
-  data: ValueWithTimestamp[] = [],
-  existingData: Record<CSVRow['timestamp'], CSVRow> = {},
-) {
-  // writing this in an immutable fashion will be detrimental to performance.
-  /* eslint-disable no-param-reassign,fp/no-mutation,fp/no-mutating-methods */
-  const result = data.reduce((obj, item) => {
-    // we are basically ensuring there's always a timestamp column in the final result.
-    if (obj[item.timestamp]) {
-      obj[item.timestamp][columnName] = item.value;
-    } else {
-      obj[item.timestamp] = {
-        timestamp: item.timestamp,
-        [columnName]: item.value,
-      };
-    }
-    return obj;
-  }, existingData);
-  return {
-    result: () =>
-      Object.values(result).sort(
-        (a, b) =>
-          new Date(a.timestamp).getTime() - new Date(b.timestamp).getTime(),
-      ),
-    chained: (
-      chainedFinalKey: CSVColumnNames,
-      chainedData: ValueWithTimestamp[] = [],
-    ) => constructCSVData(chainedFinalKey, chainedData, result),
-  };
-  /* eslint-enable no-param-reassign,fp/no-mutation */
-}
 
 interface DownloadCSVButtonParams {
   data: CSVColumnData[];
@@ -74,7 +18,6 @@ interface DownloadCSVButtonParams {
   endDate?: string;
   className?: string;
   siteId?: number | string;
-  pointId?: number | string;
   defaultMetrics?: MetricsKeys[];
 }
 
@@ -83,7 +26,6 @@ function DownloadCSVButton({
   startDate,
   endDate,
   className,
-  pointId,
   siteId,
   defaultMetrics,
 }: DownloadCSVButtonParams) {
@@ -103,33 +45,24 @@ function DownloadCSVButton({
       return;
     }
 
-    if (!additionalData && !allDates && hourly) {
-      downloadCsv(getCSVData(data), undefined, fileName);
-      setOpen(false);
-      return;
-    }
+    const fileName = `data_site_${siteId}_${moment(startDate).format(
+      DATE_FORMAT,
+    )}_${moment(endDate).format(DATE_FORMAT)}.csv`;
 
     setLoading(true);
-
     try {
-      const response = await siteServices.getSiteTimeSeriesData({
-        hourly,
-        start: allDates ? undefined : startDate,
-        end: allDates ? undefined : endDate,
-        metrics: additionalData ? undefined : defaultMetrics,
-        siteId: String(siteId),
-      });
-
-      const formattedData = Object.entries(response.data)
-        .map(([metric, sources]) => {
-          return Object.entries(sources).map(([type, values]) => ({
-            name: `${metric}_${type}`,
-            values: values.data,
-          }));
-        })
-        .flat();
-
-      downloadCsv(getCSVData(formattedData), undefined, fileName);
+      await downloadCsvFile(
+        `${
+          process.env.REACT_APP_API_BASE_URL
+        }/${constructTimeSeriesDataCsvRequestUrl({
+          hourly,
+          start: allDates ? undefined : startDate,
+          end: allDates ? undefined : endDate,
+          metrics: additionalData ? undefined : defaultMetrics,
+          siteId: String(siteId),
+        })}`,
+        fileName,
+      );
     } catch (error) {
       console.error(error);
       enqueueSnackbar('There was an error downloading csv data', {
@@ -140,24 +73,6 @@ function DownloadCSVButton({
     setLoading(false);
     setOpen(false);
   };
-
-  const getCSVData = (selectedData: CSVColumnData[]) => {
-    const [head, ...tail] = selectedData;
-
-    // TODO: Change either CSVDataColumn names type or make it generic string
-    const start = constructCSVData(head.name as CSVColumnNames, head.values);
-    const result = tail.reduce(
-      (prev, curr) => prev.chained(curr.name as CSVColumnNames, curr.values),
-      start,
-    );
-    return result.result();
-  };
-
-  const fileName = `data_site_${siteId}${
-    pointId ? `_survey_point_${pointId}` : ''
-  }_${moment(startDate).format(DATE_FORMAT)}_${moment(endDate).format(
-    DATE_FORMAT,
-  )}.csv`;
 
   return (
     <>
@@ -188,7 +103,6 @@ function DownloadCSVButton({
 DownloadCSVButton.defaultProps = {
   startDate: undefined,
   endDate: undefined,
-  pointId: undefined,
   siteId: undefined,
   className: undefined,
 };

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/DownloadCSVButton.tsx
@@ -6,11 +6,8 @@ import { MetricsKeys } from 'store/Sites/types';
 import { spotterPositionSelector } from 'store/Sites/selectedSiteSlice';
 import { downloadCsvFile } from 'utils/utils';
 import { constructTimeSeriesDataCsvRequestUrl } from 'helpers/siteUtils';
-import moment from 'moment';
 import DownloadCSVDialog from './DownloadCSVDialog';
 import { CSVColumnData } from './types';
-
-const DATE_FORMAT = 'YYYY_MM_DD';
 
 interface DownloadCSVButtonParams {
   data: CSVColumnData[];
@@ -45,10 +42,6 @@ function DownloadCSVButton({
       return;
     }
 
-    const fileName = `data_site_${siteId}_${moment(startDate).format(
-      DATE_FORMAT,
-    )}_${moment(endDate).format(DATE_FORMAT)}.csv`;
-
     setLoading(true);
     try {
       await downloadCsvFile(
@@ -61,7 +54,6 @@ function DownloadCSVButton({
           metrics: additionalData ? undefined : defaultMetrics,
           siteId: String(siteId),
         })}`,
-        fileName,
       );
     } catch (error) {
       console.error(error);

--- a/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
+++ b/packages/website/src/common/Chart/MultipleSensorsCharts/index.tsx
@@ -591,7 +591,6 @@ const MultipleSensorsCharts = ({
           startDate={pickerStartDate}
           endDate={pickerEndDate}
           siteId={site.id}
-          pointId={pointId}
           className={classes.button}
           defaultMetrics={DEFAULT_METRICS}
         />

--- a/packages/website/src/custom.d.ts
+++ b/packages/website/src/custom.d.ts
@@ -11,18 +11,6 @@ declare module '*.css' {
   export = classNames;
 }
 
-declare module 'download-csv' {
-  // These types are for our use-case and are in no way representative of the real library
-  // Real types: https://github.com/AllenZeng/download-csv#readme
-  /* eslint-disable @typescript-eslint/no-unused-vars */
-  // eslint-disable-next-line no-inner-declarations
-  export default function downloadCSV<K>(
-    data: Array<{ [k in K]?: any }>,
-    headersMap?: { [k in K]?: string },
-    fileName?: string,
-  ) {}
-  /* eslint-enable @typescript-eslint/no-unused-vars */
-}
 declare module 'react-leaflet-markercluster';
 declare module 'react-swipeable-bottom-sheet';
 declare module '@sketchfab/viewer-api';

--- a/packages/website/src/helpers/siteUtils.ts
+++ b/packages/website/src/helpers/siteUtils.ts
@@ -94,6 +94,15 @@ export const constructTimeSeriesDataRequestUrl = ({
   }${requests.generateUrlQueryParams(rest)}`;
 };
 
+export const constructTimeSeriesDataCsvRequestUrl = ({
+  siteId,
+  ...rest
+}: TimeSeriesDataRequestParams) => {
+  return `time-series/sites/${siteId}/csv${requests.generateUrlQueryParams(
+    rest,
+  )}`;
+};
+
 export const findSurveyPointFromList = (
   pointId?: string,
   points?: SurveyPoints[],

--- a/packages/website/src/helpers/siteUtils.ts
+++ b/packages/website/src/helpers/siteUtils.ts
@@ -89,8 +89,8 @@ export const constructTimeSeriesDataRequestUrl = ({
   pointId,
   ...rest
 }: TimeSeriesDataRequestParams) => {
-  return `time-series/sites/${siteId}${
-    pointId ? `/site-survey-points/${pointId}` : ''
+  return `time-series/sites/${encodeURIComponent(siteId)}${
+    pointId ? `/site-survey-points/${encodeURIComponent(pointId)}` : ''
   }${requests.generateUrlQueryParams(rest)}`;
 };
 
@@ -98,9 +98,9 @@ export const constructTimeSeriesDataCsvRequestUrl = ({
   siteId,
   ...rest
 }: TimeSeriesDataRequestParams) => {
-  return `time-series/sites/${siteId}/csv${requests.generateUrlQueryParams(
-    rest,
-  )}`;
+  return `time-series/sites/${encodeURIComponent(
+    siteId,
+  )}/csv${requests.generateUrlQueryParams(rest)}`;
 };
 
 export const findSurveyPointFromList = (

--- a/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
@@ -9,25 +9,7 @@ import {
 import ArrowBackIcon from '@material-ui/icons/ArrowBack';
 import { Link } from 'react-router-dom';
 import { Site } from 'store/Sites/types';
-
-function downloadFile(url: string, fileName: string) {
-  fetch(url, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'text/csv',
-    },
-  })
-    .then((response) => response.blob())
-    .then((blob) => {
-      const downloadUrl = window.URL.createObjectURL(new Blob([blob]));
-      const link = document.createElement('a');
-      // eslint-disable-next-line fp/no-mutation
-      link.href = downloadUrl;
-      link.setAttribute('download', fileName);
-      document.body.appendChild(link);
-      link.click();
-    });
-}
+import { downloadCsvFile } from 'utils/utils';
 
 const exampleFiles = [
   {
@@ -75,7 +57,7 @@ const Header = ({ site }: HeaderProps) => {
               <Button
                 className={classes.downloadButton}
                 onClick={() =>
-                  downloadFile(
+                  downloadCsvFile(
                     `${
                       process.env.REACT_APP_API_BASE_URL
                     }/time-series/sample-upload-files/${encodeURIComponent(

--- a/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
+++ b/packages/website/src/routes/SiteRoutes/UploadData/Header.tsx
@@ -11,24 +11,7 @@ import { Link } from 'react-router-dom';
 import { Site } from 'store/Sites/types';
 import { downloadCsvFile } from 'utils/utils';
 
-const exampleFiles = [
-  {
-    source: 'hobo',
-    fileName: 'hobo_example.csv',
-  },
-  {
-    source: 'sonde',
-    fileName: 'sonde_example_reduced.csv',
-  },
-  {
-    source: 'metlog',
-    fileName: 'metlog_example.csv',
-  },
-  {
-    source: 'hui',
-    fileName: 'hui_example.csv',
-  },
-];
+const exampleFiles = ['hobo', 'sonde', 'metlog', 'hui'];
 
 const Header = ({ site }: HeaderProps) => {
   const classes = useStyles();
@@ -53,7 +36,7 @@ const Header = ({ site }: HeaderProps) => {
         <Typography style={{ fontSize: '0.8em' }}>
           You can find example file formats here:{' '}
           {exampleFiles.map((file, i) => (
-            <span key={file.fileName}>
+            <span key={file}>
               <Button
                 className={classes.downloadButton}
                 onClick={() =>
@@ -61,13 +44,12 @@ const Header = ({ site }: HeaderProps) => {
                     `${
                       process.env.REACT_APP_API_BASE_URL
                     }/time-series/sample-upload-files/${encodeURIComponent(
-                      file.source,
+                      file,
                     )}`,
-                    file.fileName,
                   )
                 }
               >
-                {file.source}
+                {file}
               </Button>
               {i !== exampleFiles.length - 1 ? ', ' : ''}
             </span>

--- a/packages/website/src/utils/utils.ts
+++ b/packages/website/src/utils/utils.ts
@@ -2,6 +2,10 @@ export function downloadCsvFile(url: string, fileName: string) {
   const link = document.createElement('a');
   // eslint-disable-next-line fp/no-mutation
   link.href = url;
+  // eslint-disable-next-line fp/no-mutation
+  link.target = '_blank';
+  // eslint-disable-next-line fp/no-mutation
+  link.rel = 'noopener noreferrer';
   if (fileName) {
     link.setAttribute('download', fileName);
   }

--- a/packages/website/src/utils/utils.ts
+++ b/packages/website/src/utils/utils.ts
@@ -1,4 +1,4 @@
-export function downloadCsvFile(url: string, fileName: string) {
+export function downloadCsvFile(url: string) {
   const link = document.createElement('a');
   // eslint-disable-next-line fp/no-mutation
   link.href = url;
@@ -6,9 +6,6 @@ export function downloadCsvFile(url: string, fileName: string) {
   link.target = '_blank';
   // eslint-disable-next-line fp/no-mutation
   link.rel = 'noopener noreferrer';
-  if (fileName) {
-    link.setAttribute('download', fileName);
-  }
   document.body.appendChild(link);
   link.click();
 }

--- a/packages/website/src/utils/utils.ts
+++ b/packages/website/src/utils/utils.ts
@@ -1,0 +1,22 @@
+export function downloadCsvFile(url: string, fileName: string) {
+  return fetch(url, {
+    method: 'GET',
+    headers: {
+      'Content-Type': 'text/csv',
+    },
+  })
+    .then((response) => {
+      return response.blob();
+    })
+    .then((blob) => {
+      const downloadUrl = window.URL.createObjectURL(new Blob([blob]));
+      const link = document.createElement('a');
+      // eslint-disable-next-line fp/no-mutation
+      link.href = downloadUrl;
+      if (fileName) {
+        link.setAttribute('download', fileName);
+      }
+      document.body.appendChild(link);
+      link.click();
+    });
+}

--- a/packages/website/src/utils/utils.ts
+++ b/packages/website/src/utils/utils.ts
@@ -1,22 +1,10 @@
 export function downloadCsvFile(url: string, fileName: string) {
-  return fetch(url, {
-    method: 'GET',
-    headers: {
-      'Content-Type': 'text/csv',
-    },
-  })
-    .then((response) => {
-      return response.blob();
-    })
-    .then((blob) => {
-      const downloadUrl = window.URL.createObjectURL(new Blob([blob]));
-      const link = document.createElement('a');
-      // eslint-disable-next-line fp/no-mutation
-      link.href = downloadUrl;
-      if (fileName) {
-        link.setAttribute('download', fileName);
-      }
-      document.body.appendChild(link);
-      link.click();
-    });
+  const link = document.createElement('a');
+  // eslint-disable-next-line fp/no-mutation
+  link.href = url;
+  if (fileName) {
+    link.setAttribute('download', fileName);
+  }
+  document.body.appendChild(link);
+  link.click();
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5316,6 +5316,11 @@
   resolved "https://registry.yarnpkg.com/@types/trusted-types/-/trusted-types-2.0.3.tgz#a136f83b0758698df454e328759dbd3d44555311"
   integrity sha512-NfQ4gyz38SL8sDNrSixxU2Os1a5xcdFxipAFxYEuLUlvU2uDwS4NUpsImcf1//SlWItCVMMLiylsxbmNMToV/g==
 
+"@types/ungap__structured-clone@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/ungap__structured-clone/-/ungap__structured-clone-0.3.0.tgz#39ef89de1f04bb1920ed99e549b885331295c47d"
+  integrity sha512-eBWREUhVUGPze+bUW22AgUr05k8u+vETzuYdLYSvWqGTUe0KOf+zVnOB1qER5wMcw8V6D9Ar4DfJmVvD1yu0kQ==
+
 "@types/validator@^13.1.0", "@types/validator@^13.7.10":
   version "13.7.17"
   resolved "https://registry.yarnpkg.com/@types/validator/-/validator-13.7.17.tgz#0a6d1510395065171e3378a4afc587a3aefa7cc1"
@@ -5451,6 +5456,11 @@
   dependencies:
     "@typescript-eslint/types" "5.59.7"
     eslint-visitor-keys "^3.3.0"
+
+"@ungap/structured-clone@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
+  integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
 "@webassemblyjs/ast@1.11.6", "@webassemblyjs/ast@^1.11.5":
   version "1.11.6"
@@ -8833,11 +8843,6 @@ dotenv@^8.1.0:
   version "8.6.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.6.0.tgz#061af664d19f7f4d8fc6e4ff9b584ce237adcb8b"
   integrity sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==
-
-download-csv@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/download-csv/-/download-csv-1.1.1.tgz#c0b076f48344f1be47af4005cf32d53283eb88eb"
-  integrity sha512-sth80pckLRk4/9HLU5RQbRimM+8G5XAR/G8C2oRcEvfjFU4szyd0rUPADczFu7lupK3glwAiPXA+kpRXrAkfNA==
 
 duplexer@^0.1.1, duplexer@^0.1.2:
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8244,6 +8244,11 @@ csv-stringify@^5.6.5:
   resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-5.6.5.tgz#c6d74badda4b49a79bf4e72f91cce1e33b94de00"
   integrity sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==
 
+csv-stringify@^6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/csv-stringify/-/csv-stringify-6.4.0.tgz#6d006dca9194700e44f9fbc541bee8bbbd4f459c"
+  integrity sha512-HQsw0QXiN5fdlO+R8/JzCZnR3Fqp8E87YVnhHlaPtNGJjt6ffbV0LpOkieIb1x6V1+xt878IYq77SpXHWAqKkA==
+
 csv@^5.1.3:
   version "5.5.3"
   resolved "https://registry.yarnpkg.com/csv/-/csv-5.5.3.tgz#cd26c1e45eae00ce6a9b7b27dcb94955ec95207d"


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/879

Basically moves CSV creation to the backend, fixing the issue of missing date when selecting `all dates`.
The issue was caused because the backend limits time-series data to 3 months if no other limit is specified.