### PR TITLE
Add Reef Check entities

### DIFF
--- a/packages/api/migration/1731505574037-AddReefCheckData.ts
+++ b/packages/api/migration/1731505574037-AddReefCheckData.ts
@@ -1,0 +1,75 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReefCheckData1731505574037 implements MigrationInterface {
+  name = 'AddReefCheckData1731505574037';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE TABLE "reef_check_site" ("id" character varying NOT NULL, "site_id" integer NOT NULL, "reef_name" character varying, "orientation" character varying, "country" character varying, "state_province_island" character varying, "city_town" character varying, "region" character varying, "distance_from_shore" double precision, "distance_from_nearest_river" double precision, "distance_to_nearest_popn" double precision, CONSTRAINT "REL_228715834910cd57948e2d2dbd" UNIQUE ("site_id"), CONSTRAINT "PK_aeaf0fabffa46cfae6ae194864a" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_228715834910cd57948e2d2dbd" ON "reef_check_site" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "reef_check_organism" ("id" SERIAL NOT NULL, "survey_id" character varying NOT NULL, "date" TIMESTAMP NOT NULL, "organism" character varying NOT NULL, "type" character varying NOT NULL, "s1" integer NOT NULL, "s2" integer NOT NULL, "s3" integer NOT NULL, "s4" integer NOT NULL, "recorded_by" character varying, "errors" character varying, CONSTRAINT "PK_4d7d6080278505518ae5ec6cc6d" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "reef_check_survey" ("id" character varying NOT NULL, "site_id" integer NOT NULL, "reef_check_site_id" character varying NOT NULL, "date" TIMESTAMP, "errors" character varying, "depth" double precision, "time_of_day_work_began" character varying, "time_of_day_work_ended" character varying, "method_used_to_determine_location" character varying, "river_mouth_width" character varying, "weather" character varying, "air_temp" double precision NOT NULL, "water_temp_at_surface" double precision NOT NULL, "water_temp_at3_m" double precision NOT NULL, "water_temp_at10_m" double precision NOT NULL, "approx_popn_size_x1000" double precision NOT NULL, "horizontal_visibility_in_water" double precision NOT NULL, "best_reef_area" character varying, "why_was_this_site_selected" character varying, "sheltered_or_exposed" character varying, "any_major_storms_in_last_years" character varying, "when_storms" character varying, "overall_anthro_impact" character varying, "what_kind_of_impacts" character varying, "siltation" character varying, "dynamite_fishing" character varying, "poison_fishing" character varying, "aquarium_fish_collection" character varying, "harvest_of_inverts_for_food" character varying, "harvest_of_inverts_for_curio" character varying, "tourist_diving_snorkeling" character varying, "sewage_pollution" character varying, "industrial_pollution" character varying, "commercial_fishing" character varying, "live_food_fishing" character varying, "artisinal_recreational" character varying, "other_forms_of_fishing" character varying, "other_fishing" character varying, "yachts" character varying, "level_of_other_impacts" character varying, "other_impacts" character varying, "is_site_protected" character varying, "is_protection_enforced" character varying, "level_of_poaching" character varying, "spearfishing" character varying, "banned_commercial_fishing" character varying, "recreational_fishing" character varying, "invertebrate_shell_collection" character varying, "anchoring" character varying, "diving" character varying, "other_specify" character varying, "nature_of_protection" character varying, "site_comments" character varying, "substrate_comments" character varying, "fish_comments" character varying, "inverts_comments" character varying, "comments_from_organism_sheet" character varying, "grouper_size" character varying, "percent_bleaching" character varying, "percent_colonies_bleached" character varying, "percent_of_each_colony" character varying, "suspected_disease" character varying, "rare_animals_details" character varying, "submitted_by" character varying, CONSTRAINT "PK_03c9040735ab24413d06fa712d3" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_95fa2c48153ed166716efe3c23" ON "reef_check_survey" ("site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE INDEX "IDX_76957dc5cc44f8ac4aac53323f" ON "reef_check_survey" ("reef_check_site_id") `,
+    );
+    await queryRunner.query(
+      `CREATE TABLE "reef_check_substrate" ("id" SERIAL NOT NULL, "survey_id" character varying NOT NULL, "date" TIMESTAMP NOT NULL, "substrate_code" character varying NOT NULL, "s1" integer NOT NULL, "s2" integer NOT NULL, "s3" integer NOT NULL, "s4" integer NOT NULL, "recorded_by" character varying, "errors" character varying, CONSTRAINT "PK_92e3ffa57ceea62932bbd8ab756" PRIMARY KEY ("id"))`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_site" ADD CONSTRAINT "FK_228715834910cd57948e2d2dbd6" FOREIGN KEY ("site_id") REFERENCES "site"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_organism" ADD CONSTRAINT "FK_d44cfc7847e4a645262d4d17009" FOREIGN KEY ("survey_id") REFERENCES "reef_check_survey"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" ADD CONSTRAINT "FK_95fa2c48153ed166716efe3c232" FOREIGN KEY ("site_id") REFERENCES "site"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" ADD CONSTRAINT "FK_76957dc5cc44f8ac4aac53323f3" FOREIGN KEY ("reef_check_site_id") REFERENCES "reef_check_site"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_substrate" ADD CONSTRAINT "FK_81130cf898971ab45fea245e679" FOREIGN KEY ("survey_id") REFERENCES "reef_check_survey"("id") ON DELETE NO ACTION ON UPDATE NO ACTION`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_substrate" DROP CONSTRAINT "FK_81130cf898971ab45fea245e679"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" DROP CONSTRAINT "FK_76957dc5cc44f8ac4aac53323f3"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" DROP CONSTRAINT "FK_95fa2c48153ed166716efe3c232"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_organism" DROP CONSTRAINT "FK_d44cfc7847e4a645262d4d17009"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_site" DROP CONSTRAINT "FK_228715834910cd57948e2d2dbd6"`,
+    );
+    await queryRunner.query(`DROP TABLE "reef_check_substrate"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_76957dc5cc44f8ac4aac53323f"`,
+    );
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_95fa2c48153ed166716efe3c23"`,
+    );
+    await queryRunner.query(`DROP TABLE "reef_check_survey"`);
+    await queryRunner.query(`DROP TABLE "reef_check_organism"`);
+    await queryRunner.query(
+      `DROP INDEX "public"."IDX_228715834910cd57948e2d2dbd"`,
+    );
+    await queryRunner.query(`DROP TABLE "reef_check_site"`);
+  }
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -62,7 +62,8 @@
     "resize-survey-images": "ts-node -r dotenv/config scripts/resize-survey-images.ts",
     "stormglass-csv": "ts-node -r dotenv/config scripts/generate-stormglass-csv.ts",
     "fill-noaa-nearest-point": "ts-node -r dotenv/config scripts/noaa-availability.ts",
