### PR TITLE
Add 200.html in surge deployment to fix routing

### DIFF
--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -61,6 +61,11 @@ jobs:
         working-directory: packages/website
         run: yarn build
 
+      - name: Create 200.html for surge deployment
+        if: steps.build_website.outcome == 'success' && github.event.pull_request.number != null
+        working-directory: packages/website
+        run: cp index.html 200.html
+
       - name: Deploy pull request on surge
         if: steps.build_website.outcome == 'success' && github.event.pull_request.number != null
         uses: dswistowski/surge-sh-action@v1

--- a/.github/workflows/build_website.yml
+++ b/.github/workflows/build_website.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Create 200.html for surge deployment
         if: steps.build_website.outcome == 'success' && github.event.pull_request.number != null
-        working-directory: packages/website
+        working-directory: packages/website/build
         run: cp index.html 200.html
 
       - name: Deploy pull request on surge

--- a/packages/website/src/index.tsx
+++ b/packages/website/src/index.tsx
@@ -17,8 +17,6 @@ import app from './firebase';
 import { setToken } from './store/User/userSlice';
 import { initGA } from './utils/google-analytics';
 
-// Comment to trigger GH action
-
 if (app) {
   const auth = getAuth(app);
   onAuthStateChanged(auth, (user) => {

--- a/packages/website/src/index.tsx
+++ b/packages/website/src/index.tsx
@@ -17,6 +17,8 @@ import app from './firebase';
 import { setToken } from './store/User/userSlice';
 import { initGA } from './utils/google-analytics';
 
+// Comment to trigger GH action
+
 if (app) {
   const auth = getAuth(app);
   onAuthStateChanged(auth, (user) => {


### PR DESCRIPTION
Fix routing for surge deployments (UI temp deployment for PR builds) by proving a 200.html as mentioned in the [docs](https://surge.sh/help/adding-a-200-page-for-client-side-routing).

We can now directly access specific pages and not only the home page (`/`)
-> https://aqualink-app-1079.surge.sh/sites/123