### PR TITLE
Add spotter info page

### DIFF
--- a/packages/api/src/sensor-data/sensor-data.controller.ts
+++ b/packages/api/src/sensor-data/sensor-data.controller.ts
@@ -1,5 +1,8 @@
-import { Controller, Get, Query } from '@nestjs/common';
-import { ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { Controller, Get, Query, Req } from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery } from '@nestjs/swagger';
+import { Auth } from 'auth/auth.decorator';
+import { AuthRequest } from 'auth/auth.types';
+import { AdminLevel } from 'users/users.entity';
 
 import { SensorDataService } from './sensor-data.service';
 
@@ -18,5 +21,19 @@ export class SensorDataController {
     @Query('end') end?: string,
   ) {
     return this.sensorDataService.get(id, start, end);
+  }
+
+  @ApiBearerAuth()
+  @Auth(AdminLevel.SiteManager, AdminLevel.SuperAdmin)
+  @ApiOperation({ summary: 'Get sensor status information' })
+  @ApiQuery({ name: 'siteId', example: '1063' })
+  @ApiQuery({ name: 'sensorId', example: 'SPOT-0000' })
+  @Get('info')
+  sensorInfo(
+    @Req() request: AuthRequest,
+    @Query('siteId') siteId?: number,
+    @Query('sensorId') sensorId?: string,
+  ) {
+    return this.sensorDataService.getSensorInfo(siteId, sensorId, request.user);
   }
 }

--- a/packages/api/src/sensor-data/sensor-data.module.ts
+++ b/packages/api/src/sensor-data/sensor-data.module.ts
@@ -1,8 +1,11 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Site } from 'sites/sites.entity';
 import { SensorDataController } from './sensor-data.controller';
 import { SensorDataService } from './sensor-data.service';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Site])],
   controllers: [SensorDataController],
   providers: [SensorDataService],
 })

--- a/packages/api/src/sensor-data/sensor-data.service.ts
+++ b/packages/api/src/sensor-data/sensor-data.service.ts
@@ -1,8 +1,22 @@
-import { Injectable } from '@nestjs/common';
-import { sofarSensor } from '../utils/sofar';
+import {
+  BadRequestException,
+  ForbiddenException,
+  Injectable,
+  UnauthorizedException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Site } from 'sites/sites.entity';
+import { Repository } from 'typeorm';
+import { AdminLevel, User } from 'users/users.entity';
+import { sofarLatest, sofarSensor } from '../utils/sofar';
 
 @Injectable()
 export class SensorDataService {
+  constructor(
+    @InjectRepository(Site)
+    private siteRepository: Repository<Site>,
+  ) {}
+
   get(sensorId: string, startDate?: string, endDate?: string) {
     return sofarSensor(
       sensorId,
@@ -10,5 +24,32 @@ export class SensorDataService {
       startDate,
       endDate,
     );
+  }
+
+  async getSensorInfo(siteId?: number, sensorId?: string, user?: User) {
+    if (!user) throw new UnauthorizedException('Unauthorized');
+
+    if ((!siteId && !sensorId) || (siteId && sensorId))
+      throw new BadRequestException('Provide one of siteId or sensorId');
+
+    const condition = siteId ? { id: siteId } : { sensorId };
+    const site = await this.siteRepository.findOne({
+      where: condition,
+      relations: ['admins'],
+    });
+
+    if (!site) throw new BadRequestException('Invalid siteId or sensorId');
+    if (
+      !site.admins.find((x) => x.id === user.id) &&
+      !(user.adminLevel === AdminLevel.SuperAdmin)
+    )
+      throw new ForbiddenException('Forbidden');
+    if (!site.sensorId)
+      throw new BadRequestException('No deployed spotter for this site');
+
+    return sofarLatest({
+      sensorId: site.sensorId,
+      token: process.env.SOFAR_API_TOKEN,
+    });
   }
 }

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -113,6 +113,7 @@ const NavBar = ({
             await new Promise((resolve) => setTimeout(resolve));
             handleSignInDialog(true);
           }
+          return Promise.reject(error);
         },
       );
 

--- a/packages/website/src/layout/App/index.tsx
+++ b/packages/website/src/layout/App/index.tsx
@@ -11,6 +11,7 @@ import { getAuth, onAuthStateChanged } from 'firebase/auth';
 import { getSelf } from 'store/User/userSlice';
 import { useGATagManager } from 'utils/google-analytics';
 import Uploads from 'routes/Uploads';
+import SpotterInfo from 'routes/SpotterInfo';
 import NotFound from '../../routes/NotFound';
 import ErrorBoundary from './ErrorBoundary';
 import LandingPage from '../../routes/Landing';
@@ -78,6 +79,7 @@ function App() {
                   path="/collections/:collectionName"
                   component={Dashboard}
                 />
+                <Route exact path="/spotter-info" component={SpotterInfo} />
                 <Route path="*" component={NotFound} />
               </Switch>
             )}