-    "check-video-streams": "ts-node -r dotenv/config scripts/check-video-streams.ts"
+    "check-video-streams": "ts-node -r dotenv/config scripts/check-video-streams.ts",
+    "reef-check": "ts-node -r dotenv/config scripts/reef-check.ts"
   },
   "dependencies": {
     "@braintree/sanitize-url": "^7.0.1",
@@ -77,7 +78,6 @@
     "@nestjs/typeorm": "^9.0.1",
     "@turf/turf": "^6.5.0",
     "@types/bluebird": "^3.5.32",
-    "@types/node-xlsx": "^0.15.3",
     "axios": "^1.7.4",
     "axios-retry": "^3.8.1",
     "bluebird": "^3.7.2",
@@ -95,7 +95,7 @@
     "luxon": "^3.3.0",
     "md5-file": "^5.0.0",
     "multer": "^1.4.2",
-    "node-xlsx": "^0.17.2",
+    "node-xlsx": "^0.24.0",
     "objects-to-csv": "^1.3.6",
     "passport": "^0.6.0",
     "passport-custom": "^1.1.1",
@@ -118,6 +118,7 @@
     "@types/luxon": "^3.3.1",
     "@types/multer": "^1.4.3",
     "@types/node": "^18.16.16",
+    "@types/node-xlsx": "^0.21.0",
     "@types/passport": "^1.0.4",
     "@types/passport-strategy": "^0.2.35",
     "@types/sharp": "^0.30.4",

--- a/packages/api/scripts/reef-check.ts
+++ b/packages/api/scripts/reef-check.ts
@@ -1,0 +1,700 @@
+/* eslint-disable fp/no-mutating-methods */
+/* eslint-disable fp/no-mutation */
+import xlsx from 'node-xlsx';
+import { DataSource, DataSourceOptions } from 'typeorm';
+import { Logger } from '@nestjs/common';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { groupBy, keyBy, uniqWith } from 'lodash';
+import fs from 'fs';
+import { ReefCheckSubstrate } from '../src/reef-check-substrates/reef-check-substrates.entity';
+import { ReefCheckOrganism } from '../src/reef-check-organisms/reef-check-organisms.entity';
+import { ReefCheckSurvey } from '../src/reef-check-surveys/reef-check-surveys.entity';
+import { Site } from '../src/sites/sites.entity';
+import { ReefCheckSite } from '../src/reef-check-sites/reef-check-sites.entity';
+import { configService } from '../src/config/config.service';
+
+const logger = new Logger('reef-check');
+
+type Args = {
+  filePath: string;
+  dryRun?: boolean;
+};
+
+yargs(hideBin(process.argv))
+  .command(
+    'upload-sites',
+    'Upload sites from the xlsx file',
+    {
+      filePath: {
+        alias: 'f',
+        describe: 'Path to the xlsx file',
+        type: 'string',
+        demandOption: true,
+      },
+      dryRun: {
+        alias: 'd',
+        describe: 'Run the script without saving to the database',
+        type: 'boolean',
+        default: false,
+      },
+    },
+    uploadSites,
+  )
+  .command(
+    'upload-surveys',
+    'Upload surveys from the xlsx file',
+    {
+      filePath: {
+        alias: 'f',
+        describe: 'Path to the xlsx file',
+        type: 'string',
+        demandOption: true,
+      },
+    },
+    uploadSurveys,
+  )
+  .command(
+    'upload-organisms',
+    'Upload organisms from the xlsx file',
+    {
+      filePath: {
+        alias: 'f',
+        describe: 'Path to the xlsx file',
+        type: 'string',
+        demandOption: true,
+      },
+    },
+    uploadOrganisms,
+  )
+  .command(
+    'upload-substrates',
+    'Upload substrates from the xlsx file',
+    {
+      filePath: {
+        alias: 'f',
+        describe: 'Path to the xlsx file',
+        type: 'string',
+        demandOption: true,
+      },
+    },
+    uploadSubstrates,
+  )
+  .command(
+    'stats',
+    'Generate stats for the xlsx file',
+    {
+      filePath: {
+        alias: 'f',
+        describe: 'Path to the xlsx file',
+        type: 'string',
+        demandOption: true,
+      },
+    },
+    generateStats,
+  )
+  .scriptName('reef-check')
+  .version(false)
+  .help()
+  .demandCommand()
+  .parse();
+
+const beltFields = [
+  'site_id',
+  'survey_id',
+  'date',
+  'depth (m)',
+  'organism_code',
+  'type',
+  's1 (0-20m)',
+  's2 (25-45m)',
+  's3 (50-70m)',
+  's4 (75-95m)',
+  'fish_recorded_by',
+  'inverts_recorded_by',
+  'errors',
+  'what_errors',
+] as const;
+
+const siteDescriptionFields = [
+  'site_id',
+  'survey_id',
+  'reef_name',
+  'orientation_of_transect',
+  'coordinates_in_decimal_degree_format',
+  'country',
+  'state_province_island',
+  'city_town',
+  'region',
+  'distance_from_shore (m)',
+  'distance_from_nearest_river (km)',
+  'distance_to_nearest_popn (km)',
+  'errors',
+  'what_errors',
+  'year',
+  'date',
+  'depth (m)',
+  'time_of_day_work_began',
+  'time_of_day_work_ended',
+  'method_used_to_determine_location (archived field)',
+  'river_mouth_width',
+  'weather',
+  'air_temp (C)',
+  'water_temp_at_surface (C)',
+  'water_temp_at_3_m (C)',
+  'water_temp_at_10_m (C)',
+  'approx_popn_size_x_1000',
+  'horizontal_visibility_in_water (m)',
+  'best_reef_area',
+  'why_was_this_site_selected',
+  'sheltered_or_exposed',
+  'any_major_storms_in_last_years',
+  'when_storms',
+  'overall_anthro_impact',
+  'what_kind_of_impacts (archived field)',
+  'siltation',
+  'dynamite_fishing',
+  'poison_fishing',
+  'aquarium_fish_collection',
+  'harvest_of_inverts_for_food',
+  'harvest_of_inverts_for_curio',
+  'tourist_diving_snorkeling',
+  'sewage_pollution',
+  'industrial_pollution',
+  'commercial_fishing',
+  'live_food_fishing',
+  'artisinal_recreational',
+  'other_forms_of_fishing (archived field)',
+  'other_fishing (archived field)',
+  'yachts',
+  'level_of_other_impacts (archived field)',
+  'other_impacts',
+  'is_site_protected',
+  'is_protection_enforced',
+  'level_of_poaching',
+  'spearfishing',
+  'banned_commercial_fishing',
+  'recreational_fishing',
+  'invertebrate_shell_collection',
+  'anchoring',
+  'diving',
+  'other_specify',
+  'nature_of_protection (archived field)',
+  'site_comments',
+  'substrate_comments',
+  'fish_comments',
+  'inverts_comments',
+  'comments_from_organism_sheet (archived field)',
+  'grouper_size (archived field)',
+  'percent_bleaching (archived field)',
+  'percent_colonies_bleached (archived field)',
+  'percent_of_each_colony (archived field)',
+  'suspected_disease (archived field)',
+  'rare_animals_details',
+  'submitted_by (archived field)',
+] as const;
+
+const substratesFields = [
+  'survey_id',
+  'date',
+  'substrate_code',
+  'segment_code',
+  'total',
+  'substrate_recorded_by',
+  'what_errors',
+] as const;
+
+function parseFile<T extends string>(filePath: string, fields: T[]) {
+  const workbook = xlsx.parse(filePath, { raw: false });
+  const sheet = workbook[0].data as string[][];
+
+  if (sheet.length === 0) {
+    throw new Error('Empty file or failed to load file');
+  }
+  const header = sheet[0];
+  const fieldIndicesMap = fields.reduce((acc, field) => {
+    acc[field] = header.indexOf(field);
+    if (acc[field] === -1) {
+      throw new Error(`Field not found: ${field}`);
+    }
+    return acc;
+  }, {} as Record<T, number>);
+
+  const getField = (row: string[], field: T) => row[fieldIndicesMap[field]];
+
+  return {
+    rows: sheet.slice(1),
+    getField,
+    header,
+    sheetRowCount: sheet.length,
+  };
+}
+
+async function uploadSites({ filePath, dryRun }: Args) {
+  logger.log(`Processing file: ${filePath}, dryRun: ${dryRun}`);
+
+  // Initialize typeorm connection
+  const config = configService.getTypeOrmConfig() as DataSourceOptions;
+  const dataSource = new DataSource(config);
+  const connection = await dataSource.initialize();
+
+  const { rows, getField } = parseFile(filePath, [...siteDescriptionFields]);
+
+  const siteRepository = connection.getRepository(Site);
+  const reefCheckSiteRepository = connection.getRepository(ReefCheckSite);
+  let errors = 0;
+
+  await uniqWith(
+    rows,
+    (val, otherVal) =>
+      getField(val, 'site_id') === getField(otherVal, 'site_id'),
+  ).reduce(async (prevPromise, row) => {
+    await prevPromise;
+    const siteId = getField(row, 'site_id');
+    const siteName = getField(row, 'reef_name');
+    const rawCoordinates = getField(
+      row,
+      'coordinates_in_decimal_degree_format',
+    );
+    logger.debug(`Processing row: ${siteId}, ${siteName}, ${rawCoordinates}`);
+
+    const [latitude, longitude] = rawCoordinates.split(',').map(parseFloat);
+
+    if (Number.isNaN(latitude) || Number.isNaN(longitude)) {
+      logger.error(
+        `Invalid coordinates: ${latitude}, ${longitude}, for site ${siteName}, ${siteId}`,
+      );
+      return;
+    }
+    try {
+      const closeSiteWithin100m = await siteRepository
+        .createQueryBuilder('site')
+        .where(
+          `ST_DistanceSphere(ST_GeomFromText('POINT(${longitude} ${latitude})', 4326), site.polygon) <= 100`,
+        )
+        .getOne();
+
+      if (dryRun) {
+        logger.log(
+          `Dry run: ${
+            closeSiteWithin100m ? 'Update' : 'Create'
+          } site: ${siteName} (${
+            closeSiteWithin100m?.id
+          }), ${latitude}, ${longitude}`,
+        );
+      } else {
+        // Create new site
+        const newReefCheckSite = new ReefCheckSite();
+
+        if (closeSiteWithin100m) {
+          newReefCheckSite.siteId = closeSiteWithin100m.id;
+        } else {
+          const newSite = new Site();
+          newSite.name = siteName;
+          newSite.polygon = {
+            type: 'Point',
+            coordinates: [longitude, latitude],
+          };
+          newReefCheckSite.siteId = (await siteRepository.save(newSite)).id;
+        }
+
+        newReefCheckSite.id = siteId;
+        newReefCheckSite.reefName = getField(row, 'reef_name');
+        newReefCheckSite.orientation = getField(row, 'orientation_of_transect');
+        newReefCheckSite.country = getField(row, 'country');
+        newReefCheckSite.stateProvinceIsland = getField(
+          row,
+          'state_province_island',
+        );
+        newReefCheckSite.cityTown = getField(row, 'city_town');
+        newReefCheckSite.region = getField(row, 'region');
+        newReefCheckSite.distanceFromShore = parseFloat(
+          getField(row, 'distance_from_shore (m)'),
+        );
+        newReefCheckSite.distanceFromNearestRiver = parseFloat(
+          getField(row, 'distance_from_nearest_river (km)'),
+        );
+        newReefCheckSite.distanceToNearestPopn = parseFloat(
+          getField(row, 'distance_to_nearest_popn (km)'),
+        );
+        await reefCheckSiteRepository.save(newReefCheckSite);
+      }
+    } catch (err) {
+      logger.error(
+        `Error processing row: ${siteId}, ${siteName}, ${rawCoordinates}`,
+        err,
+      );
+      errors += 1;
+    }
+  }, Promise.resolve());
+
+  logger.log(`Completed with ${errors} errors.`);
+  await connection.destroy();
+}
+
+async function uploadSurveys({ filePath, dryRun }: Args) {
+  logger.log(`Processing file: ${filePath}, dryRun: ${dryRun}`);
+
+  // Initialize typeorm connection
+  const config = configService.getTypeOrmConfig() as DataSourceOptions;
+  const dataSource = new DataSource(config);
+  const connection = await dataSource.initialize();
+  const reefCheckSurveyRepository = connection.getRepository(ReefCheckSurvey);
+  const reefCheckSiteRepository = connection.getRepository(ReefCheckSite);
+
+  const { rows, getField } = parseFile(filePath, [...siteDescriptionFields]);
+
+  logger.log(`Processing ${rows.length} surveys`);
+
+  const reefCheckSites = await reefCheckSiteRepository.find({
+    select: ['id', 'siteId'],
+  });
+  const reefCheckSiteIdToSiteIdMap = new Map<string, number>();
+  reefCheckSites.forEach((reefCheckSite) => {
+    reefCheckSiteIdToSiteIdMap.set(reefCheckSite.id, reefCheckSite.siteId);
+  });
+  logger.log(`Total reef check sites loaded: ${reefCheckSites.length}`);
+
+  const surveys: Omit<ReefCheckSurvey, 'site' | 'reefCheckSite'>[] = rows
+    .map((row) => {
+      const date = new Date(
+        `${getField(row, 'date')} ${
+          getField(row, 'time_of_day_work_began') ?? ''
+        }`,
+      );
+      const siteId = reefCheckSiteIdToSiteIdMap.get(getField(row, 'site_id'));
+      if (Number.isNaN(date.valueOf()) || !siteId) {
+        return null;
+      }
+      return {
+        id: getField(row, 'survey_id'),
+        siteId,
+        reefCheckSiteId: getField(row, 'site_id'),
+        errors: getField(row, 'errors'),
+        date,
+        depth: parseFloat(getField(row, 'depth (m)')),
+        timeOfDayWorkBegan: getField(row, 'time_of_day_work_began'),
+        timeOfDayWorkEnded: getField(row, 'time_of_day_work_ended'),
+        methodUsedToDetermineLocation: getField(
+          row,
+          'method_used_to_determine_location (archived field)',
+        ),
+        riverMouthWidth: getField(row, 'river_mouth_width'),
+        weather: getField(row, 'weather'),
+        airTemp: parseFloat(getField(row, 'air_temp (C)')),
+        waterTempAtSurface: parseFloat(
+          getField(row, 'water_temp_at_surface (C)'),
+        ),
+        waterTempAt3M: parseFloat(getField(row, 'water_temp_at_3_m (C)')),
+        waterTempAt10M: parseFloat(getField(row, 'water_temp_at_10_m (C)')),
+        approxPopnSizeX1000: parseFloat(
+          getField(row, 'approx_popn_size_x_1000'),
+        ),
+        horizontalVisibilityInWater: parseFloat(
+          getField(row, 'horizontal_visibility_in_water (m)'),
+        ),
+        bestReefArea: getField(row, 'best_reef_area'),
+        whyWasThisSiteSelected: getField(row, 'why_was_this_site_selected'),
+        shelteredOrExposed: getField(row, 'sheltered_or_exposed'),
+        anyMajorStormsInLastYears: getField(
+          row,
+          'any_major_storms_in_last_years',
+        ),
+        whenStorms: getField(row, 'when_storms'),
+        overallAnthroImpact: getField(row, 'overall_anthro_impact'),
+        whatKindOfImpacts: getField(
+          row,
+          'what_kind_of_impacts (archived field)',
+        ),
+        siltation: getField(row, 'siltation'),
+        dynamiteFishing: getField(row, 'dynamite_fishing'),
+        poisonFishing: getField(row, 'poison_fishing'),
+        aquariumFishCollection: getField(row, 'aquarium_fish_collection'),
+        harvestOfInvertsForFood: getField(row, 'harvest_of_inverts_for_food'),
+        harvestOfInvertsForCurio: getField(row, 'harvest_of_inverts_for_curio'),
+        touristDivingSnorkeling: getField(row, 'tourist_diving_snorkeling'),
+        sewagePollution: getField(row, 'sewage_pollution'),
+        industrialPollution: getField(row, 'industrial_pollution'),
+        commercialFishing: getField(row, 'commercial_fishing'),
+        liveFoodFishing: getField(row, 'live_food_fishing'),
+        artisinalRecreational: getField(row, 'artisinal_recreational'),
+        otherFormsOfFishing: getField(
+          row,
+          'other_forms_of_fishing (archived field)',
+        ),
+        otherFishing: getField(row, 'other_fishing (archived field)'),
+        yachts: getField(row, 'yachts'),
+        levelOfOtherImpacts: getField(
+          row,
+          'level_of_other_impacts (archived field)',
+        ),
+        otherImpacts: getField(row, 'other_impacts'),
+        isSiteProtected: getField(row, 'is_site_protected'),
+        isProtectionEnforced: getField(row, 'is_protection_enforced'),
+        levelOfPoaching: getField(row, 'level_of_poaching'),
+        spearfishing: getField(row, 'spearfishing'),
+        bannedCommercialFishing: getField(row, 'banned_commercial_fishing'),
+        recreationalFishing: getField(row, 'recreational_fishing'),
+        invertebrateShellCollection: getField(
+          row,
+          'invertebrate_shell_collection',
+        ),
+        anchoring: getField(row, 'anchoring'),
+        diving: getField(row, 'diving'),
+        otherSpecify: getField(row, 'other_specify'),
+        natureOfProtection: getField(
+          row,
+          'nature_of_protection (archived field)',
+        ),
+        siteComments: getField(row, 'site_comments'),
+        substrateComments: getField(row, 'substrate_comments'),
+        fishComments: getField(row, 'fish_comments'),
+        invertsComments: getField(row, 'inverts_comments'),
+        commentsFromOrganismSheet: getField(
+          row,
+          'comments_from_organism_sheet (archived field)',
+        ),
+        grouperSize: getField(row, 'grouper_size (archived field)'),
+        percentBleaching: getField(row, 'percent_bleaching (archived field)'),
+        percentColoniesBleached: getField(
+          row,
+          'percent_colonies_bleached (archived field)',
+        ),
+        percentOfEachColony: getField(
+          row,
+          'percent_of_each_colony (archived field)',
+        ),
+        suspectedDisease: getField(row, 'suspected_disease (archived field)'),
+        rareAnimalsDetails: getField(row, 'rare_animals_details'),
+        submittedBy: getField(row, 'submitted_by (archived field)'),
+      };
+    })
+    .filter((survey): survey is ReefCheckSurvey => survey !== null);
+
+  logger.log(`Inserting ${surveys.length} surveys`);
+  try {
+    const result = await reefCheckSurveyRepository.save(surveys, {
+      chunk: 100,
+    });
+
+    logger.log(`Inserted ${result.length} surveys`);
+  } catch (err) {
+    logger.error('Error inserting surveys', err);
+  }
+}
+
+async function uploadOrganisms({ filePath }: Args) {
+  logger.log(`Processing file: ${filePath}`);
+
+  // Initialize typeorm connection
+  const config = configService.getTypeOrmConfig() as DataSourceOptions;
+  const dataSource = new DataSource(config);
+  const connection = await dataSource.initialize();
+  const reefCheckOrganismRepository =
+    connection.getRepository(ReefCheckOrganism);
+  const reefCheckSurveyRepository = connection.getRepository(ReefCheckSurvey);
+
+  const surveys = await reefCheckSurveyRepository.find({ select: ['id'] });
+  const surveysMap = keyBy(surveys, 'id');
+  const { rows, getField } = parseFile(filePath, [...beltFields]);
+
+  const parseIntOrZero = (str: string | undefined) => {
+    const v = parseInt(str || '0', 10);
+    return Number.isNaN(v) ? 0 : v;
+  };
+
+  logger.log(`Processing ${rows.length} rows`);
+
+  const organisms: Omit<ReefCheckOrganism, 'id' | 'survey'>[] = rows
+    .map((row) => ({
+      surveyId: getField(row, 'survey_id'),
+      date: new Date(getField(row, 'date')),
+      organism: getField(row, 'organism_code'),
+      type: getField(row, 'type'),
+      s1: parseIntOrZero(getField(row, 's1 (0-20m)')),
+      s2: parseIntOrZero(getField(row, 's2 (25-45m)')),
+      s3: parseIntOrZero(getField(row, 's3 (50-70m)')),
+      s4: parseIntOrZero(getField(row, 's4 (75-95m)')),
+      recordedBy: getField(row, 'fish_recorded_by'),
+      errors: getField(row, 'what_errors'),
+    }))
+    .filter(({ surveyId }) => surveysMap[surveyId]);
+
+  logger.log(`Inserting ${organisms.length} reef check organisms`);
+  try {
+    const result = await reefCheckOrganismRepository.save(organisms, {
+      chunk: 100,
+    });
+
+    logger.log(`Inserted ${result.length} organisms`);
+  } catch (err) {
+    logger.error('Error inserting organisms', err);
+  }
+}
+
+async function uploadSubstrates({ filePath }: Args) {
+  logger.log(`Processing file: ${filePath}`);
+
+  // Initialize typeorm connection
+  const config = configService.getTypeOrmConfig() as DataSourceOptions;
+  const dataSource = new DataSource(config);
+  const connection = await dataSource.initialize();
+  const reefCheckSubstrateRepository =
+    connection.getRepository(ReefCheckSubstrate);
+  const reefCheckSurveyRepository = connection.getRepository(ReefCheckSurvey);
+
+  const surveys = await reefCheckSurveyRepository.find({ select: ['id'] });
+  const surveysMap = keyBy(surveys, 'id');
+
+  const { rows, getField } = parseFile(filePath, [...substratesFields]);
+
+  logger.log(`Processing ${rows.length} rows`);
+
+  const groupedRows = groupBy(
+    rows,
+    (row) => `${getField(row, 'survey_id')}-${getField(row, 'substrate_code')}`,
+  );
+
+  const substrates: Omit<ReefCheckSubstrate, 'id' | 'survey'>[] = Object.values(
+    groupedRows,
+  )
+    .map((group) => {
+      const row = group[0];
+      const metrics = group.reduce(
+        (acc, item) => {
+          const segment = getField(item, 'segment_code');
+          const total = parseInt(getField(item, 'total') || '0', 10);
+          if (Number.isNaN(total)) {
+            // skip
+          } else if (segment === 'S1') {
+            acc.s1 = total;
+          } else if (segment === 'S2') {
+            acc.s2 = total;
+          } else if (segment === 'S3') {
+            acc.s3 = total;
+          } else if (segment === 'S4') {
+            acc.s4 = total;
+          }
+          return acc;
+        },
+        { s1: 0, s2: 0, s3: 0, s4: 0 },
+      );
+      return {
+        surveyId: getField(row, 'survey_id'),
+        date: new Date(getField(row, 'date')),
+        substrateCode: getField(row, 'substrate_code'),
+        type: getField(row, 'segment_code'),
+        ...metrics,
+        recordedBy: getField(row, 'substrate_recorded_by'),
+        errors: getField(row, 'what_errors'),
+      };
+    })
+    .filter(({ surveyId }) => surveysMap[surveyId]);
+
+  logger.log(`Inserting ${substrates.length} reef check substrates`);
+  try {
+    const result = await reefCheckSubstrateRepository.save(substrates, {
+      chunk: 100,
+    });
+
+    logger.log(`Inserted ${result.length} substrates`);
+  } catch (err) {
+    logger.error('Error inserting substrates', err);
+  }
+}
+
+function generateStats({ filePath }: Args) {
+  const { rows, header, sheetRowCount, getField } = parseFile(filePath, [
+    ...siteDescriptionFields,
+  ]);
+  const calculateDistance = (
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+  ) => {
+    const toRad = (value: number) => (value * Math.PI) / 180;
+    const R = 6371; // Radius of the Earth in km
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a =
+      Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+      Math.cos(toRad(lat1)) *
+        Math.cos(toRad(lat2)) *
+        Math.sin(dLon / 2) *
+        Math.sin(dLon / 2);
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c; // Distance in km
+  };
+
+  let minDistance = Infinity;
+  const dups: Record<string, string[][]> = {};
+  const closeSites: string[][] = [];
+  // eslint-disable-next-line no-plusplus
+  for (let i = 0; i < rows.length; i++) {
+    const rawCoordinates1 = getField(
+      rows[i],
+      'coordinates_in_decimal_degree_format',
+    );
+
+    const [lat1, lon1] = rawCoordinates1.split(',').map(parseFloat);
+    // eslint-disable-next-line no-plusplus
+    for (let j = i + 1; j < rows.length; j++) {
+      const rawCoordinates2 = getField(
+        rows[j],
+        'coordinates_in_decimal_degree_format',
+      );
+      const [lat2, lon2] = rawCoordinates2.split(',').map(parseFloat);
+      const distance = calculateDistance(lat1, lon1, lat2, lon2);
+      if (distance === 0) {
+        logger.error(
+          `Duplicate coordinates found: ${rawCoordinates1}, for sites ${rows[i][0]} and ${rows[j][0]}`,
+        );
+        dups[rawCoordinates1] = dups[rawCoordinates1] || [];
+        dups[rawCoordinates1].push(rows[i]);
+        dups[rawCoordinates1].push(rows[j]);
+
+        // eslint-disable-next-line no-continue
+        continue;
+      }
+      if (distance < 0.1 && distance !== 0) {
+        logger.error(
+          `Close coordinates found: ${distance} km, for sites ${rows[i][0]} and ${rows[j][0]}`,
+        );
+        closeSites.push(rows[i]);
+        closeSites.push(rows[j]);
+      }
+      if (distance < minDistance) {
+        minDistance = distance;
+        logger.log(
+          'Minimum distance updated:',
+          minDistance,
+          rawCoordinates1,
+          rawCoordinates2,
+        );
+      }
+    }
+  }
+
+  const getWorksheetRows = (rec: Record<string, string[][]>) =>
+    Object.values(rec).flatMap((arr) =>
+      uniqWith(arr, (v1, v2) => v1[0] === v2[0]),
+    );
+
+  const dupRows = [header, ...getWorksheetRows(dups)];
+  const closeRows = [header, ...closeSites];
+  const arrayBuffer = xlsx.build([
+    { name: 'Duplicates', data: dupRows, options: {} },
+    { name: 'Close distance', data: closeRows, options: {} },
+  ]);
+  fs.writeFileSync(
+    'duplicates.xlsx',
+    Buffer.from(arrayBuffer) as unknown as Uint8Array,
+  );
+
+  logger.log(`Total rows: ${sheetRowCount}`);
+  logger.log(`Total sites: ${rows.length}`);
+  logger.log(`Minimum distance between any two sites: ${minDistance} km`);
+  logger.log(`Number of duplicate coordinates found: ${dupRows.length}`);
+  logger.log(`Number of close coordinates (<100m) found: ${closeRows.length}`);
+}

--- a/packages/api/src/app.module.ts
+++ b/packages/api/src/app.module.ts
@@ -2,6 +2,8 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ScheduleModule } from '@nestjs/schedule';
 import { MonitoringModule } from 'monitoring/monitoring.module';
