### PR TITLE
Add survey collectors fields

### DIFF
--- a/packages/api/migration/1738250706996-AddReefCheckSurveyCollectors.ts
+++ b/packages/api/migration/1738250706996-AddReefCheckSurveyCollectors.ts
@@ -1,0 +1,25 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddReefCheckSurveyCollectors1738250706996
+  implements MigrationInterface
+{
+  name = 'AddReefCheckSurveyCollectors1738250706996';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" ADD "team_leader" character varying`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" ADD "team_scientist" character varying`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" DROP COLUMN "team_scientist"`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "reef_check_survey" DROP COLUMN "team_leader"`,
+    );
+  }
+}

--- a/packages/api/scripts/reef-check.ts
+++ b/packages/api/scripts/reef-check.ts
@@ -6,7 +6,6 @@ import { Logger } from '@nestjs/common';
 import yargs from 'yargs';
 import { hideBin } from 'yargs/helpers';
 import { groupBy, keyBy, uniqWith } from 'lodash';
-import fs from 'fs';
 import { ReefCheckSubstrate } from '../src/reef-check-substrates/reef-check-substrates.entity';
 import { ReefCheckOrganism } from '../src/reef-check-organisms/reef-check-organisms.entity';
 import { ReefCheckSurvey } from '../src/reef-check-surveys/reef-check-surveys.entity';

--- a/packages/api/src/reef-check-surveys/reef-check-surveys.entity.ts
+++ b/packages/api/src/reef-check-surveys/reef-check-surveys.entity.ts
@@ -293,6 +293,14 @@ export class ReefCheckSurvey {
   submittedBy: string;
 
   @ApiProperty()
+  @Column({ nullable: true })
+  teamLeader: string;
+
+  @ApiProperty()
+  @Column({ nullable: true })
+  teamScientist: string;
+
+  @ApiProperty()
   @VirtualColumn({
     query: (survey) => `
       SELECT satellite_temperature

--- a/packages/website/src/common/SiteDetails/CardWithTitle/index.tsx
+++ b/packages/website/src/common/SiteDetails/CardWithTitle/index.tsx
@@ -89,7 +89,6 @@ const useStyles = makeStyles((theme: Theme) => {
       position: 'absolute',
       top: 0,
       left: 0,
-      padding: theme.spacing(1),
       width: '100%',
       height: '100%',
     },

--- a/packages/website/src/common/SiteDetails/Surveys/ReefCheckSurveyCard/index.test.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/ReefCheckSurveyCard/index.test.tsx
@@ -29,14 +29,14 @@ describe('ReefCheckSurveyCard', () => {
     expect(
       getByText(`Depth: ${mockReefCheckSurvey.depth}m`),
     ).toBeInTheDocument();
-    expect(getByText('User: Reef Check')).toBeInTheDocument();
+    expect(getByText('Reef Check')).toBeInTheDocument();
   });
 
-  it('should render user if submittedBy is present', () => {
+  it('should render team leader if present', () => {
     const { getByText } = renderReefCheckSurveyCard({
-      submittedBy: 'Test User',
+      teamLeader: 'Test User',
     });
-    expect(getByText('User: Test User')).toBeInTheDocument();
+    expect(getByText('Test User')).toBeInTheDocument();
   });
 
   it('should render table with correct number of rows', () => {

--- a/packages/website/src/common/SiteDetails/Surveys/ReefCheckSurveyCard/index.tsx
+++ b/packages/website/src/common/SiteDetails/Surveys/ReefCheckSurveyCard/index.tsx
@@ -64,7 +64,7 @@ const ReefCheckSurveyCardComponent = ({
           </Typography>
           <Typography>Depth: {survey.depth}m</Typography>
         </Box>
-        <Typography>User: {survey.submittedBy ?? 'Reef Check'}</Typography>
+        <Typography>{survey.teamLeader ?? 'Reef Check'}</Typography>
       </Box>
       <TableContainer className={classes.tableRoot}>
         <Table size="small">

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -261,8 +261,8 @@ const useStyles = makeStyles((theme: Theme) =>
       height: '100%',
     },
     arrow: {
-      width: 20,
-      height: 20,
+      width: 22,
+      height: 22,
       marginRight: '1rem',
       marginBottom: 10,
       [theme.breakpoints.between('md', 1350)]: {

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -290,7 +290,7 @@ const SiteDetails = ({
         container
         justifyContent="space-between"
         alignItems="flex-end"
-        spacing={videoStream ? 0 : 2}
+        spacing={2}
         className={classNames({
           [classes.forcedWidth]: !!videoStream,
         })}
@@ -394,7 +394,6 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     forcedWidth: {
       width: `calc(100% + ${theme.spacing(2)})`,
-      margin: -theme.spacing(1),
     },
     mobileMargin: {
       [theme.breakpoints.down('md')]: {

--- a/packages/website/src/helpers/map.ts
+++ b/packages/website/src/helpers/map.ts
@@ -153,6 +153,7 @@ const useMarkerStyles = makeStyles({
     animationName: 'pulse',
     animationDuration: '2s',
     animationIterationCount: 'infinite',
+    transformOrigin: '50% 65%',
   },
 });
 

--- a/packages/website/src/mocks/mockReefCheckSurvey.ts
+++ b/packages/website/src/mocks/mockReefCheckSurvey.ts
@@ -65,6 +65,8 @@ export const mockReefCheckSurvey: ReefCheckSurvey = {
   suspectedDisease: null,
   rareAnimalsDetails: null,
   submittedBy: null,
+  teamLeader: 'John Doe',
+  teamScientist: 'Jane Doe',
   satelliteTemperature: 28.2,
   organisms: [
     {

--- a/packages/website/src/mocks/mockReefCheckSurvey.ts
+++ b/packages/website/src/mocks/mockReefCheckSurvey.ts
@@ -65,7 +65,7 @@ export const mockReefCheckSurvey: ReefCheckSurvey = {
   suspectedDisease: null,
   rareAnimalsDetails: null,
   submittedBy: null,
-  teamLeader: 'John Doe',
+  teamLeader: null,
   teamScientist: 'Jane Doe',
   satelliteTemperature: 28.2,
   organisms: [

--- a/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Markers/index.tsx
@@ -20,7 +20,7 @@ export const SiteMarkers = ({ collection }: SiteMarkersProps) => {
   return (
     <>
       {sitesList.map((site: Site) =>
-        sitesList[site.id] && hasSpotter(site) ? (
+        hasSpotter(site) ? (
           <SensorSiteMarker key={`${site.id}`} site={site} />
         ) : (
           <CircleSiteMarker key={`${site.id}`} site={site} />

--- a/packages/website/src/routes/HomeMap/SiteTable/body.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/body.tsx
@@ -2,6 +2,7 @@ import {
   Hidden,
   TableBody,
   TableCell,
+  TableFooter,
   TablePagination,
   TableRow,
   Theme,
@@ -192,10 +193,7 @@ const SiteTableBody = ({
   return (
     <>
       <TableBody>
-        {stableSort<Row>(
-          constructTableData(sitesList),
-          getComparator(order, orderBy),
-        )
+        {tableData
           .slice(page * ROWS_PER_PAGE, page * ROWS_PER_PAGE + ROWS_PER_PAGE)
           .map((site) => {
             return (
@@ -279,14 +277,23 @@ const SiteTableBody = ({
           })}
       </TableBody>
       {sitesList.length > ROWS_PER_PAGE && (
-        <TablePagination
-          className={classes.stickyFooter}
-          count={sitesList.length}
-          rowsPerPage={ROWS_PER_PAGE}
-          rowsPerPageOptions={[ROWS_PER_PAGE]}
-          page={page}
-          onPageChange={handlePageChange}
-        />
+        <TableFooter>
+          <TableRow>
+            <TablePagination
+              className={classes.stickyFooter}
+              count={sitesList.length}
+              rowsPerPage={ROWS_PER_PAGE}
+              rowsPerPageOptions={[ROWS_PER_PAGE]}
+              page={page}
+              onPageChange={handlePageChange}
+              slotProps={{
+                displayedRows: {
+                  sx: { marginBottom: 0 },
+                },
+              }}
+            />
+          </TableRow>
+        </TableFooter>
       )}
     </>
   );

--- a/packages/website/src/routes/HomeMap/SiteTable/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/index.tsx
@@ -249,9 +249,6 @@ const styles = (theme: Theme) =>
       overflowY: 'auto',
     },
     table: {
-      [theme.breakpoints.down('sm')]: {
-        tableLayout: 'fixed',
-      },
       borderCollapse: 'collapse',
     },
     extendedTable: {

--- a/packages/website/src/store/ReefCheckSurveys/types.ts
+++ b/packages/website/src/store/ReefCheckSurveys/types.ts
@@ -112,6 +112,8 @@ export interface ReefCheckSurvey {
   percentOfEachColony: string | null;
   suspectedDisease: string | null;
   rareAnimalsDetails: string | null;
+  teamLeader: string | null;
+  teamScientist: string | null;
   submittedBy: string | null;
 }
 


### PR DESCRIPTION
- Add `teamLeader` and `teamScientist` columns in Reef Check Surveys
- Add script to upload these fields by parsing Data_collectors.xlsx
- Remove unused and potentially incorrect reef check stats command

Other small fixes:
- Fix video stream alignment. Closes #1089 
- Fix site table styles on mobile
- Fix `validateDOMNesting(...): <td> cannot appear as a child of <table>` console error
- Fix buoy animation origin
- Update wind direction icon size to match the text
- Fix site markers filtering