### PR TITLE
Use the same getRegion function in import/create

### DIFF
--- a/packages/api/scripts/augment-site-data.ts
+++ b/packages/api/scripts/augment-site-data.ts
@@ -7,30 +7,8 @@ import { Site } from '../src/sites/sites.entity';
 import { HistoricalMonthlyMean } from '../src/sites/historical-monthly-mean.entity';
 import { Region } from '../src/regions/regions.entity';
 import { getMMM, getHistoricalMonthlyMeans } from '../src/utils/temperature';
-import { getGoogleRegion } from '../src/utils/site.utils';
-import { createPoint } from '../src/utils/coordinates';
+import { getRegion } from '../src/utils/site.utils';
 import AqualinkDataSource from '../ormconfig';
-
-async function getRegion(
-  longitude: number,
-  latitude: number,
-  regionRepository: Repository<Region>,
-) {
-  const googleRegion = await getGoogleRegion(longitude, latitude);
-  const regions = await regionRepository.find({
-    where: { name: googleRegion },
-  });
-
-  if (regions.length > 0) {
-    return regions[0];
-  }
-  return googleRegion
-    ? regionRepository.save({
-        name: googleRegion,
-        polygon: createPoint(longitude, latitude),
-      })
-    : undefined;
-}
 
 async function getAugmentedData(
   site: Site,

--- a/packages/api/src/utils/site.utils.ts
+++ b/packages/api/src/utils/site.utils.ts
@@ -86,20 +86,21 @@ export const getRegion = async (
   const country = await getGoogleRegion(longitude, latitude);
   // undefined values would result in the first database item
   // https://github.com/typeorm/typeorm/issues/2500
-  const region = country
-    ? await regionRepository.findOne({ where: { name: country } })
-    : null;
+  // bail out to avoid incorrect region assignment
+  if (!country) {
+    return undefined;
+  }
+
+  const region = await regionRepository.findOne({ where: { name: country } });
 
   if (region) {
     return region;
   }
 
-  return country
-    ? regionRepository.save({
-        name: country,
-        polygon: createPoint(longitude, latitude),
-      })
-    : undefined;
+  return regionRepository.save({
+    name: country,
+    polygon: createPoint(longitude, latitude),
+  });
 };
 
 export const getTimezones = (latitude: number, longitude: number) => {


### PR DESCRIPTION
Close #1137 
/claim #1137

Two changes:
1. use `getRegion` from site.util. the one in augment-site is virtually the same as the one in site.util, only variable name difference, and it does a `find` but only need the first one of result, which could be the same as `findOne`
2.  update `getRegion` function to return early. No functionality change, but logic flow is simpler and clear: we return undefined when `getGoogleRegion` is undefined