+import { ReefCheckSitesModule } from './reef-check-sites/reef-check-sites.module';
+import { ReefCheckSurveysModule } from './reef-check-surveys/reef-check-surveys.module';
 import { configService } from './config/config.service';
 import { SiteApplicationsModule } from './site-applications/site-applications.module';
 import { SitesModule } from './sites/sites.module';
@@ -46,6 +48,8 @@ import { SensorDataModule } from './sensor-data/sensor-data.module';
     WindWaveModule,
     SensorDataModule,
     MonitoringModule,
+    ReefCheckSitesModule,
+    ReefCheckSurveysModule,
   ],
   controllers: [AppController],
 })

--- a/packages/api/src/reef-check-organisms/reef-check-organisms.entity.ts
+++ b/packages/api/src/reef-check-organisms/reef-check-organisms.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { ReefCheckSurvey } from '../reef-check-surveys/reef-check-surveys.entity';
+
+@Entity()
+export class ReefCheckOrganism {
+  @ApiProperty()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ApiProperty()
+  @Column()
+  surveyId: string;
+
+  @ApiProperty()
+  @ManyToOne(() => ReefCheckSurvey, { nullable: false })
+  @JoinColumn()
+  survey: ReefCheckSurvey;
+
+  @ApiProperty()
+  @Column()
+  date: Date;
+
+  @ApiProperty()
+  @Column()
+  organism: string;
+
+  @ApiProperty()
+  @Column()
+  type: string;
+
+  @ApiProperty()
+  @Column()
+  s1: number;
+
+  @ApiProperty()
+  @Column()
+  s2: number;
+
+  @ApiProperty()
+  @Column()
+  s3: number;
+
+  @ApiProperty()
+  @Column()
+  s4: number;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  recordedBy: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  errors: string;
+}

