### PR TITLE
feat(map): add optional historical date mode for sites data

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2024-03-01', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly at?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -156,6 +156,9 @@ export class SitesService {
   }
 
   async find(filter: FilterSiteDto): Promise<Site[]> {
+    const historicalDate = filter.at
+      ? DateTime.fromISO(filter.at, { zone: 'utc' }).endOf('day').toJSDate()
+      : undefined;
     const query = this.sitesRepository.createQueryBuilder('site');
 
     if (filter.name) {
@@ -201,6 +204,7 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      historicalDate,
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);

--- a/packages/api/src/utils/collections.utils.test.ts
+++ b/packages/api/src/utils/collections.utils.test.ts
@@ -1,0 +1,94 @@
+import { Repository } from 'typeorm';
+import { getCollectionData } from './collections.utils';
+import { LatestData } from '../time-series/latest-data.entity';
+import { Site } from '../sites/sites.entity';
+
+const createQueryBuilderMock = (rows: unknown[]) => {
+  const queryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    addSelect: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    andWhere: jest.fn().mockReturnThis(),
+    orderBy: jest.fn().mockReturnThis(),
+    addOrderBy: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    getRawMany: jest.fn().mockResolvedValue(rows),
+  };
+  return queryBuilder;
+};
+
+describe('getCollectionData', () => {
+  it('maps latest_data values when no historical date is provided', async () => {
+    const latestRows = [
+      { siteId: 1, metric: 'temp_weekly_alert', value: 3 },
+      { siteId: 1, metric: 'satellite_temperature', value: 29.4 },
+      { siteId: 2, metric: 'dhw', value: 5 },
+    ];
+    const latestQueryBuilder = createQueryBuilderMock(latestRows);
+    const historicalQueryBuilder = createQueryBuilderMock([]);
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValue(latestQueryBuilder),
+      manager: {
+        createQueryBuilder: jest.fn().mockReturnValue(historicalQueryBuilder),
+      },
+    } as unknown as Repository<LatestData>;
+
+    const result = await getCollectionData(
+      [{ id: 1 } as Site, { id: 2 } as Site],
+      repository,
+    );
+
+    expect(repository.createQueryBuilder).toHaveBeenCalledWith('latest_data');
+    expect(repository.manager.createQueryBuilder).not.toHaveBeenCalled();
+    expect(result).toStrictEqual({
+      1: { tempWeeklyAlert: 3, satelliteTemperature: 29.4 },
+      2: { dhw: 5 },
+    });
+  });
+
+  it('maps daily_data snapshot when historical date is provided', async () => {
+    const historicalRows = [
+      {
+        siteId: 1,
+        degreeHeatingDays: '14',
+        satelliteTemperature: '30.1',
+        dailyAlertLevel: '3',
+        weeklyAlertLevel: '4',
+      },
+      {
+        siteId: 2,
+        degreeHeatingDays: null,
+        satelliteTemperature: null,
+        dailyAlertLevel: null,
+        weeklyAlertLevel: null,
+      },
+    ];
+    const latestQueryBuilder = createQueryBuilderMock([]);
+    const historicalQueryBuilder = createQueryBuilderMock(historicalRows);
+    const repository = {
+      createQueryBuilder: jest.fn().mockReturnValue(latestQueryBuilder),
+      manager: {
+        createQueryBuilder: jest.fn().mockReturnValue(historicalQueryBuilder),
+      },
+    } as unknown as Repository<LatestData>;
+    const historicalDate = new Date('2024-03-01T23:59:59.000Z');
+
+    const result = await getCollectionData(
+      [{ id: 1 } as Site, { id: 2 } as Site],
+      repository,
+      historicalDate,
+    );
+
+    expect(repository.createQueryBuilder).not.toHaveBeenCalled();
+    expect(repository.manager.createQueryBuilder).toHaveBeenCalledTimes(1);
+    expect(result).toStrictEqual({
+      1: {
+        dhw: 14,
+        satelliteTemperature: 30.1,
+        tempAlert: 3,
+        tempWeeklyAlert: 4,
+      },
+      2: {},
+    });
+  });
+});

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -9,11 +9,51 @@ import { LatestData } from '../time-series/latest-data.entity';
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  atDate?: Date,
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
   if (!siteIds.length) {
     return {};
+  }
+
+  if (atDate) {
+    const dailyData = await latestDataRepository.manager
+      .createQueryBuilder()
+      .select('DISTINCT ON (daily_data.site_id) daily_data.site_id', 'siteId')
+      .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+      .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+      .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+      .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+      .from('daily_data', 'daily_data')
+      .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+      .andWhere('daily_data.date <= :atDate', {
+        atDate: atDate.toISOString(),
+      })
+      .orderBy('daily_data.site_id')
+      .addOrderBy('daily_data.date', 'DESC')
+      .getRawMany();
+
+    return _(dailyData)
+      .groupBy((o) => Number(o.siteId))
+      .mapValues<CollectionDataDto>((rows) => {
+        const row = rows[0];
+        return {
+          ...(row?.degreeHeatingDays !== null
+            ? { dhw: Number(row.degreeHeatingDays) }
+            : {}),
+          ...(row?.satelliteTemperature !== null
+            ? { satelliteTemperature: Number(row.satelliteTemperature) }
+            : {}),
+          ...(row?.dailyAlertLevel !== null
+            ? { tempAlert: Number(row.dailyAlertLevel) }
+            : {}),
+          ...(row?.weeklyAlertLevel !== null
+            ? { tempWeeklyAlert: Number(row.weeklyAlertLevel) }
+            : {}),
+        };
+      })
+      .toJSON();
   }
 
   // Get latest data

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -8,7 +8,7 @@ import withStyles from '@mui/styles/withStyles';
 import createStyles from '@mui/styles/createStyles';
 import SearchIcon from '@mui/icons-material/Search';
 import Autocomplete from '@mui/material/Autocomplete';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { setSiteOnMap, setSearchResult } from 'store/Homepage/homepageSlice';
 import type { Site } from 'store/Sites/types';
