### PR TITLE
Add historical date support to site map

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2025-03-15', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getHistoricalCollectionData,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,17 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    if (filter.date && !DateTime.fromISO(filter.date).isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
+    const mappedSiteData = filter.date
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
+import { DailyData } from '../sites/daily-data.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
@@ -42,6 +43,52 @@ export const getCollectionData = async (
         {},
       ),
     )
+    .toJSON();
+};
+
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('DATE(daily_data.date) = DATE(:date)', { date })
+    .getRawMany();
+
+  return _(dailyData)
+    .groupBy((o) => o.siteId)
+    .mapValues<CollectionDataDto>((data) => {
+      const siteData = data[0];
+      const degreeHeatingDays =
+        typeof siteData.degreeHeatingDays === 'number'
+          ? siteData.degreeHeatingDays
+          : undefined;
+
+      return _.omitBy(
+        {
+          dhw:
+            degreeHeatingDays === undefined ? undefined : degreeHeatingDays / 7,
+          satelliteTemperature: siteData.satelliteTemperature,
+          tempAlert: siteData.dailyAlertLevel,
+          tempWeeklyAlert:
+            siteData.weeklyAlertLevel ?? siteData.dailyAlertLevel,
+        },
+        _.isNil,
+      ) as CollectionDataDto;
+    })
     .toJSON();
 };
 

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -8,7 +8,7 @@ import withStyles from '@mui/styles/withStyles';
 import createStyles from '@mui/styles/createStyles';
 import SearchIcon from '@mui/icons-material/Search';
 import Autocomplete from '@mui/material/Autocomplete';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { setSiteOnMap, setSearchResult } from 'store/Homepage/homepageSlice';
 import type { Site } from 'store/Sites/types';
@@ -29,12 +29,18 @@ const siteAugmentedName = (site: Site) => {
   return name || region || '';
 };
 
+const isDateQueryValue = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
+
 function Search({ geocodingEnabled = false, classes }: SearchProps) {
   const navigate = useNavigate();
+  const { search } = useLocation();
   const { id = '' } = useParams<{ id: string }>();
   const [searchedSite, setSearchedSite] = useState<Site | null>(null);
   const [searchValue, setSearchValue] = useState('');
   const dispatch = useAppDispatch();
+  const dateQuery = new URLSearchParams(search).get('date') || undefined;
+  const dataDate =
+    dateQuery && isDateQueryValue(dateQuery) ? dateQuery : undefined;
   const sites = useSelector(sitesListSelector);
   const filteredSites = (sites || [])
     .filter((site) => siteAugmentedName(site))
@@ -47,8 +53,8 @@ function Search({ geocodingEnabled = false, classes }: SearchProps) {
 
   // Fetch sites for the search bar
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(dataDate));
+  }, [dataDate, dispatch]);
 
   const onChangeSearchText = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -15,6 +15,7 @@ import {
   Hidden,
   Alert,
   Theme,
+  TextField,
 } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -89,6 +90,8 @@ function HomepageMap({
   defaultLayerName,
   legendBottom,
   legendLeft,
+  historicalDate,
+  onHistoricalDateChange,
   classes,
   onMapLoad,
 }: HomepageMapProps) {
@@ -275,6 +278,22 @@ function HomepageMap({
           <InfoIcon color="primary" />
         </IconButton>
       </div>
+      {onHistoricalDateChange && (
+        <div className={classes.dateControl}>
+          <TextField
+            aria-label="Map date"
+            size="small"
+            type="date"
+            value={historicalDate || ''}
+            onChange={(event) =>
+              onHistoricalDateChange(event.target.value || undefined)
+            }
+            inputProps={{
+              max: new Date().toISOString().slice(0, 10),
+            }}
+          />
+        </div>
+      )}
       <InfoDialog
         infoDialogOpen={infoDialogOpen}
         handleInfoClose={handleInfoClose}
@@ -358,6 +377,23 @@ const styles = (theme: Theme) =>
         top: 50,
       },
     },
+    dateControl: {
+      position: 'absolute',
+      left: 10,
+      top: 140,
+      zIndex: 1000,
+      borderRadius: 5,
+      backgroundColor: 'white',
+      backgroundClip: 'padding-box',
+      border: '2px solid rgba(0,0,0,0.2)',
+      '& .MuiInputBase-root': {
+        height: 40,
+        backgroundColor: 'white',
+      },
+      '& input': {
+        padding: '8px 10px',
+      },
+    },
     expandIcon: {
       fontSize: '34px',
     },
@@ -384,6 +420,10 @@ interface HomepageMapIncomingProps {
   defaultLayerName?: MapLayerName;
   legendBottom?: number;
   legendLeft?: number;
+  historicalDate?: string;
+  onHistoricalDateChange?: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
   onMapLoad?: (map: L.Map) => void;
 }
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -8,6 +8,7 @@ import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
+import { useQueryParam } from 'hooks/useQueryParams';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
@@ -21,6 +22,7 @@ import HomepageMap from './Map';
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
@@ -31,6 +33,7 @@ interface MapQueryParams {
 
 const INITIAL_CENTER = new LatLng(0, 121.3);
 const INITIAL_ZOOM = 4;
+const isDateQueryValue = (value: string) => /^\d{4}-\d{2}-\d{2}$/.test(value);
 
 function useQuery() {
   const urlParams: URLSearchParams = new URLSearchParams(useLocation().search);
@@ -67,13 +70,17 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [historicalDate, setHistoricalDate] = useQueryParam(
+    QueryParamKeys.DATE,
+    isDateQueryValue,
+  );
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(historicalDate));
+  }, [dispatch, historicalDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -124,6 +131,8 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              historicalDate={historicalDate}
+              onHistoricalDateChange={setHistoricalDate}
             />
           </Grid>
           {showSiteTable && (

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,10 +83,11 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
     url: 'sites',
     method: 'GET',
+    params: { date },
   });
 
 const getSiteSurveyPoints = (

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -31,17 +31,18 @@ const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
   filters: {},
+  dataDate: undefined,
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +50,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        dataDate: date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, dataDate },
       } = getState();
-      return !list;
+      return !list || dataDate !== date;
     },
   },
 );
@@ -108,6 +110,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        dataDate: action.payload.dataDate,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  dataDate?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  dataDate?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
/claim #1162

## Summary
- Add optional `date` filtering to the sites endpoint and return historical map collection data from `daily_data`.
- Add a date picker/query param to the homepage map so users can view site data for a past date.
- Keep site list caching and search results aligned with the selected historical date.

## Testing
- `yarn --cwd packages/api --ignore-engines run lint`
- `yarn --cwd packages/website --ignore-engines run lint`
- `node ../.tools/yarn-v1.22.21/lib/cli.js --cwd packages/api run build` with Node 20
- `node ../.tools/yarn-v1.22.21/lib/cli.js --cwd packages/website run build` with Node 20

## Notes
- Full test suites were attempted. Existing tests currently require external GeoTIFF/Sofar/API network access and `BACKEND_BASE_URL`; related HomeMap/Search tests passed during the run.