--- a/packages/website/src/routes/SpotterInfo/index.tsx
+++ b/packages/website/src/routes/SpotterInfo/index.tsx
@@ -1,0 +1,147 @@
+import {
+  Backdrop,
+  Button,
+  CircularProgress,
+  TextField,
+  Typography,
+} from '@material-ui/core';
+import { ToggleButton, ToggleButtonGroup } from '@material-ui/lab';
+import Footer from 'common/Footer';
+import NavBar from 'common/NavBar';
+import React from 'react';
+import { useSelector } from 'react-redux';
+import { userInfoSelector } from 'store/User/userSlice';
+import requests from 'helpers/requests';
+import siteServices from 'services/siteServices';
+import { useSnackbar } from 'notistack';
+
+type SearchMethod = 'siteId' | 'spotterId';
+
+function SpotterInfo() {
+  const { enqueueSnackbar } = useSnackbar();
+  const user = useSelector(userInfoSelector);
+
+  const [searchMethod, setSearchMethod] =
+    React.useState<SearchMethod>('siteId');
+  const [siteId, setSiteId] = React.useState<string>('');
+  const [sensorId, setSensorId] = React.useState<string>('');
+  const [loading, setLoading] = React.useState<boolean>(false);
+  const [result, setResult] = React.useState<any>(undefined);
+
+  function handleSearchMethod(
+    event: React.MouseEvent<HTMLElement>,
+    val: string | null,
+  ) {
+    if (val === null) return;
+    setSearchMethod(val as SearchMethod);
+  }
+
+  async function search() {
+    setResult(undefined);
+    const query = requests.generateUrlQueryParams(
+      searchMethod === 'siteId' ? { siteId } : { sensorId },
+    );
+
+    setLoading(true);
+    try {
+      const response = await siteServices.getSpotterInfo(
+        query,
+        user?.token || '',
+      );
+      if (!response) return;
+
+      const { data } = response;
+
+      const res = {
+        batteryPower: data.batteryPower,
+        batteryVoltage: data.batteryVoltage,
+        humidity: data.humidity,
+        payloadType: data.payloadType,
+        solarVoltage: data.solarVoltage,
+        spotterId: data.spotterId,
+        spotterName: data.spotterName,
+        location: {
+          latitude: data.track?.[0]?.latitude,
+          longitude: data.track?.[0]?.longitude,
+          timestamp: data.track?.[0]?.timestamp,
+        },
+      };
+      setResult(res);
+    } catch (error: any) {
+      enqueueSnackbar(error?.response?.data?.message || 'Request failed', {
+        variant: 'error',
+      });
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <>
+      <Backdrop open={loading}>
+        <CircularProgress color="inherit" />
+      </Backdrop>
+      <NavBar searchLocation={false} />
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'row' }}>
+        <div
+          style={{
+            padding: '1rem',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: '1rem',
+            width: '15rem',
+          }}
+        >
+          <div>
+            <Typography>Search with:</Typography>
+            <ToggleButtonGroup
+              exclusive
+              value={searchMethod}
+              onChange={(e, v) => handleSearchMethod(e, v)}
+            >
+              <ToggleButton value="siteId">Site ID</ToggleButton>
+              <ToggleButton value="spotterId">Spotter ID</ToggleButton>
+            </ToggleButtonGroup>
+          </div>
+
+          <div>
+            {searchMethod === 'siteId' ? (
+              <TextField
+                variant="outlined"
+                label="Site ID"
+                value={siteId}
+                onChange={(e) => setSiteId(e.target.value)}
+              />
+            ) : (
+              <TextField
+                variant="outlined"
+                label="Spotter ID"
+                value={sensorId}
+                onChange={(e) => setSensorId(e.target.value)}
+              />
+            )}
+          </div>
+
+          <Button color="primary" variant="outlined" onClick={() => search()}>
+            search
+          </Button>
+        </div>
+        <div style={{ padding: '1rem' }}>
+          {result && (
+            <code
+              style={{
+                whiteSpace: 'break-spaces',
+                overflowWrap: 'anywhere',
+              }}
+            >
+              {JSON.stringify(result, null, 2)}
+            </code>
+          )}
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+}
+
+export default SpotterInfo;

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -22,6 +22,7 @@ import {
   LatestData,
   SiteSketchFab,
   ForecastData,
+  SpotterInfoResponse,
 } from 'store/Sites/types';
 import requests from 'helpers/requests';
 import { constructTimeSeriesDataRequestUrl } from 'helpers/siteUtils';
@@ -221,6 +222,13 @@ const getOceanSenseData = ({
     method: 'GET',
   });
 
+const getSpotterInfo = (query: string, token?: string) =>
+  requests.send<SpotterInfoResponse>({
+    url: `sensor-data/info/${query}`,
+    method: 'GET',
+    token,
+  });
+
 export default {
   getSite,
   getSites,
@@ -243,4 +251,5 @@ export default {
   deploySpotter,
   maintainSpotter,
   getOceanSenseData,
+  getSpotterInfo,
 };

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -412,3 +412,18 @@ export interface SelectedSiteState {
   loadingSpotterPosition: number;
   error?: string | null;
 }
+
+export interface SpotterInfoResponse {
+  batteryPower: number;
+  batteryVoltage: number;
+  humidity: number;
+  payloadType: string;
+  solarVoltage: number;
+  spotterId: string;
+  spotterName: string;
+  track: Array<{
+    latitude: number;
+    longitude: number;
+    timestamp: string;
+  }>;
+}


### PR DESCRIPTION
resolve https://github.com/aqualinkorg/aqualink-app/issues/925

This PR adds a new simple page for accessing spotter health information. This new page can be found at `/spotter-info`

Also resolves a small bug where HTTP errors from request to our back-end would not propagate due to a newly added check for 401, 403 errors 

![Screenshot from 2023-09-28 17-48-03](https://github.com/aqualinkorg/aqualink-app/assets/80451946/229adcba-4bbc-476d-9ddc-cdd651fc2df0)