--- a/packages/api/src/reef-check-sites/reef-check-sites.controller.ts
+++ b/packages/api/src/reef-check-sites/reef-check-sites.controller.ts
@@ -1,0 +1,21 @@
+import { Controller, Param, Get } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ReefCheckSitesService } from './reef-check-sites.service';
+import { Public } from '../auth/public.decorator';
+import { ApiNestNotFoundResponse } from '../docs/api-response';
+import { ReefCheckSite } from './reef-check-sites.entity';
+
+@ApiTags('Reef Check Sites')
+@Controller('reef-check-sites')
+export class ReefCheckSitesController {
+  constructor(private sitesService: ReefCheckSitesService) {}
+
+  @ApiNestNotFoundResponse('No reef check site was found with the specified id')
+  @ApiOperation({ summary: 'Returns specified reef check site' })
+  @ApiParam({ name: 'id', example: '12345678-abcd-efgh-12345678' })
+  @Public()
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<ReefCheckSite> {
+    return this.sitesService.findOne(id);
+  }
+}

--- a/packages/api/src/reef-check-sites/reef-check-sites.entity.ts
+++ b/packages/api/src/reef-check-sites/reef-check-sites.entity.ts
@@ -1,0 +1,63 @@
+import {
+  Entity,
+  Column,
+  Index,
+  JoinColumn,
+  PrimaryColumn,
+  OneToOne,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { Site } from '../sites/sites.entity';
+
+@Entity()
+export class ReefCheckSite {
+  @ApiProperty()
+  @PrimaryColumn()
+  id: string;
+
+  @ApiProperty()
+  @Column()
+  siteId: number;
+
+  @ApiProperty()
+  @OneToOne(() => Site, { nullable: false })
+  @JoinColumn({ name: 'site_id' })
+  @Index()
+  site: Site;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  reefName: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  orientation: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  country: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  stateProvinceIsland: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  cityTown: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  region: string;
+
+  @ApiProperty()
+  @Column('float', { nullable: true })
+  distanceFromShore: number;
+
+  @ApiProperty()
+  @Column('float', { nullable: true })
+  distanceFromNearestRiver: number;
+
+  @ApiProperty()
+  @Column('float', { nullable: true })
+  distanceToNearestPopn: number;
+}

--- a/packages/api/src/reef-check-sites/reef-check-sites.module.ts
+++ b/packages/api/src/reef-check-sites/reef-check-sites.module.ts
@@ -1,0 +1,12 @@
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { ReefCheckSitesController } from './reef-check-sites.controller';
+import { ReefCheckSite } from './reef-check-sites.entity';
+import { ReefCheckSitesService } from './reef-check-sites.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ReefCheckSite])],
+  providers: [ReefCheckSitesService],
+  controllers: [ReefCheckSitesController],
+})
+export class ReefCheckSitesModule {}

