### PR TITLE
Add historical date support to map sites

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,8 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -62,6 +62,11 @@ export class SitesController {
   }
 
   @ApiOperation({ summary: 'Returns sites filtered by provided filters' })
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    example: '2021-05-18T08:45:35.780Z',
+  })
   @Public()
   @Get()
   find(@Query() filterSiteDto: FilterSiteDto): Promise<Site[]> {

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getHistoricalCollectionData,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,17 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mapDate = filter.date
+      ? DateTime.fromISO(filter.date, { zone: 'utc' })
+      : undefined;
+    const mappedSiteData = mapDate
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          mapDate.startOf('day').toJSDate(),
+          mapDate.endOf('day').toJSDate(),
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,24 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / find all sites at a historical date', async () => {
+    const targetDailyData = californiaDailyData[5];
+    const rsp = await request(app.getHttpServer()).get('/sites').query({
+      date: targetDailyData.date,
+    });
+
+    expect(rsp.status).toBe(200);
+    const california = rsp.body.find(
+      (site: Site) => site.id === californiaSite.id,
+    );
+
+    expect(california.collectionData).toMatchObject({
+      satelliteTemperature: targetDailyData.satelliteTemperature,
+      dhw: targetDailyData.degreeHeatingDays! / 7,
+      tempAlert: targetDailyData.dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,9 +2,18 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
+
+interface HistoricalCollectionDataRow {
+  siteId: number;
+  satelliteTemperature: number | null;
+  degreeHeatingDays: number | null;
+  dailyAlertLevel: number | null;
+  weeklyAlertLevel: number | null;
+}
 
 export const getCollectionData = async (
   sites: Site[],
@@ -42,6 +51,47 @@ export const getCollectionData = async (
         {},
       ),
     )
+    .toJSON();
+};
+
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  startDate: Date,
+  endDate: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const historicalData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .distinctOn(['daily_data.site_id'])
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date >= :startDate', { startDate })
+    .andWhere('daily_data.date <= :endDate', { endDate })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany<HistoricalCollectionDataRow>();
+
+  return _(historicalData)
+    .keyBy((data) => data.siteId)
+    .mapValues<CollectionDataDto>((data) => ({
+      satelliteTemperature: data.satelliteTemperature ?? undefined,
+      dhw:
+        data.degreeHeatingDays === null || data.degreeHeatingDays === undefined
+          ? undefined
+          : data.degreeHeatingDays / 7,
+      tempAlert: data.dailyAlertLevel ?? undefined,
+      tempWeeklyAlert: data.weeklyAlertLevel ?? undefined,
+    }))
     .toJSON();
 };
 

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,24 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
+        <mock-box
+          classname="Homepage-dateControl-3"
+        >
+          <mock-datepicker
+            autook="true"
+            datename="MAP DATE"
+            datenametextvariant="subtitle1"
+            timezone="UTC"
+          />
+          <button
+            class="MuiButtonBase-root MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary Mui-disabled MuiButton-root MuiButton-outlined MuiButton-outlinedPrimary MuiButton-sizeSmall MuiButton-outlinedSizeSmall MuiButton-colorPrimary css-wyro15-MuiButtonBase-root-MuiButton-root"
+            disabled=""
+            tabindex="-1"
+            type="button"
+          >
+            Latest
+          </button>
+        </mock-box>
         <mock-map
           initialcenter="LatLng(0, 121.3)"
           initialzoom="4"
@@ -29,7 +47,7 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-4 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -9,6 +9,7 @@ import { mockSite } from 'mocks/mockSite';
 import Homepage from '.';
 
 vi.mock('common/NavBar', () => ({ default: 'Mock-NavBar' }));
+vi.mock('common/Datepicker', () => ({ default: 'Mock-DatePicker' }));
 vi.mock('./Map', () => ({ default: 'Mock-Map' }));
 vi.mock('./SiteTable', () => ({ default: 'Mock-SiteTable' }));
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,18 +3,23 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Box, Button, Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
+import { DateTime } from 'luxon-extensions';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
-import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
+import {
+  siteOnMapSelector,
+  unsetSiteOnMap,
+} from 'store/Homepage/homepageSlice';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import DatePicker from 'common/Datepicker';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
@@ -67,13 +72,14 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapDate, setMapDate] = useState<string>();
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest({ date: mapDate }));
+  }, [dispatch, mapDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -89,6 +95,17 @@ function Homepage({ classes }: HomepageProps) {
 
   const toggleDrawer = () => {
     setDrawerOpen(!isDrawerOpen);
+  };
+
+  const onMapDateChange = (date: Date | null) => {
+    if (!date || Number.isNaN(date.getTime())) return;
+    setMapDate(DateTime.fromJSDate(date).toISODate() || undefined);
+    dispatch(unsetSiteOnMap());
+  };
+
+  const onLatestClick = () => {
+    setMapDate(undefined);
+    dispatch(unsetSiteOnMap());
   };
 
   // scroll drawer to top when its closed.
@@ -118,6 +135,25 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
+            <Box className={classes.dateControl}>
+              <DatePicker
+                value={mapDate || null}
+                dateName="MAP DATE"
+                dateNameTextVariant="subtitle1"
+                autoOk
+                onChange={onMapDateChange}
+                timeZone="UTC"
+              />
+              <Button
+                color="primary"
+                disabled={!mapDate}
+                onClick={onLatestClick}
+                size="small"
+                variant="outlined"
+              >
+                Latest
+              </Button>
+            </Box>
             <HomepageMap
               onMapLoad={setMapInstance}
               setShowSiteTable={setShowSiteTable}
@@ -164,7 +200,27 @@ const styles = () =>
     },
     map: {
       display: 'flex',
+      position: 'relative',
       zIndex: 0,
+    },
+    dateControl: {
+      position: 'absolute',
+      top: 16,
+      left: 16,
+      zIndex: 1000,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 8,
+      padding: '8px 12px',
+      backgroundColor: 'rgba(255, 255, 255, 0.95)',
+      borderRadius: 4,
+      boxShadow: '0 2px 8px rgba(0, 0, 0, 0.18)',
+      '@media (max-width: 600px)': {
+        top: 8,
+        left: 8,
+        right: 8,
+        justifyContent: 'space-between',
+      },
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${requests.generateUrlQueryParams({ date })}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -21,6 +21,7 @@ import type {
   PatchSiteFiltersPayload,
   SiteFilters,
   SitesListState,
+  SitesRequestParams,
   SitesRequestData,
   UpdateSiteNameFromListArgs,
 } from './types';
@@ -35,13 +36,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  SitesRequestParams | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(arg?.date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +50,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date: arg?.date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: SitesRequestParams | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { date, list },
       } = getState();
-      return !list;
+      return !list || date !== arg?.date;
     },
   },
 );
