### PR TITLE
Add option to backfill only missing data

### DIFF
--- a/packages/api/scripts/backfill-daily-data.ts
+++ b/packages/api/scripts/backfill-daily-data.ts
@@ -1,8 +1,18 @@
 import Bluebird from 'bluebird';
 import yargs from 'yargs';
 import { DateTime } from 'luxon';
-import { getSitesDailyData } from '../src/workers/dailyData';
+import { Logger } from '@nestjs/common';
+import {
+  getSitesDailyData,
+  getSitesIdsWithoutDataForDate,
+} from '../src/workers/dailyData';
 import AqualinkDataSource from '../ormconfig';
+
+type Args = {
+  d: number;
+  s?: string[];
+  m: boolean;
+};
 
 const { argv } = yargs
   .scriptName('backfill-data')
@@ -18,19 +28,32 @@ const { argv } = yargs
     describe: 'Specify the sites which will be backfilled with data',
     type: 'array',
   })
+  .option('m', {
+    alias: 'missing',
+    describe: 'Backfill only missing data',
+    type: 'boolean',
+    default: false,
+  })
   .help();
 
 async function run() {
-  const { d: days, s: sites } = argv as any;
+  const { d: days, s: sites, m: missing } = argv as Args;
   const backlogArray = Array.from(Array(days).keys());
   const siteIds = sites && sites.map((site) => parseInt(`${site}`, 10));
   const today = DateTime.utc().endOf('day');
   const connection = await AqualinkDataSource.initialize();
+
+  Logger.log(
+    `Backfilling ${days} days for ${siteIds?.length ?? 'all'} sites...`,
+  );
   // eslint-disable-next-line fp/no-mutating-methods
   await Bluebird.mapSeries(backlogArray.reverse(), async (past) => {
-    const date = today.set({ day: today.day - past - 1 });
+    const date = today.set({ day: today.day - past - 1 }).toJSDate();
     try {
-      await getSitesDailyData(connection, date.toJSDate(), siteIds);
+      const filteredSiteIds = missing
+        ? await getSitesIdsWithoutDataForDate(connection, date, siteIds)
+        : siteIds;
+      await getSitesDailyData(connection, date, filteredSiteIds);
     } catch (error) {
       console.error(error);
     }

--- a/packages/api/scripts/noaa-availability.ts
+++ b/packages/api/scripts/noaa-availability.ts
@@ -14,7 +14,13 @@ import {
   updateNOAALocation,
 } from '../src/utils/noaa-availability-utils';
 
-let netcdf4;
+type Argv = {
+  s?: number[];
+  a: boolean;
+  u: boolean;
+};
+
+let netcdf4: any;
 try {
   // eslint-disable-next-line global-require, fp/no-mutation, import/no-unresolved
   netcdf4 = require('netcdf4');
@@ -88,7 +94,7 @@ async function getAvailabilityMapFromNetCDF4() {
 }
 
 async function run() {
-  const { s: sites, a: all, u: update } = argv;
+  const { s: sites, a: all, u: update } = argv as Argv;
   const parsedIds = sites && sites.map((site) => Number(site));
   const siteIds =
     parsedIds?.filter((x, i) => {

--- a/packages/api/src/workers/dailyData.ts
+++ b/packages/api/src/workers/dailyData.ts
@@ -4,6 +4,7 @@ import { DataSource, In, Repository } from 'typeorm';
 import { Point } from 'geojson';
 import Bluebird from 'bluebird';
 import { DateTime } from 'luxon';
+import { Logger } from '@nestjs/common';
 import { Site } from '../sites/sites.entity';
 import { DailyData } from '../sites/daily-data.entity';
 import { getMax } from '../utils/math';
@@ -128,6 +129,32 @@ export function getMaxAlert(
   return getMax([weeklyAlertLevel, dailyAlertLevel].filter(isNumber));
 }
 
+export async function getSitesIdsWithoutDataForDate(
+  dataSource: DataSource,
+  date: Date,
+  siteIds?: number[],
+): Promise<number[]> {
+  const query = dataSource
+    .getRepository(Site)
+    .createQueryBuilder('s')
+    .select('s.id', 'id')
+    .where(
+      `NOT EXISTS (
+        SELECT 1
+        FROM daily_data dd
+        WHERE dd.site_id = s.id
+        AND dd.date = :date
+      )`,
+      { date },
+    );
+
+  if (siteIds?.length) {
+    query.andWhere('s.id IN (:...siteIds)', { siteIds });
+  }
+
+  return (await query.getRawMany<{ id: number }>()).map((site) => site.id);
+}
+
 /* eslint-disable no-console */
 export async function getSitesDailyData(
   dataSource: DataSource,
@@ -147,7 +174,7 @@ export async function getSitesDailyData(
     select: getAllColumns(siteRepository),
   });
   const start = new Date();
-  console.log(
+  Logger.log(
     `Updating ${allSites.length} sites for ${endOfDate.toDateString()}.`,
   );
   await Bluebird.map(
@@ -157,7 +184,7 @@ export async function getSitesDailyData(
 
       // If no data returned from the update function, skip
       if (hasNoData(dailyDataInput)) {
-        console.log('No data has been fetched. Skipping...');
+        console.log(`No data has been fetched. Skipping ${site.id}...`);
         return;
       }
 
@@ -200,7 +227,7 @@ export async function getSitesDailyData(
     },
     { concurrency: 8 },
   );
-  console.log(
+  Logger.log(
     `Updated ${allSites.length} sites in ${
       (new Date().valueOf() - start.valueOf()) / 1000
     } seconds`,


### PR DESCRIPTION
Modify `backfill-daily-data` to accept `--missing`/`-m` argument to backfill only sites that don't have any data for the specific date. It works with `-s` option to filter only requested sites, otherwise filters all sites.

Sample output:
```bash
> yarn backfill-daily-data -d 2 -m 
[Nest] 26309  - 02/07/2025, 12:15:06 PM     LOG Updating 620 sites for Wed Feb 05 2025.
[Nest] 26309  - 02/07/2025, 12:16:46 PM     LOG Updating 57 sites for Thu Feb 06 2025.
```