--- a/packages/api/src/reef-check-sites/reef-check-sites.service.ts
+++ b/packages/api/src/reef-check-sites/reef-check-sites.service.ts
@@ -1,0 +1,26 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReefCheckSite } from './reef-check-sites.entity';
+
+@Injectable()
+export class ReefCheckSitesService {
+  private readonly logger = new Logger(ReefCheckSitesService.name);
+
+  constructor(
+    @InjectRepository(ReefCheckSite)
+    private reefCheckRepository: Repository<ReefCheckSite>,
+  ) {}
+
+  async findOne(id: string): Promise<ReefCheckSite> {
+    const reefCheckSite = await this.reefCheckRepository.findOne({
+      where: { id },
+    });
+
+    if (!reefCheckSite) {
+      throw new NotFoundException(`No site was found with the specified id`);
+    }
+
+    return reefCheckSite;
+  }
+}

--- a/packages/api/src/reef-check-substrates/reef-check-substrates.entity.ts
+++ b/packages/api/src/reef-check-substrates/reef-check-substrates.entity.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { ReefCheckSurvey } from '../reef-check-surveys/reef-check-surveys.entity';
+
+@Entity()
+export class ReefCheckSubstrate {
+  @ApiProperty()
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ApiProperty()
+  @Column()
+  surveyId: string;
+
+  @ApiProperty()
+  @ManyToOne(() => ReefCheckSurvey, { nullable: false })
+  @JoinColumn()
+  survey: ReefCheckSurvey;
+
+  @ApiProperty()
+  @Column()
+  date: Date;
+
+  @ApiProperty()
+  @Column()
+  substrateCode: string;
+
+  @ApiProperty()
+  @Column()
+  s1: number;
+
+  @ApiProperty()
+  @Column()
+  s2: number;
+
+  @ApiProperty()
+  @Column()
+  s3: number;
+
+  @ApiProperty()
+  @Column()
+  s4: number;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  recordedBy: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  errors: string;
+}

