### PR TITLE
feat: add historical date picker to view past map/site data

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2024-03-01' })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getHistoricalCollectionData,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mappedSiteData = filter.date
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,32 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET /?date= find all sites with historical date', async () => {
+    const date = DateTime.now().minus({ days: 2 }).toFormat('yyyy-MM-dd');
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({ date });
+
+    expect(rsp.status).toBe(200);
+    expect(rsp.body.length).toBeGreaterThan(0);
+    // Sites with daily_data should have collectionData populated from daily_data
+    const siteWithData = rsp.body.find(
+      (site: any) => site.id === californiaSite.id,
+    );
+    expect(siteWithData).toBeDefined();
+    if (siteWithData?.collectionData) {
+      // When collectionData is populated from daily_data, it should contain
+      // satellite temperature and/or DHW values
+      const { satelliteTemperature, dhw, tempAlert } =
+        siteWithData.collectionData;
+      const hasAnyData =
+        satelliteTemperature !== undefined ||
+        dhw !== undefined ||
+        tempAlert !== undefined;
+      expect(hasAnyData).toBe(true);
+    }
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
+import { DailyData } from '../sites/daily-data.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
@@ -42,6 +43,57 @@ export const getCollectionData = async (
         {},
       ),
     )
+    .toJSON();
+};
+
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.id', 'id')
+    .addSelect('daily_data.date', 'date')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .addSelect('site_id', 'siteId')
+    .where('site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date })
+    .andWhere(
+      'daily_data.date >= :minDate',
+      // Look back up to 7 days to find the closest data
+      {
+        minDate: new Date(
+          new Date(date).getTime() - 7 * 24 * 60 * 60 * 1000,
+        )
+          .toISOString()
+          .split('T')[0],
+      },
+    )
+    .orderBy('daily_data.date', 'DESC')
+    .getRawMany();
+
+  // Group by site and take the most recent row per site
+  return _(dailyData)
+    .groupBy((o) => o.siteId)
+    .mapValues<CollectionDataDto>((data) => {
+      const latest = data[0]; // Already sorted DESC by date
+      return {
+        satelliteTemperature: latest.satelliteTemperature,
+        dhw: latest.degreeHeatingDays,
+        tempAlert: latest.dailyAlertLevel,
+        tempWeeklyAlert: latest.weeklyAlertLevel,
+      };
+    })
     .toJSON();
 };
 

