### PR TITLE
Add past-date collection data support to the map

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2024-01-01' })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getCollectionDataForDate,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,17 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    if (filter.date && !DateTime.fromISO(filter.date).isValid) {
+      throw new BadRequestException('Date is not valid');
+    }
+
+    const mappedSiteData = filter.date
+      ? await getCollectionDataForDate(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -305,6 +305,23 @@ export const siteTests = () => {
       expect(rsp.status).toBe(200);
       expect(rsp.body.length).toBe(2);
     });
+
+    it('GET / filter sites collection data by date', async () => {
+      const dailyData = californiaDailyData[0];
+      const rsp = await request(app.getHttpServer()).get('/sites').query({
+        date: dailyData.date,
+      });
+
+      expect(rsp.status).toBe(200);
+      const california = rsp.body.find(
+        (site: Site) => site.id === californiaSite.id,
+      );
+      expect(california.collectionData).toMatchObject({
+        satelliteTemperature: dailyData.satelliteTemperature,
+        dhw: dailyData.degreeHeatingDays! / 7,
+        tempAlert: dailyData.dailyAlertLevel,
+      });
+    });
   });
 
   describe('test edge cases', () => {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,6 +2,7 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
@@ -42,6 +43,49 @@ export const getCollectionData = async (
         {},
       ),
     )
+    .toJSON();
+};
+
+export const getCollectionDataForDate = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .leftJoin('daily_data.site', 'site')
+    .select('site.id', 'siteId')
+    .addSelect('daily_data.satelliteTemperature', 'satelliteTemperature')
+    .addSelect('daily_data.degreeHeatingDays', 'degreeHeatingDays')
+    .addSelect('daily_data.dailyAlertLevel', 'dailyAlertLevel')
+    .addSelect('daily_data.weeklyAlertLevel', 'weeklyAlertLevel')
+    .where('site.id IN (:...siteIds)', { siteIds })
+    .andWhere('Date(daily_data.date) = Date(:date)', { date })
+    .getRawMany<{
+      siteId: number;
+      satelliteTemperature?: number | null;
+      degreeHeatingDays?: number | null;
+      dailyAlertLevel?: number | null;
+      weeklyAlertLevel?: number | null;
+    }>();
+
+  return _(dailyData)
+    .keyBy((siteData) => siteData.siteId)
+    .mapValues<CollectionDataDto>((siteData) => ({
+      satelliteTemperature: siteData.satelliteTemperature ?? undefined,
+      dhw:
+        siteData.degreeHeatingDays != null
+          ? siteData.degreeHeatingDays / 7
+          : undefined,
+      tempAlert: siteData.dailyAlertLevel ?? undefined,
+      tempWeeklyAlert: siteData.weeklyAlertLevel ?? undefined,
+    }))
     .toJSON();
 };
 

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,46 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
+        <div
+          class="Homepage-mapDateControl-3"
+        >
+          <div
+            class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
+          >
+            <label
+              class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-hvjq6j-MuiFormLabel-root-MuiInputLabel-root"
+              data-shrink="true"
+              for=":r0:"
+              id=":r0:-label"
+            >
+              Map date
+            </label>
+            <div
+              class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-quhxjy-MuiInputBase-root-MuiOutlinedInput-root"
+            >
+              <input
+                aria-invalid="false"
+                class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-1pzfmz2-MuiInputBase-input-MuiOutlinedInput-input"
+                id=":r0:"
+                max="2026-05-20"
+                type="date"
+                value=""
+              />
+              <fieldset
+                aria-hidden="true"
+                class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+              >
+                <legend
+                  class="css-ex8a5f-MuiNotchedOutlined-root"
+                >
+                  <span>
+                    Map date
+                  </span>
+                </legend>
+              </fieldset>
+            </div>
+          </div>
+        </div>
         <mock-map
           initialcenter="LatLng(0, 121.3)"
           initialzoom="4"
@@ -29,7 +69,7 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-4 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Button, Grid, Hidden, TextField } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -67,13 +67,14 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapDate, setMapDate] = useState<string | null>(null);
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(mapDate));
+  }, [dispatch, mapDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -118,6 +119,31 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
+            <div className={classes.mapDateControl}>
+              <TextField
+                label="Map date"
+                size="small"
+                type="date"
+                value={mapDate || ''}
+                InputLabelProps={{ shrink: true }}
+                inputProps={{
+                  max: new Date().toISOString().slice(0, 10),
+                }}
+                onChange={(event) => {
+                  setMapDate(event.target.value || null);
+                }}
+              />
+              {mapDate && (
+                <Button
+                  color="primary"
+                  onClick={() => setMapDate(null)}
+                  size="small"
+                  variant="contained"
+                >
+                  Live
+                </Button>
+              )}
+            </div>
             <HomepageMap
               onMapLoad={setMapInstance}
               setShowSiteTable={setShowSiteTable}
@@ -164,7 +190,21 @@ const styles = () =>
     },
     map: {
       display: 'flex',
+      position: 'relative',
       zIndex: 0,
+    },
+    mapDateControl: {
+      alignItems: 'center',
+      backgroundColor: 'white',
+      borderRadius: 4,
+      boxShadow: '0 1px 4px rgba(0, 0, 0, 0.3)',
+      display: 'flex',
+      gap: 8,
+      left: 56,
+      padding: 8,
+      position: 'absolute',
+      top: 12,
+      zIndex: 401,
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string | null) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${requests.generateUrlQueryParams({ date })}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,14 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | null | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const requestedDate = arg || null;
+      const { data } = await siteServices.getSites(requestedDate);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +50,19 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        requestedDate,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: string | null | undefined, { getState }) {
+      const requestedDate = arg || null;
       const {
-        sitesList: { list },
+        sitesList: { list, requestedDate: currentRequestedDate },
       } = getState();
-      return !list;
+      return !list || currentRequestedDate !== requestedDate;
     },
   },
 );
@@ -108,6 +111,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        requestedDate: action.payload.requestedDate,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  requestedDate?: string | null;
 }
 
 export interface SitesListState {
   list?: Site[];
+  requestedDate?: string | null;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
## Summary

Adds an optional date selector to the home map so site markers and map table data can be loaded for a past date.

This introduces `GET /sites?date=YYYY-MM-DD` support. When a date is provided, site `collectionData` is derived from `daily_data` for that date instead of `latest_data`.

Fixes #1162.

## Scope

- Adds optional `date` filtering to the sites list endpoint
- Maps daily data into existing collection data fields used by the map:
  - `satelliteTemperature`
  - `dhw`
  - `tempAlert`
  - `tempWeeklyAlert`
- Adds a small date control on the map with a reset back to live/latest data
- Adds API coverage for date-filtered site collection data

## Notes

This focuses on the map/list data path first. Selected site details still use the existing latest-data endpoint and can be adapted separately.

## Testing

- `yarn install --frozen-lockfile` under Node 20: passed
- `yarn workspace api build`: passed
- Targeted ESLint on changed API files: passed
- Targeted ESLint on changed website files: passed
- `git diff --check`: passed

Could not fully run the new API test locally because the expected Postgres/PostGIS test database was not running on `localhost:54321`.

Could not complete `yarn workspace website build` locally because Windows Application Control blocked the Rspack native binding.

/claim #1162