--- a/packages/api/src/reef-check-surveys/reef-check-surveys.controller.ts
+++ b/packages/api/src/reef-check-surveys/reef-check-surveys.controller.ts
@@ -1,0 +1,33 @@
+import { Controller, Param, Get } from '@nestjs/common';
+import { ApiOperation, ApiParam, ApiTags } from '@nestjs/swagger';
+import { ReefCheckSurveysService } from './reef-check-surveys.service';
+import { Public } from '../auth/public.decorator';
+import { ApiNestNotFoundResponse } from '../docs/api-response';
+import { ReefCheckSurvey } from './reef-check-surveys.entity';
+
+@ApiTags('Reef Check Surveys')
+@Controller('reef-check-sites/:reefCheckSiteId/surveys')
+export class ReefCheckSurveysController {
+  constructor(private surveysService: ReefCheckSurveysService) {}
+
+  @ApiOperation({ summary: "Returns all reef check site's survey" })
+  @ApiParam({ name: 'reefCheckSiteId', example: '12345678-abcd-efgh-12345678' })
+  @Public()
+  @Get()
+  find(
+    @Param('reefCheckSiteId') reefCheckSiteId: string,
+  ): Promise<ReefCheckSurvey[]> {
+    return this.surveysService.find(reefCheckSiteId);
+  }
+
+  @ApiNestNotFoundResponse(
+    'No reef check survey was found with the specified id',
+  )
+  @ApiOperation({ summary: 'Returns specified reef check survey' })
+  @ApiParam({ name: 'id', example: '12345678-abcd-efgh-12345678' })
+  @Public()
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<ReefCheckSurvey> {
+    return this.surveysService.findOne(id);
+  }
+}

--- a/packages/api/src/reef-check-surveys/reef-check-surveys.entity.ts
+++ b/packages/api/src/reef-check-surveys/reef-check-surveys.entity.ts
@@ -1,0 +1,288 @@
+import {
+  Entity,
+  Column,
+  Index,
+  JoinColumn,
+  ManyToOne,
+  PrimaryColumn,
+  OneToMany,
+} from 'typeorm';
+import { ApiProperty } from '@nestjs/swagger';
+import { Site } from '../sites/sites.entity';
+import { ReefCheckSite } from '../reef-check-sites/reef-check-sites.entity';
+import { ReefCheckOrganism } from '../reef-check-organisms/reef-check-organisms.entity';
+
+@Entity()
+export class ReefCheckSurvey {
+  @ApiProperty()
+  @PrimaryColumn()
+  id: string;
+
+  @ApiProperty()
+  @Column()
+  siteId: number;
+
+  @ApiProperty()
+  @ManyToOne(() => Site, { nullable: false })
+  @JoinColumn({ name: 'site_id' })
+  @Index()
+  site: Site;
+
+  @ApiProperty()
+  @Column()
+  reefCheckSiteId: string;
+
+  @ApiProperty()
+  @ManyToOne(() => ReefCheckSite, { nullable: false })
+  @JoinColumn({ name: 'reef_check_site_id' })
+  @Index()
+  reefCheckSite: ReefCheckSite;
+
+  @ApiProperty()
+  @OneToMany(() => ReefCheckOrganism, (organism) => organism.surveyId)
+  organisms: ReefCheckOrganism[];
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  date: Date;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  errors: string;
+
+  @ApiProperty()
+  @Column('float', { nullable: true })
+  depth: number;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  timeOfDayWorkBegan: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  timeOfDayWorkEnded: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  methodUsedToDetermineLocation: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  riverMouthWidth: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  weather: string;
+
+  @ApiProperty()
+  @Column('float')
+  airTemp: number;
+
+  @ApiProperty()
+  @Column('float')
+  waterTempAtSurface: number;
+
+  @ApiProperty()
+  @Column('float')
+  waterTempAt3M: number;
+
+  @ApiProperty()
+  @Column('float')
+  waterTempAt10M: number;
+
+  @ApiProperty()
+  @Column('float')
+  approxPopnSizeX1000: number;
+
+  @ApiProperty()
+  @Column('float')
+  horizontalVisibilityInWater: number;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  bestReefArea: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  whyWasThisSiteSelected: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  shelteredOrExposed: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  anyMajorStormsInLastYears: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  whenStorms: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  overallAnthroImpact: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  whatKindOfImpacts: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  siltation: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  dynamiteFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  poisonFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  aquariumFishCollection: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  harvestOfInvertsForFood: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  harvestOfInvertsForCurio: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  touristDivingSnorkeling: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  sewagePollution: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  industrialPollution: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  commercialFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  liveFoodFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  artisinalRecreational: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  otherFormsOfFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  otherFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  yachts: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  levelOfOtherImpacts: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  otherImpacts: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  isSiteProtected: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  isProtectionEnforced: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  levelOfPoaching: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  spearfishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  bannedCommercialFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  recreationalFishing: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  invertebrateShellCollection: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  anchoring: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  diving: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  otherSpecify: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  natureOfProtection: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  siteComments: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  substrateComments: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  fishComments: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  invertsComments: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  commentsFromOrganismSheet: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  grouperSize: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  percentBleaching: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  percentColoniesBleached: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  percentOfEachColony: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  suspectedDisease: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  rareAnimalsDetails: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  submittedBy: string;
+}

