### PR TITLE
Add info on register a site page

### DIFF
--- a/packages/website/src/routes/RegisterSite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/RegisterSite/__snapshots__/index.test.tsx.snap
@@ -196,7 +196,7 @@ exports[`Site registration page should render with given state from Redux store 
                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12"
                   >
                     <mock-typography>
-                      Location: Select point on map
+                      Location: Select a coastal point on the map in the ocean or sea. Land or lakes are not allowed.
                     </mock-typography>
                   </div>
                   <div

--- a/packages/website/src/routes/RegisterSite/index.tsx
+++ b/packages/website/src/routes/RegisterSite/index.tsx
@@ -249,7 +249,7 @@ const Apply = ({ classes }: ApplyProps) => {
                         ))}
 
                         <Grid item xs={12}>
-                          <Typography>Location: Select point on map</Typography>
+                          <Typography>Location: Select a coastal point on the map in the ocean or sea. Land or lakes are not allowed.</Typography>
                         </Grid>
 
                         {locationFormElements.map(({ id, label }) => (


### PR DESCRIPTION
Changed text on the register a site page from "Location: Select point on map" to "Location: Select a coastal point on the map in the ocean or sea. Land or lakes are not allowed."

I've realized that many of the newly created sites are not registered properly. Many are located on land or in the middle of the ocean. I'm guessing that many of these people are not familiar with the Aqualink program. A quick fix would be to change the text from "Location: Select point on map" to "Location: Select a coastal point on the map in the ocean or sea. Land or lakes are not allowed."

I'll make the changes in a new branch and wait for confirmation in the new PR before merging.