### PR TITLE
Make survey_id not null in time-series

### DIFF
--- a/packages/api/migration/1689848494071-MakeTimeSeriesSourceNotNull.ts
+++ b/packages/api/migration/1689848494071-MakeTimeSeriesSourceNotNull.ts
@@ -1,0 +1,46 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class MakeTimeSeriesSourceNotNull1689848494071
+  implements MigrationInterface
+{
+  name = 'MakeTimeSeriesSourceNotNull1689848494071';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // delete rows with null source_id, since they are meaningless for the app.
+    await queryRunner.query('delete from time_series where source_id is null');
+
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "FK_fb5d7b75a674607b65fa78d5c92"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "no_duplicate_data"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ALTER COLUMN "source_id" SET NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "no_duplicate_data" UNIQUE ("metric", "source_id", "timestamp")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "FK_fb5d7b75a674607b65fa78d5c92" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE CASCADE ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "FK_fb5d7b75a674607b65fa78d5c92"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" DROP CONSTRAINT "no_duplicate_data"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ALTER COLUMN "source_id" DROP NOT NULL`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "no_duplicate_data" UNIQUE ("timestamp", "metric", "source_id")`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "time_series" ADD CONSTRAINT "FK_fb5d7b75a674607b65fa78d5c92" FOREIGN KEY ("source_id") REFERENCES "sources"("id") ON DELETE SET NULL ON UPDATE NO ACTION`,
+    );
+  }
+}

--- a/packages/api/migration/1689848494071-MakeTimeSeriesSourceNotNull.ts
+++ b/packages/api/migration/1689848494071-MakeTimeSeriesSourceNotNull.ts
@@ -6,6 +6,9 @@ export class MakeTimeSeriesSourceNotNull1689848494071
   name = 'MakeTimeSeriesSourceNotNull1689848494071';
 
   public async up(queryRunner: QueryRunner): Promise<void> {
+    // lock time_series so we can safely execute DDL operations
+    await queryRunner.query('LOCK TABLE time_series IN ACCESS EXCLUSIVE MODE');
+
     // delete rows with null source_id, since they are meaningless for the app.
     await queryRunner.query('delete from time_series where source_id is null');
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -41,7 +41,7 @@
     "test:e2e": "jest --config ./test/jest-e2e.json",
     "typeorm": "ts-node $(yarn bin typeorm) -d ormconfig.ts",
     "migration:generate": "yarn typeorm migration:generate",
-    "migration:run": "yarn typeorm migration:run -t each",
+    "migration:run": "yarn typeorm migration:run --transaction each",
     "migration:revert": "yarn typeorm migration:revert",
     "hashId": "ts-node -r dotenv/config scripts/url-hash.ts toHash",
     "hashId:prod": "DOTENV_CONFIG_PATH=.env.prod ts-node -r dotenv/config scripts/url-hash.ts toHash",

--- a/packages/api/src/time-series/time-series.entity.ts
+++ b/packages/api/src/time-series/time-series.entity.ts
@@ -34,7 +34,7 @@ export class TimeSeries {
   @Column({ type: 'enum', enum: Metric, nullable: false })
   metric: Metric;
 
-  @ManyToOne(() => Sources, { onDelete: 'SET NULL', nullable: true })
+  @ManyToOne(() => Sources, { onDelete: 'CASCADE', nullable: false })
   source: Sources | null;
 
   @ManyToOne(() => DataUploads, { onDelete: 'CASCADE', nullable: true })


### PR DESCRIPTION
This PR makes `survey_id` not NULL in `time-series` table.

`time-series` rows with NULL values for `survey_id` are meaningless for the application, since they can not be related to any site.