### PR TITLE
Use canvas marker for buoys

### DIFF
--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -43,6 +43,7 @@
     "geolib": "^3.3.4",
     "immutable": "^4.0.0-rc.12",
     "leaflet": "^1.7.1",
+    "leaflet-markers-canvas": "^0.2.2",
     "leaflet.locatecontrol": "^0.79.0",
     "lodash": "^4.17.15",
     "luxon": "^3.3.0",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -57,7 +57,6 @@
     "react-hook-form": "^7.41.5",
     "react-jwt": "^1.1.8",
     "react-leaflet": "^2.7.0",
-    "react-leaflet-markercluster": "^2.0.0",
     "react-material-ui-carousel": "3.4.2",
     "react-redux": "^7.2.0",
     "react-router-dom": "^6.0.0",

--- a/packages/website/src/custom.d.ts
+++ b/packages/website/src/custom.d.ts
@@ -11,6 +11,5 @@ declare module '*.css' {
   export = classNames;
 }
 
-declare module 'react-leaflet-markercluster';
 declare module 'react-swipeable-bottom-sheet';
 declare module '@sketchfab/viewer-api';

--- a/packages/website/src/layout/App/App.css
+++ b/packages/website/src/layout/App/App.css
@@ -123,6 +123,10 @@ iframe {
   border: 2px solid white;
 }
 