@@ -108,6 +110,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,16 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date?: string;
+}
+
+export interface SitesRequestParams {
+  date?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  date?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
## Summary

Adds the ability to view map site data at a specific historical date.
Previously, the map always showed the latest data. Now users can select
a date using a date picker overlay on the map, and the site collection
data (satellite temperature, DHW, alert levels) will reflect that date.
Clicking **Latest** resets back to real-time data.

## Changes

### Backend (`packages/api`)
- `filter-site.dto.ts` — Added optional `date` query param with
  `@IsDateString()` validation
- `sites.controller.ts` — Exposed `date` param in Swagger docs
- `sites.service.ts` — When `date` is provided, resolves map data via
  `getHistoricalCollectionData()` instead of `getCollectionData()`
- `collections.utils.ts` — Added new `getHistoricalCollectionData()`
  function that queries `daily_data` for a specific date range per site,
  mapping DHW, satellite temperature, and alert levels

### Frontend (`packages/website`)
- `HomeMap/index.tsx` — Added `mapDate` state and a floating date
  picker + "Latest" button overlay on the map; dispatches
  `sitesRequest({ date })` on change
- `siteServices.ts` — `getSites()` now accepts an optional `date`
  query param
- `sitesListSlice.ts` — `sitesRequest` thunk updated to accept
  `SitesRequestParams`; re-fetch condition checks if `date` changed
- `types.ts` — Added `SitesRequestParams` interface and `date` field
  to `SitesListState` and `SitesRequestData`

### Tests
- `sites.spec.ts` — Added integration test for `GET /sites?date=`
  verifying historical `collectionData` matches expected `daily_data`
- `HomeMap/index.test.tsx` — Mocked `DatePicker`, updated snapshot

## How to Test

1. Open the homepage map
2. Use the **MAP DATE** picker (top-left overlay on the map) to select
   a past date
3. Verify site markers/table reflect data from that date
4. Click **Latest** to return to real-time data