--- a/packages/api/test/mock/daily-data.mock.ts
+++ b/packages/api/test/mock/daily-data.mock.ts
@@ -11,6 +11,7 @@ const getMockDailyData = (
   site: DeepPartial<Site>,
 ): DeepPartial<DailyData> => ({
   dailyAlertLevel: random(4),
+  weeklyAlertLevel: random(4),
   degreeHeatingDays: random(70, true),
   date,
   site,

--- a/packages/website/src/routes/HomeMap/Map/HistoricalDatePicker/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/HistoricalDatePicker/index.tsx
@@ -1,0 +1,172 @@
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  IconButton,
+  Tooltip,
+  Theme,
+  Typography,
+  Box,
+} from '@mui/material';
+import { WithStyles } from '@mui/styles';
+import createStyles from '@mui/styles/createStyles';
+import withStyles from '@mui/styles/withStyles';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
+import CloseIcon from '@mui/icons-material/Close';
+import { DatePicker } from '@mui/x-date-pickers/DatePicker';
+import { LocalizationProvider } from '@mui/x-date-pickers/LocalizationProvider';
+import { AdapterDateFns } from '@mui/x-date-pickers/AdapterDateFns';
+import { format } from 'date-fns';
+import { useAppDispatch } from 'store/hooks';
+import {
+  historicalDateSelector,
+  setHistoricalDate,
+} from 'store/Homepage/homepageSlice';
+import { sitesRequest } from 'store/Sites/sitesListSlice';
+import { mapIconSize } from 'layout/App/theme';
+
+function HistoricalDatePicker({ classes }: HistoricalDatePickerProps) {
+  const dispatch = useAppDispatch();
+  const historicalDate = useSelector(historicalDateSelector);
+  const [pickerOpen, setPickerOpen] = React.useState(false);
+
+  const handleDateChange = useCallback(
+    (date: Date | null) => {
+      if (date && !Number.isNaN(date.getTime())) {
+        const dateStr = format(date, 'yyyy-MM-dd');
+        dispatch(setHistoricalDate(dateStr));
+        dispatch(sitesRequest(dateStr));
+      }
+      setPickerOpen(false);
+    },
+    [dispatch],
+  );
+
+  const handleClear = useCallback(() => {
+    dispatch(setHistoricalDate(null));
+    dispatch(sitesRequest());
+  }, [dispatch]);
+
+  const isActive = Boolean(historicalDate);
+
+  return (
+    <div className={classes.container}>
+      {isActive && (
+        <Box className={classes.dateLabel}>
+          <Typography variant="caption" className={classes.dateLabelText}>
+            {historicalDate}
+          </Typography>
+          <IconButton
+            size="small"
+            onClick={handleClear}
+            className={classes.clearButton}
+          >
+            <CloseIcon fontSize="small" />
+          </IconButton>
+        </Box>
+      )}
+      <Tooltip title="View historical data">
+        <IconButton
+          onClick={() => setPickerOpen(true)}
+          className={isActive ? classes.activeButton : classes.button}
+          size="large"
+        >
+          <CalendarTodayIcon
+            color={isActive ? 'inherit' : 'primary'}
+            fontSize="small"
+          />
+        </IconButton>
+      </Tooltip>
+      <LocalizationProvider dateAdapter={AdapterDateFns}>
+        <DatePicker
+          open={pickerOpen}
+          onClose={() => setPickerOpen(false)}
+          value={historicalDate ? new Date(historicalDate) : null}
+          onChange={handleDateChange}
+          maxDate={new Date()}
+          minDate={new Date('2000-01-01')}
+          slotProps={{
+            textField: {
+              className: classes.hiddenInput,
+            },
+            toolbar: { hidden: true },
+          }}
+        />
+      </LocalizationProvider>
+    </div>
+  );
+}
+
+const styles = (theme: Theme) =>
+  createStyles({
+    container: {
+      position: 'absolute',
+      right: 0,
+      top: 150,
+      zIndex: 400,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-end',
+      margin: '10px',
+      [theme.breakpoints.down('lg')]: {
+        top: 100,
+      },
+    },
+    button: {
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: mapIconSize,
+      width: mapIconSize,
+      borderRadius: 5,
+      backgroundColor: 'white',
+      backgroundClip: 'padding-box',
+      border: '2px solid rgba(0,0,0,0.2)',
+    },
+    activeButton: {
+      cursor: 'pointer',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      height: mapIconSize,
+      width: mapIconSize,
+      borderRadius: 5,
+      backgroundColor: theme.palette.primary.main,
+      color: 'white',
+      backgroundClip: 'padding-box',
+      border: '2px solid rgba(0,0,0,0.2)',
+      '&:hover': {
+        backgroundColor: theme.palette.primary.dark,
+      },
+    },
+    dateLabel: {
+      display: 'flex',
+      alignItems: 'center',
+      backgroundColor: theme.palette.primary.main,
+      borderRadius: 4,
+      padding: '2px 4px 2px 8px',
+      marginBottom: 4,
+    },
+    dateLabelText: {
+      color: 'white',
+      fontWeight: 600,
+      whiteSpace: 'nowrap',
+    },
+    clearButton: {
+      color: 'white',
+      padding: 2,
+      marginLeft: 2,
+    },
+    hiddenInput: {
+      position: 'absolute',
+      width: 0,
+      height: 0,
+      overflow: 'hidden',
+      opacity: 0,
+      pointerEvents: 'none',
+    },
+  });
+
+type HistoricalDatePickerProps = WithStyles<typeof styles>;
+
+export default withStyles(styles)(HistoricalDatePicker);

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -40,6 +40,7 @@ import { SofarLayers } from './sofarLayers';
 import { InfoDialog } from './InfoDialog';
 import Legend from './Legend';
 import AlertLevelLegend from './alertLevelLegend';
+import HistoricalDatePicker from './HistoricalDatePicker';
 
 const accessToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 
@@ -279,6 +280,7 @@ function HomepageMap({
         infoDialogOpen={infoDialogOpen}
         handleInfoClose={handleInfoClose}
       />
+      <HistoricalDatePicker />
       {tileLayer}
       {sofarLayers}
       {siteMarkers}

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -27,6 +27,7 @@ describe('Homepage', () => {
       },
       homepage: {
         siteOnMap: null,
+        historicalDate: null,
       },
       user: {
         userInfo: mockUser,

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -10,7 +10,10 @@ import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
-import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
+import {
+  siteOnMapSelector,
+  historicalDateSelector,
+} from 'store/Homepage/homepageSlice';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
@@ -65,6 +68,7 @@ function useQuery() {
 function Homepage({ classes }: HomepageProps) {
   const dispatch = useAppDispatch();
   const siteOnMap = useSelector(siteOnMapSelector);
+  const historicalDate = useSelector(historicalDateSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
@@ -72,8 +76,8 @@ function Homepage({ classes }: HomepageProps) {
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(historicalDate ?? undefined));
+  }, [dispatch, historicalDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: date ? `sites?date=${date}` : 'sites',
     method: 'GET',
   });
 

--- a/packages/website/src/store/Homepage/homepageSlice.ts
+++ b/packages/website/src/store/Homepage/homepageSlice.ts
@@ -7,6 +7,7 @@ import type { RootState } from '../configure';
 const homepageInitialState: HomePageState = {
   siteOnMap: null,
   siteFilter: 'All sites',
+  historicalDate: null,
 };
 
 const homepageSlice = createSlice({
@@ -35,6 +36,10 @@ const homepageSlice = createSlice({
       ...state,
       siteOnMap: null,
     }),
+    setHistoricalDate: (state, action: PayloadAction<string | null>) => ({
+      ...state,
+      historicalDate: action.payload,
+    }),
   },
 });
 
@@ -53,11 +58,16 @@ export const siteFilterSelector = (
   state: RootState,
 ): HomePageState['siteFilter'] => state.homepage.siteFilter;
 
+export const historicalDateSelector = (
+  state: RootState,
+): HomePageState['historicalDate'] => state.homepage.historicalDate;
+
 export const {
   setSearchResult,
   setSiteOnMap,
   unsetSiteOnMap,
   setWithSpotterOnly,
+  setHistoricalDate,
 } = homepageSlice.actions;
 
 export default homepageSlice.reducer;

--- a/packages/website/src/store/Homepage/types.ts
+++ b/packages/website/src/store/Homepage/types.ts
@@ -19,6 +19,7 @@ export interface HomePageState {
   siteOnMap: SiteOnMap;
   searchResult?: MapboxGeolocationData;
   siteFilter: (typeof siteOptions)[number];
+  historicalDate: string | null;
 }
 
 export interface TableRow {

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,7 +55,9 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date: string | undefined, { getState }) {
+      // Always refetch when a historical date is provided
+      if (date) return true;
       const {
         sitesList: { list },
       } = getState();


### PR DESCRIPTION
Allow users to select a date in the past and view the map and site data as it was on that date.

- Add HistoricalDatePicker component to the map UI
- Extend API filter DTOs to accept date query parameters
- Add date filtering utilities for daily data collections
- Update Redux store with historical date state management
- Add API test coverage for date-filtered queries

Resolves https://github.com/aqualinkorg/aqualink-app/issues/1162