### PR TITLE
Fix random region for new sites

### DIFF
--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -122,9 +122,13 @@ export class SitesService {
       siteId: site.id,
     });
 
+    const regionWarningMessage = site.region
+      ? 'Warning: No region for this site'
+      : '';
+
     const messageTemplate: SlackMessage = {
       channel: process.env.SLACK_BOT_CHANNEL as string,
-      text: `New site ${site.name} created with id=${site.id}, by ${user.fullName}`,
+      text: `New site ${site.name} created with id=${site.id}, by ${user.fullName}\n${regionWarningMessage}`,
       mrkdwn: true,
     };
 

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -123,7 +123,7 @@ export class SitesService {
     });
 
     const regionWarningMessage = site.region
-      ? '\nWarning: No region was found for this site, please ask devs to enter one manually.'
+      ? '\n:warning: *Warning*: No region was found for this site, please ask devs to enter one manually.'
       : '';
 
     const messageTemplate: SlackMessage = {

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -123,12 +123,12 @@ export class SitesService {
     });
 
     const regionWarningMessage = site.region
-      ? 'Warning: No region for this site'
+      ? '\nWarning: No region was found for this site, please ask devs to enter one manually.'
       : '';
 
     const messageTemplate: SlackMessage = {
       channel: process.env.SLACK_BOT_CHANNEL as string,
-      text: `New site ${site.name} created with id=${site.id}, by ${user.fullName}\n${regionWarningMessage}`,
+      text: `New site ${site.name} created with id=${site.id}, by ${user.fullName}${regionWarningMessage}`,
       mrkdwn: true,
     };
 

--- a/packages/api/src/utils/site.utils.ts
+++ b/packages/api/src/utils/site.utils.ts
@@ -295,7 +295,7 @@ export const createSite = async (
   regionRepository: Repository<Region>,
   sitesRepository: Repository<Site>,
   historicalMonthlyMeanRepository: Repository<HistoricalMonthlyMean>,
-) => {
+): Promise<Site> => {
   const region = await getRegion(longitude, latitude, regionRepository);
   const maxMonthlyMean = await getMMM(longitude, latitude);
   const historicalMonthlyMeans = await getHistoricalMonthlyMeans(

--- a/packages/api/src/utils/site.utils.ts
+++ b/packages/api/src/utils/site.utils.ts
@@ -82,7 +82,11 @@ export const getRegion = async (
   regionRepository: Repository<Region>,
 ) => {
   const country = await getGoogleRegion(longitude, latitude);
-  const region = await regionRepository.findOne({ where: { name: country } });
+  // undefined values would result in the first database item
+  // https://github.com/typeorm/typeorm/issues/2500
+  const region = country
+    ? await regionRepository.findOne({ where: { name: country } })
+    : null;
 
   if (region) {
     return region;


### PR DESCRIPTION
resolves https://github.com/aqualinkorg/aqualink-app/issues/937

In the case of new sites, if the `getGoogleRegion` function returned `undefined`, they would be automatically assigned to the first available region in the database.