### PR TITLE
Support historical dates on the map

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2026-02-15T00:00:00.000Z', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -62,6 +62,11 @@ export class SitesController {
   }
 
   @ApiOperation({ summary: 'Returns sites filtered by provided filters' })
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    example: '2026-02-15T00:00:00.000Z',
+  })
   @Public()
   @Get()
   find(@Query() filterSiteDto: FilterSiteDto): Promise<Site[]> {

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getCollectionDataForDate,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,20 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const selectedDate = filter.date ? DateTime.fromISO(filter.date) : null;
+
+    if (selectedDate && !selectedDate.isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
+    const mappedSiteData = selectedDate
+      ? await getCollectionDataForDate(
+          res,
+          this.dailyDataRepository,
+          selectedDate.startOf('day').toJSDate(),
+          selectedDate.endOf('day').toJSDate(),
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -19,6 +19,7 @@ import {
 import { createPoint } from '../utils/coordinates';
 import { AdminLevel } from '../users/users.entity';
 import { Site, SiteStatus } from './sites.entity';
+import { DailyData } from './daily-data.entity';
 import {
   athensSite,
   californiaSite,
@@ -97,6 +98,42 @@ export const siteTests = () => {
     });
     expect(testSite.id).toBeDefined();
     siteId = sortedSites[sortedSites.length - 1].id;
+  });
+
+  it('GET / find all sites with collection data for a past date', async () => {
+    const requestedDate = DateTime.now()
+      .minus({ days: 30 })
+      .endOf('day')
+      .toISOString();
+    const selectedDay = DateTime.fromISO(requestedDate);
+    const pastCollectionData = {
+      satelliteTemperature: 26.5,
+      degreeHeatingDays: 7.5,
+      dailyAlertLevel: 2,
+      weeklyAlertLevel: 4,
+    };
+
+    await dataSource.getRepository(DailyData).save({
+      ...pastCollectionData,
+      date: selectedDay.toJSDate(),
+      site: { id: californiaSite.id },
+    });
+
+    const rsp = await request(app.getHttpServer()).get('/sites').query({
+      date: requestedDate,
+    });
+
+    expect(rsp.status).toBe(200);
+    const site = rsp.body.find(
+      (item: { id: number }) => item.id === californiaSite.id,
+    );
+
+    expect(site.collectionData).toMatchObject({
+      satelliteTemperature: pastCollectionData.satelliteTemperature,
+      dhw: pastCollectionData.degreeHeatingDays,
+      tempAlert: pastCollectionData.dailyAlertLevel,
+      tempWeeklyAlert: pastCollectionData.weeklyAlertLevel,
+    });
   });
 
   it('GET /:id retrieve one site', async () => {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
+import { DailyData } from '../sites/daily-data.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
@@ -43,6 +44,48 @@ export const getCollectionData = async (
       ),
     )
     .toJSON();
+};
+
+export const getCollectionDataForDate = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  startDate: Date,
+  endDate: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date >= :startDate', { startDate })
+    .andWhere('daily_data.date <= :endDate', { endDate })
+    .getRawMany();
+
+  return dailyData.reduce<Record<number, CollectionDataDto>>((acc, data) => {
+    const collectionData = _.omitBy(
+      {
+        satelliteTemperature: data.satelliteTemperature,
+        dhw: data.degreeHeatingDays,
+        tempAlert: data.dailyAlertLevel,
+        tempWeeklyAlert: data.weeklyAlertLevel,
+      },
+      _.isNil,
+    );
+
+    return {
+      ...acc,
+      [data.siteId]: collectionData,
+    };
+  }, {});
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,16 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
+        <div
+          class="Homepage-mapDateControl-3"
+        >
+          <mock-datepicker
+            datename="Map date"
+            datenametextvariant="body2"
+            timezone="UTC"
+            value="2026-05-12"
+          />
+        </div>
         <mock-map
           initialcenter="LatLng(0, 121.3)"
           initialzoom="4"
@@ -29,7 +39,7 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-4 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -9,6 +9,7 @@ import { mockSite } from 'mocks/mockSite';
 import Homepage from '.';
 
 vi.mock('common/NavBar', () => ({ default: 'Mock-NavBar' }));
+vi.mock('common/Datepicker', () => ({ default: 'Mock-DatePicker' }));
 vi.mock('./Map', () => ({ default: 'Mock-Map' }));
 vi.mock('./SiteTable', () => ({ default: 'Mock-SiteTable' }));
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,11 +3,12 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Button, Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
+import { DateTime } from 'luxon-extensions';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
@@ -15,12 +16,15 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import DatePicker from 'common/Datepicker';
+import { useQueryParam } from 'hooks/useQueryParams';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
@@ -67,13 +71,17 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapDate, setMapDate] = useQueryParam(
+    QueryParamKeys.DATE,
+    (value) => DateTime.fromISO(value).isValid,
+  );
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(mapDate));
+  }, [dispatch, mapDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -89,6 +97,22 @@ function Homepage({ classes }: HomepageProps) {
 
   const toggleDrawer = () => {
     setDrawerOpen(!isDrawerOpen);
+  };
+
+  const handleMapDateChange = (date: Date | null) => {
+    if (!date) {
+      setMapDate(undefined);
+      return;
+    }
+
+    const selectedDate = DateTime.fromJSDate(date).toUTC().endOf('day');
+    const today = DateTime.now().toUTC();
+
+    setMapDate(
+      selectedDate.hasSame(today, 'day')
+        ? undefined
+        : selectedDate.toISO() || undefined,
+    );
   };
 
   // scroll drawer to top when its closed.
@@ -118,6 +142,20 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
+            <div className={classes.mapDateControl}>
+              <DatePicker
+                value={mapDate || DateTime.now().toUTC().toISODate() || ''}
+                dateName="Map date"
+                dateNameTextVariant="body2"
+                timeZone="UTC"
+                onChange={handleMapDateChange}
+              />
+              {mapDate && (
+                <Button size="small" onClick={() => setMapDate(undefined)}>
+                  Today
+                </Button>
+              )}
+            </div>
             <HomepageMap
               onMapLoad={setMapInstance}
               setShowSiteTable={setShowSiteTable}
@@ -164,7 +202,21 @@ const styles = () =>
     },
     map: {
       display: 'flex',
+      position: 'relative',
       zIndex: 0,
+    },
+    mapDateControl: {
+      position: 'absolute',
+      top: 8,
+      left: 8,
+      zIndex: 500,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '6px 10px',
+      backgroundColor: 'rgba(255, 255, 255, 0.95)',
+      borderRadius: 4,
+      boxShadow: '0 1px 4px rgba(0, 0, 0, 0.25)',
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.test.ts
+++ b/packages/website/src/services/siteServices.test.ts
@@ -1,0 +1,25 @@
+import requests from 'helpers/requests';
+import siteServices from './siteServices';
+
+vi.mock('helpers/requests', () => ({
+  default: {
+    send: vi.fn(),
+  },
+}));
+
+describe('siteServices', () => {
+  beforeEach(() => {
+    vi.mocked(requests.send).mockReset();
+  });
+
+  it('requests sites for the selected historical date', () => {
+    const date = '2026-02-15T23:59:59.999Z';
+
+    siteServices.getSites(date);
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: `sites?date=${encodeURIComponent(date)}`,
+      method: 'GET',
+    });
+  });
+});

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: date ? `sites?date=${encodeURIComponent(date)}` : 'sites',
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +49,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date: string | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, date: storedDate },
       } = getState();
-      return !list;
+      return !list || storedDate !== date;
     },
   },
 );
@@ -108,6 +109,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  date?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
Fixes #1162.

## What changed
- Add an optional `date` query parameter to `GET /sites` so map collection data can be read from `daily_data` for a selected historical day.
- Add a map date picker and keep the selected date in the `date` query parameter; selecting today clears the query parameter and keeps the existing latest-data behavior.
- Pass the selected map date through the sites Redux request and service layer.
- Add backend and frontend regression coverage for historical map data requests.

## Verification
- `corepack yarn workspace website test src/services/siteServices.test.ts src/routes/HomeMap/index.test.tsx`
- backend targeted Jest: `node ../../node_modules/jest/bin/jest.js --config ./test/jest.json --runInBand --runTestsByPath ./test/app.spec.ts --testNamePattern "GET / find all sites with collection data for a past date"`
- scoped website ESLint on touched files
- scoped API ESLint on touched files
- `corepack yarn workspace website build`
- `corepack yarn workspace api build`
- `git diff --check`