+.popup-offset {
+  margin-bottom: 30px;
+}
+
 @media screen and (max-width: 599px) {
   .mapbox-wordmark {
     bottom: 55px;

--- a/packages/website/src/routes/HomeMap/Map/Markers/CanvasMarkersLayer.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/CanvasMarkersLayer.tsx
@@ -1,0 +1,35 @@
+import L from 'leaflet';
+import 'leaflet-markers-canvas';
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import { useLeaflet } from 'react-leaflet';
+
+const CanvasIconLayerContext = createContext<L.LayerGroup | null>(null);
+export const useCanvasIconLayer = () => {
+  return useContext(CanvasIconLayerContext);
+};
+
+type CanvasMarkersLayerProps = {
+  children: React.ReactNode | React.ReactNode[];
+};
+export const CanvasMarkersLayer = ({ children }: CanvasMarkersLayerProps) => {
+  const { map } = useLeaflet();
+
+  const [canvasIconLayer, setCanvasIconLayer] = useState<L.LayerGroup | null>(
+    null,
+  );
+
+  useEffect(() => {
+    if (map && !canvasIconLayer) {
+      // @ts-ignore
+      const markersCanvas = new L.MarkersCanvas();
+      markersCanvas.addTo(map);
+      setCanvasIconLayer(markersCanvas);
+    }
+  }, [map, canvasIconLayer]);
+
+  return (
+    <CanvasIconLayerContext.Provider value={canvasIconLayer}>
+      {children}
+    </CanvasIconLayerContext.Provider>
+  );
+};

--- a/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
@@ -45,9 +45,9 @@ export const CircleSiteMarker = React.memo(({ site }: SiteMarkerProps) => {
           }}
           key={`${site.id}-${offset}`}
           color={alertColorFinder(tempWeeklyAlert)}
-          // icon={markerIcon}
+          fillOpacity={1}
           center={[lat, lng + offset]}
-          radius={8}
+          radius={5}
           data-alert={tempWeeklyAlert}
         >
           {isSelected && <Popup site={site} autoOpen={offset === 0} />}

--- a/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/SiteMarker.tsx
@@ -1,18 +1,18 @@
-import { Marker } from 'react-leaflet';
+import { CircleMarker, Marker } from 'react-leaflet';
 import { useDispatch, useSelector } from 'react-redux';
 import React from 'react';
 import { Site } from 'store/Sites/types';
 import {
-  setSiteOnMap,
-  setSearchResult,
   isSelectedOnMapSelector,
+  setSearchResult,
+  setSiteOnMap,
 } from 'store/Homepage/homepageSlice';
-import { useMarkerIcon } from 'helpers/map';
-import { hasDeployedSpotter } from 'helpers/siteUtils';
 import {
   alertColorFinder,
   alertIconFinder,
 } from 'helpers/bleachingAlertIntervals';
+import { useMarkerIcon } from 'helpers/map';
+import { hasDeployedSpotter } from 'helpers/siteUtils';
 import Popup from '../Popup';
 
 // To make sure we can see all the sites all the time, and especially
@@ -26,7 +26,38 @@ interface SiteMarkerProps {
 /**
  * All in one site marker with icon, offset duplicates, and popup built in.
  */
-export const SiteMarker = React.memo(({ site }: SiteMarkerProps) => {
+export const CircleSiteMarker = React.memo(({ site }: SiteMarkerProps) => {
+  const isSelected = useSelector(isSelectedOnMapSelector(site.id));
+  const dispatch = useDispatch();
+  const { tempWeeklyAlert } = site.collectionData || {};
+
+  if (site.polygon.type !== 'Point') return null;
+
+  const [lng, lat] = site.polygon.coordinates;
+
+  return (
+    <>
+      {LNG_OFFSETS.map((offset) => (
+        <CircleMarker
+          onclick={() => {
+            dispatch(setSearchResult());
+            dispatch(setSiteOnMap(site));
+          }}
+          key={`${site.id}-${offset}`}
+          color={alertColorFinder(tempWeeklyAlert)}
+          // icon={markerIcon}
+          center={[lat, lng + offset]}
+          radius={8}
+          data-alert={tempWeeklyAlert}
+        >
+          {isSelected && <Popup site={site} autoOpen={offset === 0} />}
+        </CircleMarker>
+      ))}
+    </>
+  );
+});
+
+export const SensorSiteMarker = React.memo(({ site }: SiteMarkerProps) => {
   const isSelected = useSelector(isSelectedOnMapSelector(site.id));
   const dispatch = useDispatch();
   const { tempWeeklyAlert } = site.collectionData || {};

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -1,31 +1,14 @@
 import { useSelector } from 'react-redux';
-import { useLeaflet } from 'react-leaflet';
-import MarkerClusterGroup from 'react-leaflet-markercluster';
-import React, { useEffect, useState, useMemo } from 'react';
-import L from 'leaflet';
+import React, { useMemo } from 'react';
 import { sitesToDisplayListSelector } from 'store/Sites/sitesListSlice';
 import { Site } from 'store/Sites/types';
 import 'leaflet/dist/leaflet.css';
 import 'react-leaflet-markercluster/dist/styles.min.css';
 import { CollectionDetails } from 'store/Collection/types';
-import { getColorByLevel } from 'helpers/bleachingAlertIntervals';
-import { countBy } from 'lodash';
-import { createDonutChart } from 'helpers/map';
-import { SiteMarker } from './SiteMarker';
+import { hasDeployedSpotter } from 'helpers/siteUtils';
+import { CircleSiteMarker, SensorSiteMarker } from './SiteMarker';
 
-const clusterIcon = (cluster: any) => {
-  const alertLevels: number[] = cluster
-    .getAllChildMarkers()
-    .map((marker: any) => marker?.options?.['data-alert'] ?? 0);
-  const alertToCountMap = countBy(alertLevels);
-  const counts = Object.values(alertToCountMap);
-  const colors = Object.keys(alertToCountMap).map((level) =>
-    getColorByLevel(parseInt(level, 10)),
-  );
-  return L.divIcon({
-    html: createDonutChart(counts, colors),
-  });
-};
+const hasSpotter = (site: Site) => site.hasHobo || hasDeployedSpotter(site);
 
 export const SiteMarkers = ({ collection }: SiteMarkersProps) => {
   const storedSites = useSelector(sitesToDisplayListSelector);
@@ -33,50 +16,17 @@ export const SiteMarkers = ({ collection }: SiteMarkersProps) => {
     () => collection?.sites || storedSites || [],
     [collection?.sites, storedSites],
   );
-  const { map } = useLeaflet();
-  const [visibleSitesMap, setVisibleSitesMap] = useState<
-    Record<string, boolean>
-  >({});
-
-  useEffect(() => {
-    // Incrementally mount visible site markers on map
-    // Avoid mounting all sites at once, mount only the visible ones and don't umount them
-
-    if (!map) return undefined;
-    const mountSitesInViewport = () => {
-      if (!map) return;
-      const bounds = map.getBounds();
-      const filtered: Record<string, boolean> = {};
-      sitesList.forEach((site: Site) => {
-        if (!site.polygon || site.polygon.type !== 'Point') return;
-        const [lng, lat] = site.polygon.coordinates;
-        if (bounds.contains([lat, lng])) {
-          // eslint-disable-next-line fp/no-mutation
-          filtered[site.id] = true;
-        }
-      });
-      // Keep the previous markers and add the new visible sites
-      setVisibleSitesMap((prev) => ({ ...prev, ...filtered }));
-    };
-
-    mountSitesInViewport();
-    map.on('moveend', mountSitesInViewport);
-
-    return () => {
-      map.off('moveend', mountSitesInViewport);
-      return undefined;
-    };
-  }, [map, sitesList]);
 
   return (
-    <MarkerClusterGroup iconCreateFunction={clusterIcon}>
-      {sitesList.map(
-        (site: Site) =>
-          visibleSitesMap[site.id] && (
-            <SiteMarker key={`${site.id}`} site={site} />
-          ),
+    <>
+      {sitesList.map((site: Site) =>
+        sitesList[site.id] && hasSpotter(site) ? (
+          <SensorSiteMarker key={`${site.id}`} site={site} />
+        ) : (
+          <CircleSiteMarker key={`${site.id}`} site={site} />
+        ),
       )}
-    </MarkerClusterGroup>
+    </>
   );
 };
 

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -7,6 +7,7 @@ import 'react-leaflet-markercluster/dist/styles.min.css';
 import { CollectionDetails } from 'store/Collection/types';
 import { hasDeployedSpotter } from 'helpers/siteUtils';
 import { CircleSiteMarker, SensorSiteMarker } from './SiteMarker';
+import { CanvasMarkersLayer } from './CanvasMarkersLayer';
 
 const hasSpotter = (site: Site) => site.hasHobo || hasDeployedSpotter(site);
 
@@ -18,7 +19,7 @@ export const SiteMarkers = ({ collection }: SiteMarkersProps) => {
   );
 
   return (
-    <>
+    <CanvasMarkersLayer>
       {sitesList.map((site: Site) =>
         sitesList[site.id] && hasSpotter(site) ? (
           <SensorSiteMarker key={`${site.id}`} site={site} />
@@ -26,7 +27,7 @@ export const SiteMarkers = ({ collection }: SiteMarkersProps) => {
           <CircleSiteMarker key={`${site.id}`} site={site} />
         ),
       )}
-    </>
+    </CanvasMarkersLayer>
   );
 };
 

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -3,7 +3,6 @@ import React, { useMemo } from 'react';
 import { sitesToDisplayListSelector } from 'store/Sites/sitesListSlice';
 import { Site } from 'store/Sites/types';
 import 'leaflet/dist/leaflet.css';
-import 'react-leaflet-markercluster/dist/styles.min.css';
 import { CollectionDetails } from 'store/Collection/types';
 import { hasDeployedSpotter } from 'helpers/siteUtils';
 import { CircleSiteMarker, SensorSiteMarker } from './SiteMarker';

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -127,7 +127,7 @@ const HomepageMap = ({
       const pointBounds = L.latLngBounds(latLng, latLng);
       const maxZoom = Math.max(map.getZoom() || 6);
       map.flyToBounds(pointBounds, {
-        duration: 2,
+        animate: false,
         maxZoom,
         paddingTopLeft: L.point(0, 200),
       });

--- a/packages/website/src/routes/SiteRoutes/SiteApplication/Form/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/SiteApplication/Form/__snapshots__/index.test.tsx.snap
@@ -540,12 +540,11 @@ exports[`renders as expected 1`] = `
                           </button>
                           <button
                             aria-colindex="4"
-                            aria-current="date"
                             aria-selected="false"
-                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin MuiPickersDay-today css-qt9k9u-MuiButtonBase-root-MuiPickersDay-root"
+                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin css-wbk8ya-MuiButtonBase-root-MuiPickersDay-root"
                             data-timestamp="1736899200000"
                             role="gridcell"
-                            tabindex="0"
+                            tabindex="-1"
                             type="button"
                           >
                             15
@@ -563,11 +562,12 @@ exports[`renders as expected 1`] = `
                           </button>
                           <button
                             aria-colindex="6"
+                            aria-current="date"
                             aria-selected="false"
-                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin css-wbk8ya-MuiButtonBase-root-MuiPickersDay-root"
+                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin MuiPickersDay-today css-qt9k9u-MuiButtonBase-root-MuiPickersDay-root"
                             data-timestamp="1737072000000"
                             role="gridcell"
-                            tabindex="-1"
+                            tabindex="0"
                             type="button"
                           >
                             17

--- a/packages/website/src/routes/SiteRoutes/SiteApplication/Form/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/SiteApplication/Form/__snapshots__/index.test.tsx.snap
@@ -562,12 +562,11 @@ exports[`renders as expected 1`] = `
                           </button>
                           <button
                             aria-colindex="6"
-                            aria-current="date"
                             aria-selected="false"
-                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin MuiPickersDay-today css-qt9k9u-MuiButtonBase-root-MuiPickersDay-root"
+                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin css-wbk8ya-MuiButtonBase-root-MuiPickersDay-root"
                             data-timestamp="1737072000000"
                             role="gridcell"
-                            tabindex="0"
+                            tabindex="-1"
                             type="button"
                           >
                             17
@@ -602,11 +601,12 @@ exports[`renders as expected 1`] = `
                           </button>
                           <button
                             aria-colindex="2"
+                            aria-current="date"
                             aria-selected="false"
-                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin css-wbk8ya-MuiButtonBase-root-MuiPickersDay-root"
+                            class="MuiButtonBase-root MuiPickersDay-root MuiPickersDay-dayWithMargin MuiPickersDay-today css-qt9k9u-MuiButtonBase-root-MuiPickersDay-root"
                             data-timestamp="1737331200000"
                             role="gridcell"
-                            tabindex="-1"
+                            tabindex="0"
                             type="button"
                           >
                             20

--- a/yarn.lock
+++ b/yarn.lock
@@ -14344,12 +14344,7 @@ leaflet.locatecontrol@^0.79.0:
   resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.79.0.tgz#0236b87c699a49f9ddb2f289941fbc0d3c3f8b62"
   integrity sha512-h64QIHFkypYdr90lkSfjKvPvvk8/b8UnP3m9WuoWdp5p2AaCWC0T1NVwyuj4rd5U4fBW3tQt4ppmZ2LceHMIDg==
 
-leaflet.markercluster@^1.4.1:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz#9cdb52a4eab92671832e1ef9899669e80efc4056"
-  integrity sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==
-
-leaflet@^1.6.0, leaflet@^1.7.1:
+leaflet@^1.7.1:
   version "1.9.4"
   resolved "https://registry.yarnpkg.com/leaflet/-/leaflet-1.9.4.tgz#23fae724e282fa25745aff82ca4d394748db7d8d"
   integrity sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==
@@ -18032,16 +18027,7 @@ react-jwt@^1.1.8:
   optionalDependencies:
     fsevents "^2.3.2"
 
-react-leaflet-markercluster@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/react-leaflet-markercluster/-/react-leaflet-markercluster-2.0.0.tgz#e0138b89a1b9c5cf752c9a8ec80231588ab46b38"
-  integrity sha512-X1OuaMf4LeAQap638+X46+AN7ZqJKZse84o964brKj4AVVifs4fKCxTTFH6+MoyIarbWvF8x6tJ4vxT2BtxLYg==
-  dependencies:
-    leaflet "^1.6.0"
-    leaflet.markercluster "^1.4.1"
-    react-leaflet "^2.6.3"
-
-react-leaflet@^2.6.3, react-leaflet@^2.7.0:
+react-leaflet@^2.7.0:
   version "2.8.0"
   resolved "https://registry.yarnpkg.com/react-leaflet/-/react-leaflet-2.8.0.tgz#14bfc77b6ae8263d3a62e0ba7a39539c05973c6f"
   integrity sha512-Y7oHtNrrlRH8muDttXf+jZ2Ga/X7jneSGi1GN8uEdeCfLProTqgG2Zoa5TfloS3ZnY20v7w+DIenMG59beFsQw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -14334,6 +14334,11 @@ lazystream@^1.0.0:
   dependencies:
     readable-stream "^2.0.5"
 
+leaflet-markers-canvas@^0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/leaflet-markers-canvas/-/leaflet-markers-canvas-0.2.2.tgz#fde165d4531c326d9120494aea52b0e753cc48fd"
+  integrity sha512-UU/98qrmljhU6Xl3lrsUAUke4Qb/p8BCfmhiw7L1hHtkVMxdRYgwk7RwUW9QNoPbhnmuyxsc90whKjWVVP5cNw==
+
 leaflet.locatecontrol@^0.79.0:
   version "0.79.0"
   resolved "https://registry.yarnpkg.com/leaflet.locatecontrol/-/leaflet.locatecontrol-0.79.0.tgz#0236b87c699a49f9ddb2f289941fbc0d3c3f8b62"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19702,7 +19702,16 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -19797,7 +19806,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -19817,6 +19826,13 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.0.1"
@@ -20776,7 +20792,7 @@ typeorm-seeding@^1.6.1:
     reflect-metadata "0.1.13"
     yargs "15.3.1"
 
-typeorm@^0.3.18:
+typeorm@^0.3.19:
   version "0.3.20"
   resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.20.tgz#4b61d737c6fed4e9f63006f88d58a5e54816b7ab"
   integrity sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==
@@ -21702,7 +21718,7 @@ workbox-window@6.5.4:
     "@types/trusted-types" "^2.0.2"
     workbox-core "6.5.4"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -21715,6 +21731,15 @@ wrap-ansi@^6.0.1, wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
Target: #1069 `map-performance`

- Use `leaflet-markers-canvas` for buoys to render marker on canvas which improves performance.
- Use `Marker` (which is rendered on DOM) for the rest of markers (minority).
- Remove filtering & clustering