### PR TITLE
Update back button behavior

### DIFF
--- a/packages/website/src/common/Chip/index.tsx
+++ b/packages/website/src/common/Chip/index.tsx
@@ -58,14 +58,15 @@ interface ChipProps {
   image?: string | null;
   width?: number;
   onClick?: () => void;
+  state?: any;
 }
 
 const LinkWrapper: FC<
-  Pick<ChipProps, 'to' | 'href'> & {
+  Pick<ChipProps, 'to' | 'href' | 'state'> & {
     className?: string;
     children?: React.ReactNode;
   }
-> = ({ to, href, className, children }) => {
+> = ({ to, href, className, children, state }) => {
   const url = to || href;
 
   return url ? (
@@ -74,6 +75,7 @@ const LinkWrapper: FC<
       target={href ? '_blank' : undefined}
       className={className}
       rel="noopener noreferrer"
+      state={state}
     >
       {children}
     </Link>
@@ -91,13 +93,19 @@ const Chip = ({
   liveText = 'LIVE',
   width,
   onClick,
+  state,
 }: ChipProps) => {
   const classes = useStyles({ width });
   return (
     <Grid className={classes.chip} item>
       <Grid container alignItems="center" justifyContent="center">
         <Button className={classes.button} onClick={onClick}>
-          <LinkWrapper to={to} href={href} className={classes.link}>
+          <LinkWrapper
+            to={to}
+            href={href}
+            className={classes.link}
+            state={state}
+          >
             {live ? (
               <>
                 <div className={classes.circle} />

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -12,7 +12,7 @@ import {
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import { Popup as LeafletPopup, useLeaflet } from 'react-leaflet';
 import { useSelector } from 'react-redux';
 
@@ -30,6 +30,7 @@ const Popup = ({ site, classes, autoOpen = true }: PopupProps) => {
   const { map } = useLeaflet();
   const siteOnMap = useSelector(siteOnMapSelector);
   const popupRef = useRef<LeafletPopup>(null);
+  const location = useLocation();
   const { name, region } = getSiteNameAndRegion(site);
   const isNameLong = name?.length && name.length > maxLengths.SITE_NAME_POPUP;
 
@@ -142,6 +143,7 @@ const Popup = ({ site, classes, autoOpen = true }: PopupProps) => {
               <Link
                 style={{ color: 'inherit', textDecoration: 'none' }}
                 to={`/sites/${site.id}`}
+                state={{ from: location.pathname }}
               >
                 <Button
                   onClick={onExploreButtonClick}

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -13,7 +13,7 @@ import {
 } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import { isNumber } from 'lodash';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
 
 import { Site } from 'store/Sites/types';
@@ -35,6 +35,7 @@ const SelectedSiteCardContent = ({
 }: SelectedSiteCardContentProps) => {
   const classes = useStyles({ imageUrl, loading });
   const theme = useTheme();
+  const location = useLocation();
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
   const {
     bottomTemperature,
@@ -125,7 +126,7 @@ const SelectedSiteCardContent = ({
               height="100%"
             >
               {site && imageUrl && (
-                <Link to={`/sites/${site.id}`}>
+                <Link to={`/sites/${site.id}`} state={{ from: location.pathname }}>
                   <CardMedia
                     className={classNames(
                       classes.cardImage,
@@ -175,6 +176,7 @@ const SelectedSiteCardContent = ({
                         live
                         liveText="LIVE VIDEO"
                         to={`/sites/${site.id}`}
+                        state={{ from: location.pathname }}
                         width={80}
                       />
                     )}
@@ -183,6 +185,7 @@ const SelectedSiteCardContent = ({
                         className={classes.exporeButton}
                         component={Link}
                         to={`/sites/${site.id}`}
+                        state={{ from: location.pathname }}
                         onClick={onExploreButtonClick}
                         size="small"
                         variant="contained"
@@ -229,6 +232,7 @@ const SelectedSiteCardContent = ({
                     live
                     liveText="LIVE VIDEO"
                     to={`/sites/${site.id}`}
+                    state={{ from: location.pathname }}
                     width={80}
                   />
                 )}

--- a/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/SiteInfo/index.tsx
@@ -15,7 +15,7 @@ import createStyles from '@mui/styles/createStyles';
 import Alert from '@mui/material/Alert';
 import CloseIcon from '@mui/icons-material/Close';
 import { useDispatch, useSelector } from 'react-redux';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useLocation } from 'react-router-dom';
 import ArrowBack from '@mui/icons-material/ArrowBack';
 
 import {
@@ -48,6 +48,7 @@ const SiteNavBar = ({
   const dispatch = useDispatch();
   const theme = useTheme();
   const navigate = useNavigate();
+  const location = useLocation();
   const user = useSelector(userInfoSelector);
   const sitesList = useSelector(sitesListSelector);
   const siteContactInfoLoading = useSelector(siteContactInfoLoadingSelector);
@@ -66,12 +67,15 @@ const SiteNavBar = ({
       dispatch(setSelectedSite(null));
     }
 
-    // Go back if there's history, otherwise go to map
-    if (window.history.length > 1) {
-      navigate(-1);
-    } else {
-      navigate('/map');
-    }
+    // Determine the target path based on location state
+    const previousPath = location.state?.from;
+    // Default to '/map' if no state or state.from is not a site page
+    const targetPath =
+      previousPath && !previousPath.startsWith('/sites/')
+        ? previousPath
+        : '/map';
+
+    navigate(targetPath);
   };
 
   const onCloseForm = () => {
@@ -182,8 +186,6 @@ const SiteNavBar = ({
                   edge="start"
                   color="primary"
                   aria-label="menu"
-                  component={Link}
-                  to="/map"
                   size="large"
                 >
                   <ArrowBack />


### PR DESCRIPTION
This is another tentative which uses state to remember what page and filters we had before.

1. if you come from a filtered version of the map and hit the button, you will go back to the same filtered view, even if you played with dates on the site page
2. same for collections
3. if you come from the survey page, the link would go back to the map

@Caesarh97 I think this is a bit closer to what you had in mind but let me know.