--- a/packages/api/src/reef-check-surveys/reef-check-surveys.module.ts
+++ b/packages/api/src/reef-check-surveys/reef-check-surveys.module.ts
@@ -1,0 +1,12 @@
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Module } from '@nestjs/common';
+import { ReefCheckSurveysController } from './reef-check-surveys.controller';
+import { ReefCheckSurvey } from './reef-check-surveys.entity';
+import { ReefCheckSurveysService } from './reef-check-surveys.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([ReefCheckSurvey])],
+  providers: [ReefCheckSurveysService],
+  controllers: [ReefCheckSurveysController],
+})
+export class ReefCheckSurveysModule {}

--- a/packages/api/src/reef-check-surveys/reef-check-surveys.service.ts
+++ b/packages/api/src/reef-check-surveys/reef-check-surveys.service.ts
@@ -1,0 +1,34 @@
+import { Injectable, Logger, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReefCheckSurvey } from './reef-check-surveys.entity';
+
+@Injectable()
+export class ReefCheckSurveysService {
+  private readonly logger = new Logger(ReefCheckSurveysService.name);
+
+  constructor(
+    @InjectRepository(ReefCheckSurvey)
+    private reefCheckSurveyRepository: Repository<ReefCheckSurvey>,
+  ) {}
+
+  async find(reefCheckSiteId: string): Promise<ReefCheckSurvey[]> {
+    return this.reefCheckSurveyRepository.find({
+      where: { reefCheckSiteId },
+      relations: ['organisms'],
+    });
+  }
+
+  async findOne(id: string): Promise<ReefCheckSurvey> {
+    const reefCheckSurvey = await this.reefCheckSurveyRepository.findOne({
+      where: { id },
+      relations: ['organisms'],
+    });
+
+    if (!reefCheckSurvey) {
+      throw new NotFoundException(`No site was found with the specified id`);
+    }
+
+    return reefCheckSurvey;
+  }
+}

--- a/packages/api/src/sites/sites.entity.ts
+++ b/packages/api/src/sites/sites.entity.ts
@@ -18,6 +18,7 @@ import {
   ApiProperty,
   ApiPropertyOptional,
 } from '@nestjs/swagger';
+import { ReefCheckSurvey } from '../reef-check-surveys/reef-check-surveys.entity';
 import { SketchFab } from '../site-sketchfab/site-sketchfab.entity';
 import { Region } from '../regions/regions.entity';
 import { Survey } from '../surveys/surveys.entity';
