### PR TITLE
Add historical date support to map sites

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2024-01-15', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getCollectionDataForDate,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,21 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const requestedDate = filter.date
+      ? DateTime.fromISO(filter.date, { zone: 'utc' })
+      : undefined;
+
+    if (filter.date && !requestedDate?.isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
+    const mappedSiteData = requestedDate
+      ? await getCollectionDataForDate(
+          res,
+          this.dailyDataRepository,
+          requestedDate.toJSDate(),
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -5,6 +5,7 @@ import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
+import { DailyData } from '../sites/daily-data.entity';
 
 export const getCollectionData = async (
   sites: Site[],
@@ -42,6 +43,59 @@ export const getCollectionData = async (
         {},
       ),
     )
+    .toJSON();
+};
+
+export const getCollectionDataForDate = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const startDate = new Date(
+    Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()),
+  );
+  const endDate = new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      date.getUTCMonth(),
+      date.getUTCDate(),
+      23,
+      59,
+      59,
+      999,
+    ),
+  );
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .leftJoinAndSelect('daily_data.site', 'site')
+    .where('site.id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date >= :startDate', { startDate })
+    .andWhere('daily_data.date <= :endDate', { endDate })
+    .orderBy('daily_data.date', 'DESC')
+    .getMany();
+
+  return _(dailyData)
+    .filter((siteData) => Boolean(siteData.site?.id))
+    .groupBy((siteData) => siteData.site.id)
+    .mapValues<CollectionDataDto>((data) => {
+      const [siteData] = data;
+      return _.omitBy(
+        {
+          satelliteTemperature: siteData.satelliteTemperature,
+          dhw: siteData.degreeHeatingDays,
+          tempAlert: siteData.dailyAlertLevel,
+          tempWeeklyAlert: siteData.weeklyAlertLevel,
+        },
+        _.isNil,
+      ) as CollectionDataDto;
+    })
     .toJSON();
 };
 

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -34,7 +34,7 @@ function DatePicker({
                 .toJSDate()}
               minDate={DateTime.fromMillis(0).toJSDate()}
               closeOnSelect={autoOk}
-              value={parseISO(value ?? '')}
+              value={value ? parseISO(value) : null}
               onChange={(v) => onChange(v)}
               slotProps={{
                 textField: {

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -13,11 +13,20 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
   <div
     class="Homepage-root-1"
   >
+    <mock-box
+      classname="Homepage-mapDateControl-2"
+    >
+      <mock-datepicker
+        datename="Map date"
+        datenametextvariant="subtitle2"
+        timezone="UTC"
+      />
+    </mock-box>
     <div
       class="MuiGrid-root MuiGrid-container css-11lq3yg-MuiGrid-root"
     >
       <div
-        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-3 css-1fyyp8j-MuiGrid-root"
       >
         <mock-map
           initialcenter="LatLng(0, 121.3)"
@@ -29,7 +38,7 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-4 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -9,6 +9,7 @@ import { mockSite } from 'mocks/mockSite';
 import Homepage from '.';
 
 vi.mock('common/NavBar', () => ({ default: 'Mock-NavBar' }));
+vi.mock('common/Datepicker', () => ({ default: 'Mock-DatePicker' }));
 vi.mock('./Map', () => ({ default: 'Mock-Map' }));
 vi.mock('./SiteTable', () => ({ default: 'Mock-SiteTable' }));
 
@@ -19,6 +20,7 @@ describe('Homepage', () => {
     const store = mockStore({
       sitesList: {
         list: [mockSite],
+        requestedDate: null,
         loading: false,
         error: null,
       },

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,11 +3,12 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Box, Button, Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
+import { DateTime } from 'luxon-extensions';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
@@ -15,6 +16,7 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import DatePicker from 'common/Datepicker';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
@@ -67,13 +69,23 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapDate, setMapDate] = useState<string | undefined>();
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(mapDate));
+  }, [dispatch, mapDate]);
+
+  const onMapDateChange = (date: Date | null) => {
+    if (!date) {
+      setMapDate(undefined);
+      return;
+    }
+
+    setMapDate(DateTime.fromJSDate(date).toFormat('yyyy-MM-dd'));
+  };
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -111,6 +123,20 @@ function Homepage({ classes }: HomepageProps) {
         <HomepageNavBar searchLocation geocodingEnabled />
       </div>
       <div className={classes.root}>
+        <Box className={classes.mapDateControl}>
+          <DatePicker
+            value={mapDate || null}
+            dateName="Map date"
+            dateNameTextVariant="subtitle2"
+            timeZone="UTC"
+            onChange={onMapDateChange}
+          />
+          {mapDate && (
+            <Button size="small" onClick={() => setMapDate(undefined)}>
+              Today
+            </Button>
+          )}
+        </Box>
         <Grid container>
           <Grid
             className={classes.map}
@@ -161,6 +187,24 @@ const styles = () =>
       display: 'flex',
       flexGrow: 1,
       userSelect: 'none',
+      position: 'relative',
+    },
+    mapDateControl: {
+      position: 'absolute',
+      top: 16,
+      left: 16,
+      zIndex: 500,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 12px',
+      backgroundColor: 'rgba(255, 255, 255, 0.92)',
+      borderRadius: 4,
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.22)',
+      '@media (max-width:600px)': {
+        top: 8,
+        left: 8,
+      },
     },
     map: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -31,17 +31,18 @@ const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
   filters: {},
+  requestedDate: null,
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (requestedDate, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(requestedDate);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +50,20 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        requestedDate: requestedDate || null,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(requestedDate, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, loading, requestedDate: currentRequestedDate },
       } = getState();
-      return !list;
+      return (
+        !loading && (!list || currentRequestedDate !== (requestedDate || null))
+      );
     },
   },
 );
@@ -108,6 +112,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        requestedDate: action.payload.requestedDate,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  requestedDate: string | null;
 }
 
 export interface SitesListState {
   list?: Site[];
+  requestedDate?: string | null;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
## Summary
Adds historical map data support for the sites endpoint and a map date selector so users can view reef data for a past date.

## Changes
- Added optional `date` query support to the `/sites` API.
- Mapped historical `daily_data` values into the existing collection data fields used by the map and site table.
- Added a small map date picker with a reset button for returning to current data.

## Testing
- `corepack yarn --ignore-engines lint ./packages/api/src/utils/collections.utils.ts ./packages/api/src/sites/sites.service.ts ./packages/api/src/sites/dto/filter-site.dto.ts ./packages/website/src/common/Datepicker/index.tsx ./packages/website/src/routes/HomeMap/index.tsx ./packages/website/src/services/siteServices.ts ./packages/website/src/store/Sites/sitesListSlice.ts ./packages/website/src/store/Sites/types.ts`
- `corepack yarn --ignore-engines --cwd packages/website test src/routes/HomeMap/index.test.tsx`
- `corepack yarn --ignore-engines --cwd packages/api build`
- `corepack yarn --ignore-engines --cwd packages/website build`
- Full API test suite was run, but some existing environment/external-service tests require local app environment/Sofar data.
- Full website test suite was run, but two existing locale-sensitive snapshots fail in unrelated monitoring routes.

## Notes
Kept the change minimal and focused on the reported issue.

Closes #1162

The existing per-site daily data endpoint can support one selected site/date, but using it for all visible map markers would require many frontend requests. This PR keeps the existing sites list and collectionData flow and adds only an optional date path for the map.

## Bounty
/claim #1162