@@ -30,6 +30,7 @@ const siteAugmentedName = (site: Site) => {
 };
 
 function Search({ geocodingEnabled = false, classes }: SearchProps) {
+  const location = useLocation();
   const navigate = useNavigate();
   const { id = '' } = useParams<{ id: string }>();
   const [searchedSite, setSearchedSite] = useState<Site | null>(null);
@@ -47,8 +48,9 @@ function Search({ geocodingEnabled = false, classes }: SearchProps) {
 
   // Fetch sites for the search bar
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    const at = new URLSearchParams(location.search).get('at') || undefined;
+    dispatch(sitesRequest({ at }));
+  }, [dispatch, location.search]);
 
   const onChangeSearchText = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -15,6 +15,7 @@ import {
   Hidden,
   Alert,
   Theme,
+  Button,
 } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -23,6 +24,7 @@ import withStyles, {
   CSSProperties,
 } from '@mui/styles/withStyles';
 import MyLocationIcon from '@mui/icons-material/MyLocation';
+import CalendarMonthIcon from '@mui/icons-material/CalendarMonth';
 import { sitesListLoadingSelector } from 'store/Sites/sitesListSlice';
 import {
   searchResultSelector,
@@ -35,6 +37,9 @@ import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import InfoIcon from '@mui/icons-material/Info';
 import { mapIconSize } from 'layout/App/theme';
+import { DatePicker, LocalizationProvider } from '@mui/x-date-pickers';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { format, parseISO } from 'date-fns';
 import { SiteMarkers } from './Markers';
 import { SofarLayers } from './sofarLayers';
 import { InfoDialog } from './InfoDialog';
@@ -91,6 +96,8 @@ function HomepageMap({
   legendLeft,
   classes,
   onMapLoad,
+  historicalAt,
+  onHistoricalDateChange,
 }: HomepageMapProps) {
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [legendName, setLegendName] = useState<string>(defaultLayerName || '');
@@ -100,6 +107,7 @@ function HomepageMap({
   const [currentLocationErrorMessage, setCurrentLocationErrorMessage] =
     useState<string>();
   const [mapReady, setMapReady] = useState(false);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
   const loading = useSelector(sitesListLoadingSelector);
   const searchResult = useSelector(searchResultSelector);
   const siteOnMap = useSelector(siteOnMapSelector);
@@ -184,6 +192,8 @@ function HomepageMap({
   const onMapReady = () => {
     setMapReady(true);
   };
+
+  const historicalDateValue = historicalAt ? parseISO(historicalAt) : null;
 
   const ExpandIcon = showSiteTable ? FullscreenIcon : FullscreenExitIcon;
 
@@ -275,6 +285,42 @@ function HomepageMap({
           <InfoIcon color="primary" />
         </IconButton>
       </div>
+      <div className={classes.historicalDateButton}>
+        <IconButton
+          onClick={() => setDatePickerOpen((open) => !open)}
+          size="large"
+        >
+          <CalendarMonthIcon color={historicalAt ? 'primary' : 'action'} />
+        </IconButton>
+      </div>
+      {datePickerOpen && (
+        <div className={classes.historicalDatePanel}>
+          <LocalizationProvider dateAdapter={AdapterDateFns}>
+            <DatePicker
+              label="Historical date"
+              format="MM/dd/yyyy"
+              maxDate={new Date()}
+              value={historicalDateValue}
+              onChange={(date) =>
+                onHistoricalDateChange(date ? format(date, 'yyyy-MM-dd') : null)
+              }
+              slotProps={{
+                textField: {
+                  size: 'small',
+                },
+              }}
+            />
+          </LocalizationProvider>
+          <Button
+            color="secondary"
+            disabled={!historicalAt}
+            onClick={() => onHistoricalDateChange(null)}
+            size="small"
+          >
+            Clear
+          </Button>
+        </div>
+      )}
       <InfoDialog
         infoDialogOpen={infoDialogOpen}
         handleInfoClose={handleInfoClose}
@@ -358,6 +404,31 @@ const styles = (theme: Theme) =>
         top: 50,
       },
     },
+    historicalDateButton: {
+      ...mapButtonStyles,
+      right: 0,
+      top: 150,
+      zIndex: 400,
+      [theme.breakpoints.down('lg')]: {
+        top: 100,
+      },
+    },
+    historicalDatePanel: {
+      position: 'absolute',
+      right: 60,
+      top: 150,
+      zIndex: 400,
+      backgroundColor: 'white',
+      borderRadius: 8,
+      border: '1px solid rgba(0, 0, 0, 0.23)',
+      padding: theme.spacing(1),
+      display: 'flex',
+      gap: theme.spacing(1),
+      alignItems: 'center',
+      [theme.breakpoints.down('lg')]: {
+        top: 100,
+      },
+    },
     expandIcon: {
       fontSize: '34px',
     },
@@ -385,6 +456,8 @@ interface HomepageMapIncomingProps {
   legendBottom?: number;
   legendLeft?: number;
   onMapLoad?: (map: L.Map) => void;
+  historicalAt: string | null;
+  onHistoricalDateChange: (at: string | null) => void;
 }
 
 type HomepageMapProps = WithStyles<typeof styles> & HomepageMapIncomingProps;

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -2,7 +2,7 @@ import L, { LatLng } from 'leaflet';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -21,12 +21,14 @@ import HomepageMap from './Map';
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  AT = 'at',
 }
 
 interface MapQueryParams {
   initialCenter: LatLng;
   initialZoom: number;
   initialSiteId: string | undefined;
+  initialAt: string | null;
 }
 
 const INITIAL_CENTER = new LatLng(0, 121.3);
@@ -37,6 +39,7 @@ function useQuery() {
   const zoomLevelParam = urlParams.get(QueryParamKeys.ZOOM_LEVEL);
   const initialZoom: number = zoomLevelParam ? +zoomLevelParam : INITIAL_ZOOM;
   const queryParamSiteId = urlParams.get(QueryParamKeys.SITE_ID) || '';
+  const initialAt = urlParams.get(QueryParamKeys.AT);
   const sitesList = useSelector(sitesListSelector) || [];
   const featuredSiteId = process.env.REACT_APP_FEATURED_SITE_ID || '';
   const initialSiteId = queryParamSiteId
@@ -59,21 +62,52 @@ function useQuery() {
     initialCenter,
     initialSiteId,
     initialZoom,
+    initialAt,
   };
 }
 
 function Homepage({ classes }: HomepageProps) {
   const dispatch = useAppDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
-  const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
-    useQuery();
+  const {
+    initialZoom,
+    initialSiteId,
+    initialCenter,
+    initialAt,
+  }: MapQueryParams = useQuery();
+  const [historicalAt, setHistoricalAt] = useState<string | null>(initialAt);
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    setHistoricalAt(initialAt);
+  }, [initialAt]);
+
+  useEffect(() => {
+    dispatch(sitesRequest({ at: historicalAt || undefined }));
+  }, [dispatch, historicalAt]);
+
+  const onHistoricalDateChange = (at: string | null) => {
+    setHistoricalAt(at);
+    const queryParams = new URLSearchParams(location.search);
+
+    if (at) {
+      queryParams.set(QueryParamKeys.AT, at);
+    } else {
+      queryParams.delete(QueryParamKeys.AT);
+    }
+
+    navigate(
+      {
+        pathname: location.pathname,
+        search: queryParams.toString() ? `?${queryParams.toString()}` : '',
+      },
+      { replace: true },
+    );
+  };
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -124,6 +158,8 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              historicalAt={historicalAt}
+              onHistoricalDateChange={onHistoricalDateChange}
             />
           </Grid>
           {showSiteTable && (

--- a/packages/website/src/services/siteServices.test.ts
+++ b/packages/website/src/services/siteServices.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import requests from 'helpers/requests';
+import siteServices from './siteServices';
+
+vi.mock('helpers/requests', () => ({
+  default: {
+    send: vi.fn(),
+  },
+}));
+
+describe('siteServices.getSites', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requests live sites when historical date is not provided', () => {
+    siteServices.getSites();
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: 'sites',
+      method: 'GET',
+    });
+  });
+
+  it('requests historical sites with at query param', () => {
+    siteServices.getSites('2024-03-01');
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: 'sites?at=2024-03-01',
+      method: 'GET',
+    });
+  });
+});

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (at?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${at ? `?at=${encodeURIComponent(at)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -30,18 +30,24 @@ import { readFiltersFromUrl, writeFiltersToUrl } from './helpers';
 const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
+  requestedAt: null,
   filters: {},
+};
+
+type SitesRequestArgs = {
+  at?: string;
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  SitesRequestArgs | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
+    const requestedAt = arg?.at || null;
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(arg?.at);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +55,19 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        requestedAt,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: SitesRequestArgs | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, requestedAt },
       } = getState();
-      return !list;
+      const nextRequestedAt = arg?.at || null;
+      return !list || requestedAt !== nextRequestedAt;
     },
   },
 );
@@ -108,6 +116,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        requestedAt: action.payload.requestedAt,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  requestedAt: string | null;
 }
 
 export interface SitesListState {
   list?: Site[];
+  requestedAt: string | null;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
/claim #1162

## Summary

This adds an optional historical date mode for the map/sites view so users can inspect past heat-stress conditions instead of always seeing current/latest values.

### What changed

- Added optional `at` filter support in `GET /sites`.
  - `FilterSiteDto` now accepts `at` (ISO date)
  - `SitesService.find` passes `at` through to collection data resolution
- Extended collection-data mapping to support historical snapshots.
  - For historical mode, data is sourced from `daily_data` (latest row up to selected day)
  - Mapped to existing frontend marker fields (`dhw`, `satelliteTemperature`, `tempAlert`, `tempWeeklyAlert`)
- Added map UI control to choose/clear a historical date.
  - Floating calendar control on HomeMap
  - URL query sync via `?at=YYYY-MM-DD`
- Updated sites request flow to refetch when historical date changes.
  - `sitesRequest` now tracks `requestedAt` context
  - Search component aligns prefetch with current URL date context so historical view is not overwritten

## Why this is safe

- Default behavior remains unchanged when `at` is not provided.
- Historical mode only changes collection-data source path used for map/site cards.
- Existing filters and route flow remain intact.

## Validation

- `YARN_IGNORE_ENGINES=1 corepack yarn workspace api test src/utils/collections.utils.test.ts`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace website test src/services/siteServices.test.ts`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace api eslint src/sites/dto/filter-site.dto.ts src/sites/sites.service.ts src/utils/collections.utils.ts src/utils/collections.utils.test.ts`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace website eslint --ext .ts,.tsx src/routes/HomeMap/index.tsx src/routes/HomeMap/Map/index.tsx src/common/Search/index.tsx src/store/Sites/sitesListSlice.ts src/services/siteServices.ts src/services/siteServices.test.ts`