@@ -130,6 +131,10 @@ export class Site {
   @ApiPropertyOptional()
   @OneToMany(() => Survey, (survey) => survey.site)
   surveys: Survey[];
+
+  @ApiPropertyOptional()
+  @OneToMany(() => ReefCheckSurvey, (reefCheckSurvey) => reefCheckSurvey.site)
+  reefCheckSurveys: ReefCheckSurvey[];
 
   @OneToOne(() => SiteApplication, (siteApplication) => siteApplication.site)
   siteApplication?: SiteApplication;

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -240,6 +240,7 @@ export class SitesService {
       id: site.id,
       name: site.name,
       sensorId: site.sensorId,
+      reefCheckSurveys: site.reefCheckSurveys ?? [],
       polygon: site.polygon,
       nearestNOAALocation: site.nearestNOAALocation,
       depth: site.depth,

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -7,6 +7,6 @@
     "noImplicitAny": false,
     "baseUrl": "./src"
   },
-  "include": ["src"],
+  "include": ["src", "scripts"],
   "files": ["src/custom.d.ts", "ormconfig.ts", "firebaseConfig.ts"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -5389,10 +5389,12 @@
   dependencies:
     "@types/express" "*"
 
-"@types/node-xlsx@^0.15.3":
-  version "0.15.3"
-  resolved "https://registry.yarnpkg.com/@types/node-xlsx/-/node-xlsx-0.15.3.tgz#675e5f91868b6c76c0bd3234fb84e4b55b807b1c"
-  integrity sha512-6UAa+t9eR3AZzRanZWGNUV8MoXwVpXQHMqCMdK8PNPwTy+G3kYHP+2KkTI+39vXETNb6krRijL+zWzmFrlfLjw==
+"@types/node-xlsx@^0.21.0":
+  version "0.21.0"
+  resolved "https://registry.yarnpkg.com/@types/node-xlsx/-/node-xlsx-0.21.0.tgz#51693f08b81c42deb8f556e3db7a41ebe441f923"
+  integrity sha512-2phXePog1DbnNWMpl0wEaH/4ABKOBfgp+0IWLFzVzKkaWwHKwT5HcKHZYvEVv/Tntr3xf4J98Syvz7aPUmU2wA==
+  dependencies:
+    node-xlsx "*"
 
 "@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
   version "20.2.3"
@@ -6061,19 +6063,6 @@ adjust-sourcemap-loader@^4.0.0:
   dependencies:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
-
-adler-32@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.2.0.tgz#6a3e6bf0a63900ba15652808cb15c6813d1a5f25"
-  integrity sha512-/vUqU/UY4MVeFsg+SsK6c+/05RZXIHZMGJA+PX5JyWI0ZRcBpupnRuPLU/NXXoFwMYCPCoxIfElM2eS+DUXCqQ==
-  dependencies:
-    exit-on-epipe "~1.0.1"
-    printj "~1.1.0"
-
-adler-32@~1.3.0:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/adler-32/-/adler-32-1.3.1.tgz#1dbf0b36dda0012189a32b3679061932df1821e2"
-  integrity sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"
@@ -7058,7 +7047,7 @@ buffer-equal-constant-time@1.0.1:
   resolved "https://registry.yarnpkg.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz#f8e71132f7ffe6e01a5c9697a4c6f3e48d5cc819"
   integrity sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==
 
-buffer-from@^1.0.0, buffer-from@^1.1.2:
+buffer-from@^1.0.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
   integrity sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==
@@ -7285,14 +7274,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
-
-cfb@^1.1.4:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/cfb/-/cfb-1.2.2.tgz#94e687628c700e5155436dac05f74e08df23bc44"
-  integrity sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==
-  dependencies:
-    adler-32 "~1.3.0"
-    crc-32 "~1.2.0"
 
 chalk@4.1.0:
   version "4.1.0"
@@ -7633,11 +7614,6 @@ coa@^2.0.2:
     "@types/q" "^1.5.1"
     chalk "^2.4.1"
     q "^1.1.2"
-
-codepage@~1.15.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/codepage/-/codepage-1.15.0.tgz#2e00519024b39424ec66eeb3ec07227e692618ab"
-  integrity sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==
 
 collect-v8-coverage@^1.0.0:
   version "1.0.1"
@@ -8124,7 +8100,7 @@ cosmiconfig@^7.0.0, cosmiconfig@^7.0.1:
     path-type "^4.0.0"
     yaml "^1.10.0"
 
-crc-32@^1.2.0, crc-32@~1.2.0:
+crc-32@^1.2.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/crc-32/-/crc-32-1.2.2.tgz#3cad35a934b8bf71f25ca524b6da51fb7eace2ff"
   integrity sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==
@@ -9998,11 +9974,6 @@ exegesis@^4.1.2:
     raw-body "^2.3.3"
     semver "^7.0.0"
 
-exit-on-epipe@~1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/exit-on-epipe/-/exit-on-epipe-1.0.1.tgz#0bdd92e87d5285d267daa8171d0eb06159689692"
-  integrity sha512-h2z5mrROTxce56S+pnvAV890uu7ls7f1kEvVGJbw1OlFH3/mlJ5bkXu0KRyW94v37zzHPiUd55iLn3DA7TjWpw==
-
 exit@^0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/exit/-/exit-0.1.2.tgz#0632638f8d877cc82107d30a0fff1a17cba1cd0c"
@@ -10669,11 +10640,6 @@ forwarded@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/forwarded/-/forwarded-0.2.0.tgz#2269936428aad4c15c7ebe9779a84bf0b2a81811"
   integrity sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==
-
-frac@~1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/frac/-/frac-1.1.2.tgz#3d74f7f6478c88a1b5020306d747dc6313c74d0b"
-  integrity sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==
 
 fraction.js@^4.2.0:
   version "4.2.0"
@@ -15159,14 +15125,12 @@ node-releases@^2.0.8:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-2.0.12.tgz#35627cc224a23bfb06fb3380f2b3afaaa7eb1039"
   integrity sha512-QzsYKWhXTWx8h1kIvqfnC++o0pEmpRQA/aenALsL2F4pqNVr7YzcdMlDij5WBnwftRbJCNJL/O7zdKaxKPHqgQ==
 
-node-xlsx@^0.17.2:
-  version "0.17.2"
-  resolved "https://registry.yarnpkg.com/node-xlsx/-/node-xlsx-0.17.2.tgz#286215afa63e096d5317a7cb0e5d599cfa1f7b62"
-  integrity sha512-j92dGS8KvGPi6YpYovHrR9zWiyDONx7DiGhl1SjM+vzxAh3do6hmerFCyN+hRuK7QhwHdwzfpYxZm+hKA/uErA==
+node-xlsx@*, node-xlsx@^0.24.0:
+  version "0.24.0"
+  resolved "https://registry.yarnpkg.com/node-xlsx/-/node-xlsx-0.24.0.tgz#a6a365acb18ad37c66c2b254b6ebe0c22dc9dc6f"
+  integrity sha512-1olwK48XK9nXZsyH/FCltvGrQYvXXZuxVitxXXv2GIuRm51aBi1+5KwR4rWM4KeO61sFU+00913WLZTD+AcXEg==
   dependencies:
-    "@babel/runtime" "^7.15.4"
-    buffer-from "^1.1.2"
-    xlsx "^0.17.2"
+    xlsx "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz"
 
 nodemon@^2.0.4:
   version "2.0.22"
@@ -17106,11 +17070,6 @@ pretty-format@^29.0.0, pretty-format@^29.7.0:
     "@jest/schemas" "^29.6.3"
     ansi-styles "^5.0.0"
     react-is "^18.0.0"
-
-printj@~1.1.0:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/printj/-/printj-1.1.2.tgz#d90deb2975a8b9f600fb3a1c94e3f4c53c78a222"
-  integrity sha512-zA2SmoLaxZyArQTOPj5LXecR+RagfPSU5Kw1qP+jkWeNlrq+eJZyY2oS68SU1Z/7/myXM4lo9716laOFAVStCQ==
 
 proc-log@^2.0.0, proc-log@^2.0.1:
   version "2.0.1"
@@ -19196,13 +19155,6 @@ sql-formatter@^15.3.0:
     get-stdin "=8.0.0"
     nearley "^2.20.1"
 
-ssf@~0.11.2:
-  version "0.11.2"
-  resolved "https://registry.yarnpkg.com/ssf/-/ssf-0.11.2.tgz#0b99698b237548d088fc43cdf2b70c1a7512c06c"
-  integrity sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==
-  dependencies:
-    frac "~1.1.2"
-
 sshpk@^1.7.0:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
@@ -21182,20 +21134,10 @@ winston@^3.0.0:
     triple-beam "^1.3.0"
     winston-transport "^4.5.0"
 
-wmf@~1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/wmf/-/wmf-1.0.2.tgz#7d19d621071a08c2bdc6b7e688a9c435298cc2da"
-  integrity sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==
-
 word-wrap@^1.2.3, word-wrap@~1.2.3:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.4.tgz#cb4b50ec9aca570abd1f52f33cd45b6c61739a9f"
   integrity sha512-2V81OA4ugVo5pRo46hAoD2ivUJx8jXmWXfUkY4KFNw0hEptvN0QfH3K4nHiwzGeKl5rFKedV48QVoqYavy4YpA==
-
-word@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/word/-/word-0.3.0.tgz#8542157e4f8e849f4a363a288992d47612db9961"
-  integrity sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==
 
 wordwrap@^1.0.0:
   version "1.0.0"
@@ -21491,18 +21433,9 @@ xdg-basedir@^4.0.0:
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
 
-xlsx@^0.17.2:
-  version "0.17.5"
-  resolved "https://registry.yarnpkg.com/xlsx/-/xlsx-0.17.5.tgz#78b788fcfc0773d126cdcd7ea069cb7527c1ce81"
-  integrity sha512-lXNU0TuYsvElzvtI6O7WIVb9Zar1XYw7Xb3VAx2wn8N/n0whBYrCnHMxtFyIiUU1Wjf09WzmLALDfBO5PqTb1g==
-  dependencies:
-    adler-32 "~1.2.0"
-    cfb "^1.1.4"
-    codepage "~1.15.0"
-    crc-32 "~1.2.0"
-    ssf "~0.11.2"
-    wmf "~1.0.1"
-    word "~0.3.0"
+"xlsx@https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz":
+  version "0.20.2"
+  resolved "https://cdn.sheetjs.com/xlsx-0.20.2/xlsx-0.20.2.tgz#0f64eeed3f1a46e64724620c3553f2dbd3cd2d7d"
 
 xml-name-validator@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Integrate provided Reef Check Data into Aqualink.

- Add Reef Check entities: `ReefCheckSite`, `ReefCheckSurvey`, `ReefCheckOrganism`, `ReefCheckSubstrate`
- Add script to parse the xlsx files and create the entities.
- Add basic api controllers for sites and surveys

![image](https://github.com/user-attachments/assets/b7d05b8d-1a52-4879-87e9-3d5f16626d8c)
