### PR TITLE
Fix Prompts Editor issues

### DIFF
--- a/packages/website/src/routes/MonitoringRoutes/PromptsEditor/index.tsx
+++ b/packages/website/src/routes/MonitoringRoutes/PromptsEditor/index.tsx
@@ -40,6 +40,7 @@ import promptServices, {
   AIPrompt,
   AIPromptHistory,
 } from 'services/promptServices';
+import { useNavigate } from 'react-router-dom';
 
 interface SearchResult {
   promptKey: string;
@@ -226,6 +227,17 @@ function PromptsEditor() {
   const classes = useStyles();
   const user = useSelector(userInfoSelector);
   const token = user?.token || null;
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!user || !token) {
+      navigate('/');
+      return;
+    }
+    if (user.adminLevel !== 'super_admin') {
+      navigate('/');
+    }
+  }, [user, token, navigate]);
 
   const [prompts, setPrompts] = useState<AIPrompt[]>([]);
   const [selectedPrompt, setSelectedPrompt] = useState<AIPrompt | null>(null);
@@ -242,6 +254,7 @@ function PromptsEditor() {
   const [viewingVersion, setViewingVersion] = useState<AIPromptHistory | null>(
     null,
   );
+  const [searchExecuted, setSearchExecuted] = useState(false);
 
   // Search functionality
   const [viewMode, setViewMode] = useState<ViewMode>('single');
@@ -418,6 +431,7 @@ function PromptsEditor() {
   const handleSearch = () => {
     if (!searchQuery.trim()) {
       setSearchResults([]);
+      setSearchExecuted(false);
       return;
     }
 
@@ -461,6 +475,7 @@ function PromptsEditor() {
       );
 
     setSearchResults(newResults);
+    setSearchExecuted(true);
     setViewMode('search');
   };
 
@@ -564,7 +579,11 @@ function PromptsEditor() {
           <TextField
             fullWidth
             value={searchQuery}
-            onChange={(e) => setSearchQuery(e.target.value)}
+            onChange={(e) => {
+              setSearchQuery(e.target.value);
+              setSearchResults([]);
+              setSearchExecuted(false);
+            }}
             onKeyPress={(e) => e.key === 'Enter' && handleSearch()}
             placeholder="Search across all prompts..."
             InputProps={{
@@ -806,12 +825,14 @@ function PromptsEditor() {
         </Box>
       )}
 
-      {viewMode === 'search' && searchResults.length === 0 && searchQuery && (
-        <Alert severity="info">
-          No results found for &quot;{searchQuery}&quot;. Try a different search
-          term.
-        </Alert>
-      )}
+      {viewMode === 'search' &&
+        searchResults.length === 0 &&
+        searchExecuted && (
+          <Alert severity="info">
+            No results found for &quot;{searchQuery}&quot;. Try a different
+            search term.
+          </Alert>
+        )}
 
       {/* VIEW ALL MODE */}
       {viewMode === 'all' && (

--- a/packages/website/src/services/promptServices.ts
+++ b/packages/website/src/services/promptServices.ts
@@ -79,7 +79,7 @@ const rollbackToVersion = (
 
 const refreshCache = (token: string) =>
   requests.send<{ success: boolean; message: string }>({
-    url: 'monitoring/prompts/refresh-cache',
+    url: 'monitoring/prompts/cache/refresh',
     method: 'POST',
     token,
   });


### PR DESCRIPTION
## Issues Fixed

## 1. Missing Auth Protection
**Problem:** Non-super-admin users could access `/monitoring/prompts` directly via URL
**Cause:** Missing useEffect redirect in PromptsEditor component
**Fix:** Added auth check that redirects non-super-admins to home page
**Result:** Only super_admin users can access the page, even via direct URL

## 2. RELOAD PROMPTS Button Failing (404 Error) 
**Problem:** Button returned 404 Not Found error
**Cause:** Frontend called `/monitoring/prompts/refresh-cache` but backend endpoint is `/monitoring/prompts/cache/refresh`
**Fix:** Updated endpoint URL in `promptServices.ts`
**Result:** RELOAD PROMPTS button now works correctly

## 3. Search UX Issue
**Problem:** "No results found" message appeared while typing, showing stale search terms
**Cause:** Alert displayed based only on empty results array, not whether search was executed
**Fix:** Added `searchExecuted` state flag that only shows message after clicking SEARCH
**Result:** Cleaner UX - message only appears after actual search attempt

Fixes issues found during QA of #1225