### PR TITLE
Update dates overlap logic 

### DIFF
--- a/packages/website/src/helpers/dates.ts
+++ b/packages/website/src/helpers/dates.ts
@@ -217,6 +217,7 @@ export const rangeOverlapWithRange = (
 ) => {
   return (
     (minDate2 <= minDate1 && minDate1 <= maxDate2) ||
-    (minDate2 <= maxDate1 && maxDate1 <= maxDate2)
+    (minDate2 <= maxDate1 && maxDate1 <= maxDate2) ||
+    (minDate1 <= maxDate2 && maxDate2 <= maxDate1)
   );
 };


### PR DESCRIPTION


## Issue

Fixes #1051 . Some charts in site page are disappearing when user changes the time range.

## Cause

We are hiding charts that do not have data within with the selected timeframe. The function (`rangeOverlapWithRange`) that checks if the ranges overlap was missing one case (case 4):

![image](https://github.com/user-attachments/assets/2387e753-a32b-4488-9da3-87ba67a021a5)

# Changes
- Updated the logic to cover all cases and verified the charts are not disappearing after changing the time range.