### PR TITLE
Home map: add "As of" date selector

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,14 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({
+    required: false,
+    example: '2026-05-20T12:00:00.000Z',
+    description:
+      'Return collectionData as-of this timestamp (ISO 8601). Defaults to latest when omitted.',
+  })
+  @IsOptional()
+  @IsDateString()
+  readonly asOf?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -71,10 +71,18 @@ export class SitesController {
   @ApiNestNotFoundResponse('No site was found with the specified id')
   @ApiOperation({ summary: 'Returns specified site' })
   @ApiParam({ name: 'id', example: 1 })
+  @ApiQuery({
+    name: 'asOf',
+    required: false,
+    example: '2026-05-20T12:00:00.000Z',
+  })
   @Public()
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Site> {
-    return this.sitesService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('asOf', ParseDatePipe) asOf?: string,
+  ): Promise<Site> {
+    return this.sitesService.findOne(id, asOf);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -198,9 +198,14 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
+    const asOf = filter.asOf ? new Date(filter.asOf) : undefined;
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      {
+        asOf,
+        timeSeriesRepository: this.timeSeriesRepository,
+      },
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
@@ -223,7 +228,7 @@ export class SitesService {
     }));
   }
 
-  async findOne(id: number): Promise<Site> {
+  async findOne(id: number, asOf?: string): Promise<Site> {
     const site = await getSite(
       id,
       this.sitesRepository,
@@ -249,6 +254,10 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       [site],
       this.latestDataRepository,
+      {
+        asOf: asOf ? new Date(asOf) : undefined,
+        timeSeriesRepository: this.timeSeriesRepository,
+      },
     );
 
     const maskedSpotterApiToken = site.spotterApiToken

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -5,10 +5,15 @@ import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
+import { TimeSeries } from '../time-series/time-series.entity';
 
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  options?: {
+    asOf?: Date;
+    timeSeriesRepository?: Repository<TimeSeries>;
+  },
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
@@ -16,19 +21,68 @@ export const getCollectionData = async (
     return {};
   }
 
-  // Get latest data
-  const latestData: LatestData[] = await latestDataRepository
-    .createQueryBuilder('latest_data')
-    .select('id')
-    .addSelect('timestamp')
-    .addSelect('value')
-    .addSelect('site_id', 'siteId')
-    .addSelect('survey_point_id', 'surveyPointId')
-    .addSelect('metric')
-    .addSelect('source')
-    .where('site_id IN (:...siteIds)', { siteIds })
-    .andWhere('source != :hoboSource', { hoboSource: SourceType.HOBO })
-    .getRawMany();
+  const asOf = options?.asOf;
+  const timeSeriesRepository = options?.timeSeriesRepository;
+
+  const weekAgo = asOf ? new Date(asOf.getTime() - 7 * 24 * 60 * 60 * 1000) : null;
+  const twoYearsAgo = asOf
+    ? new Date(asOf.getTime() - 2 * 365 * 24 * 60 * 60 * 1000)
+    : null;
+
+  const latestData: Array<{
+    siteId: number;
+    metric: string;
+    value: number;
+  }> =
+    asOf && timeSeriesRepository
+      ? await timeSeriesRepository
+          .createQueryBuilder('time_series')
+          .select(
+            'DISTINCT ON (time_series.metric, sources.type, sources.site_id, sources.survey_point_id) time_series.id',
+            'id',
+          )
+          .addSelect('time_series.metric', 'metric')
+          .addSelect('time_series.timestamp', 'timestamp')
+          .addSelect('time_series.value', 'value')
+          .addSelect('sources.type', 'source')
+          .addSelect('sources.site_id', 'siteId')
+          .addSelect('sources.survey_point_id', 'surveyPointId')
+          .innerJoin('sources', 'sources', 'sources.id = time_series.source_id')
+          .where('sources.site_id IN (:...siteIds)', { siteIds })
+          .andWhere('sources.type != :hoboSource', {
+            hoboSource: SourceType.HOBO,
+          })
+          .andWhere('time_series.timestamp <= :asOf', { asOf })
+          .andWhere(
+            `(
+              time_series.timestamp >= :weekAgo
+              OR (
+                sources.type IN ('sonde', 'hui', 'sheet_data')
+                AND time_series.timestamp >= :twoYearsAgo
+              )
+            )`,
+            {
+              weekAgo,
+              twoYearsAgo,
+            },
+          )
+          .orderBy(
+            'time_series.metric, sources.type, sources.site_id, sources.survey_point_id, time_series.timestamp',
+            'DESC',
+          )
+          .getRawMany()
+      : await latestDataRepository
+          .createQueryBuilder('latest_data')
+          .select('id')
+          .addSelect('timestamp')
+          .addSelect('value')
+          .addSelect('site_id', 'siteId')
+          .addSelect('survey_point_id', 'surveyPointId')
+          .addSelect('metric')
+          .addSelect('source')
+          .where('site_id IN (:...siteIds)', { siteIds })
+          .andWhere('source != :hoboSource', { hoboSource: SourceType.HOBO })
+          .getRawMany();
 
   // Map data to each site and map each site's data to the CollectionDataDto
   return _(latestData)

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -34,7 +34,7 @@ function DatePicker({
                 .toJSDate()}
               minDate={DateTime.fromMillis(0).toJSDate()}
               closeOnSelect={autoOk}
-              value={parseISO(value ?? '')}
+              value={value ? parseISO(value) : null}
               onChange={(v) => onChange(v)}
               slotProps={{
                 textField: {
@@ -63,7 +63,7 @@ const styles = (theme: Theme) =>
         borderColor: 'rgba(0, 0, 0, 0.23)',
       },
       '& .MuiOutlinedInput-root.Mui-focused .MuiOutlinedInput-notchedOutline': {
-        borderColor: theme.palette.primary.main,
+        borderColor: theme?.palette?.primary?.main ?? 'rgba(0, 0, 0, 0.23)',
       },
       '& input': {
         paddingTop: 0,

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,17 +19,60 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
-        <mock-map
-          initialcenter="LatLng(0, 121.3)"
-          initialzoom="4"
-          showsitetable="true"
-        />
+        <mock-box
+          classname="Homepage-mapContainer-3"
+        >
+          <mock-box
+            classname="Homepage-asOfPicker-4"
+          >
+            <div
+              class="MuiGrid-root MuiGrid-item css-13i4rnv-MuiGrid-root"
+            >
+              <mock-box
+                alignitems="flex-end"
+                display="flex"
+              >
+                <mock-typography
+                  color="textSecondary"
+                  variant="h6"
+                >
+                  As of:
+                </mock-typography>
+                <div
+                  class="DatePicker-datePicker-6"
+                >
+                  <mock-date-picker
+                    classname="DatePicker-textField-7"
+                    closeonselect="true"
+                    format="MM/dd/yyyy"
+                    maxdate="Wed May 20 2026 23:08:46 GMT+0000 (Coordinated Universal Time)"
+                    mindate="Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                    slotprops="[object Object]"
+                  />
+                </div>
+              </mock-box>
+            </div>
+            <button
+              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeSmall MuiButton-textSizeSmall MuiButton-colorPrimary css-1ccsd5i-MuiButtonBase-root-MuiButton-root"
+              disabled=""
+              tabindex="-1"
+              type="button"
+            >
+              Latest
+            </button>
+          </mock-box>
+          <mock-map
+            initialcenter="LatLng(0, 121.3)"
+            initialzoom="4"
+            showsitetable="true"
+          />
+        </mock-box>
       </div>
       <mock-hidden
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-5 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Box, Button, Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -11,6 +11,7 @@ import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
+import DatePicker from 'common/Datepicker';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
@@ -67,13 +68,14 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [asOf, setAsOf] = useState<string | null>(null);
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest({ asOf }));
+  }, [dispatch, asOf]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -118,13 +120,38 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
-            <HomepageMap
-              onMapLoad={setMapInstance}
-              setShowSiteTable={setShowSiteTable}
-              showSiteTable={showSiteTable}
-              initialZoom={initialZoom}
-              initialCenter={initialCenter}
-            />
+            <Box className={classes.mapContainer}>
+              <Box className={classes.asOfPicker}>
+                <DatePicker
+                  dateName="As of"
+                  timeZone={null}
+                  value={asOf}
+                  onChange={(date) => {
+                    if (!date) {
+                      setAsOf(null);
+                      return;
+                    }
+                    const endOfDay = new Date(date);
+                    endOfDay.setHours(23, 59, 59, 999);
+                    setAsOf(endOfDay.toISOString());
+                  }}
+                />
+                <Button
+                  size="small"
+                  onClick={() => setAsOf(null)}
+                  disabled={!asOf}
+                >
+                  Latest
+                </Button>
+              </Box>
+              <HomepageMap
+                onMapLoad={setMapInstance}
+                setShowSiteTable={setShowSiteTable}
+                showSiteTable={showSiteTable}
+                initialZoom={initialZoom}
+                initialCenter={initialCenter}
+              />
+            </Box>
           </Grid>
           {showSiteTable && (
             <Hidden mdDown>
@@ -165,6 +192,22 @@ const styles = () =>
     map: {
       display: 'flex',
       zIndex: 0,
+    },
+    mapContainer: {
+      position: 'relative',
+      flex: 1,
+    },
+    asOfPicker: {
+      position: 'absolute',
+      zIndex: 500,
+      top: 12,
+      left: 12,
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.5rem',
+      padding: '0.25rem 0.5rem',
+      borderRadius: 8,
+      background: 'rgba(255, 255, 255, 0.9)',
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (asOf?: string | null) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${asOf ? `?asOf=${encodeURIComponent(asOf)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -31,17 +31,18 @@ const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
   filters: {},
+  asOf: null,
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  { asOf?: string | null } | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(arg?.asOf ?? null);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,11 +56,12 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: { asOf?: string | null } | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, asOf },
       } = getState();
-      return !list;
+      const requestedAsOf = arg?.asOf ?? null;
+      return !list || (asOf ?? null) !== requestedAsOf;
     },
   },
 );
@@ -103,14 +105,14 @@ const sitesListSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      sitesRequest.fulfilled,
-      (state, action: PayloadAction<SitesRequestData>) => ({
-        ...state,
-        list: action.payload.list,
-        loading: false,
-      }),
-    );
+    builder.addCase(sitesRequest.fulfilled, (state, action) => {
+      // eslint-disable-next-line fp/no-mutation
+      state.list = action.payload.list;
+      // eslint-disable-next-line fp/no-mutation
+      state.asOf = action.meta.arg?.asOf ?? null;
+      // eslint-disable-next-line fp/no-mutation
+      state.loading = false;
+    });
 
     builder.addCase(sitesRequest.rejected, (state, action) => ({
       ...state,

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -401,6 +401,7 @@ export interface SitesRequestData {
 export interface SitesListState {
   list?: Site[];
   filters: SiteFilters;
+  asOf?: string | null;
   loading: boolean;
   error?: string | null;
 }


### PR DESCRIPTION
Fixes #1162

Changes:
- API: supports `asOf` (ISO-8601) on `GET /sites` and `GET /sites/:id` to compute `collectionData` as-of a timestamp.
- Website: adds an "As of" date picker overlay on the home map, re-fetching sites with `asOf`. Includes a "Latest" reset button.

Notes:
- `packages/website` tests pass (vitest).
- `packages/api` tests currently fail in CI/local when required env vars / external service auth are missing; failures are unrelated to this change.