### PR TITLE
Add historical site date support

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2026-05-25T00:00:00.000Z', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -73,8 +73,11 @@ export class SitesController {
   @ApiParam({ name: 'id', example: 1 })
   @Public()
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Site> {
-    return this.sitesService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('date') date?: string,
+  ): Promise<Site> {
+    return this.sitesService.findOne(id, date);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -201,6 +201,8 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      this.dailyDataRepository,
+      filter.date,
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
@@ -223,7 +225,7 @@ export class SitesService {
     }));
   }
 
-  async findOne(id: number): Promise<Site> {
+  async findOne(id: number, date?: string): Promise<Site> {
     const site = await getSite(
       id,
       this.sitesRepository,
@@ -249,6 +251,8 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       [site],
       this.latestDataRepository,
+      this.dailyDataRepository,
+      date,
     );
 
     const maskedSpotterApiToken = site.spotterApiToken

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,26 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / find all sites as of a historical date', async () => {
+    const historicalIndex = 3;
+    const historicalDate = DateTime.now()
+      .minus({ days: historicalIndex })
+      .endOf('day')
+      .toISOString();
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({ date: historicalDate });
+
+    expect(rsp.status).toBe(200);
+    const california = rsp.body.find((site) => site.id === californiaSite.id);
+    expect(california.collectionData).toMatchObject({
+      dhw: californiaDailyData[historicalIndex].degreeHeatingDays,
+      satelliteTemperature:
+        californiaDailyData[historicalIndex].satelliteTemperature,
+      tempAlert: californiaDailyData[historicalIndex].dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 
@@ -111,6 +131,25 @@ export const siteTests = () => {
     expect(rsp.body.historicalMonthlyMean).toBeDefined();
     expect(rsp.body.historicalMonthlyMean.length).toBe(12);
     expect(rsp.body.maskedSpotterApiToken).toBeUndefined();
+  });
+
+  it('GET /:id retrieve one site as of a historical date', async () => {
+    const historicalIndex = 3;
+    const historicalDate = DateTime.now()
+      .minus({ days: historicalIndex })
+      .endOf('day')
+      .toISOString();
+    const rsp = await request(app.getHttpServer())
+      .get(`/sites/${californiaSite.id}`)
+      .query({ date: historicalDate });
+
+    expect(rsp.status).toBe(200);
+    expect(rsp.body.collectionData).toMatchObject({
+      dhw: californiaDailyData[historicalIndex].degreeHeatingDays,
+      satelliteTemperature:
+        californiaDailyData[historicalIndex].satelliteTemperature,
+      tempAlert: californiaDailyData[historicalIndex].dailyAlertLevel,
+    });
   });
 
   it('GET /:id/daily_data', async () => {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,6 +2,7 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
@@ -9,6 +10,8 @@ import { LatestData } from '../time-series/latest-data.entity';
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  dailyDataRepository: Repository<DailyData>,
+  date?: string,
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
@@ -16,31 +19,63 @@ export const getCollectionData = async (
     return {};
   }
 
-  // Get latest data
-  const latestData: LatestData[] = await latestDataRepository
-    .createQueryBuilder('latest_data')
-    .select('id')
-    .addSelect('timestamp')
-    .addSelect('value')
-    .addSelect('site_id', 'siteId')
-    .addSelect('survey_point_id', 'surveyPointId')
-    .addSelect('metric')
-    .addSelect('source')
-    .where('site_id IN (:...siteIds)', { siteIds })
-    .andWhere('source != :hoboSource', { hoboSource: SourceType.HOBO })
-    .getRawMany();
+  const collectionRows = date
+    ? await dailyDataRepository
+        .createQueryBuilder('daily_data')
+        .select('daily_data.id', 'id')
+        .addSelect('daily_data.date', 'date')
+        .addSelect('daily_data.degreeHeatingDays', 'degreeHeatingDays')
+        .addSelect('daily_data.satelliteTemperature', 'satelliteTemperature')
+        .addSelect('daily_data.dailyAlertLevel', 'dailyAlertLevel')
+        .addSelect('daily_data.weeklyAlertLevel', 'weeklyAlertLevel')
+        .addSelect('daily_data.site_id', 'siteId')
+        .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+        .andWhere('daily_data.date <= :date', { date })
+        .distinctOn(['daily_data.site_id'])
+        .orderBy('daily_data.site_id', 'ASC')
+        .addOrderBy('daily_data.date', 'DESC')
+        .getRawMany()
+    : await latestDataRepository
+        .createQueryBuilder('latest_data')
+        .select('id')
+        .addSelect('timestamp')
+        .addSelect('value')
+        .addSelect('site_id', 'siteId')
+        .addSelect('survey_point_id', 'surveyPointId')
+        .addSelect('metric')
+        .addSelect('source')
+        .where('site_id IN (:...siteIds)', { siteIds })
+        .andWhere('source != :hoboSource', { hoboSource: SourceType.HOBO })
+        .getRawMany();
 
   // Map data to each site and map each site's data to the CollectionDataDto
-  return _(latestData)
+  return _(collectionRows)
     .groupBy((o) => o.siteId)
     .mapValues<CollectionDataDto>((data) =>
-      data.reduce<CollectionDataDto>(
-        (acc, siteData): CollectionDataDto => ({
+      data.reduce<CollectionDataDto>((acc, siteData): CollectionDataDto => {
+        if (!date) {
+          return {
+            ...acc,
+            [camelCase(siteData.metric)]: siteData.value,
+          };
+        }
+
+        return {
           ...acc,
-          [camelCase(siteData.metric)]: siteData.value,
-        }),
-        {},
-      ),
+          ...(siteData.degreeHeatingDays !== undefined
+            ? { dhw: siteData.degreeHeatingDays }
+            : {}),
+          ...(siteData.satelliteTemperature !== undefined
+            ? { satelliteTemperature: siteData.satelliteTemperature }
+            : {}),
+          ...(siteData.dailyAlertLevel !== undefined
+            ? { tempAlert: siteData.dailyAlertLevel }
+            : {}),
+          ...(siteData.weeklyAlertLevel !== undefined
+            ? { tempWeeklyAlert: siteData.weeklyAlertLevel }
+            : {}),
+        };
+      }, {}),
     )
     .toJSON();
 };

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Grid, Hidden, Box, Button } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -15,8 +15,11 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import DatePicker from 'common/Datepicker';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
+import { useQueryParam } from 'hooks/useQueryParams';
+import { DateTime } from 'luxon-extensions';
 
 enum QueryParamKeys {
   SITE_ID = 'site_id',
@@ -67,23 +70,25 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [selectedDate, setSelectedDate] = useQueryParam('date');
+  const displayDate = selectedDate || DateTime.now().toISODate() || '';
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(selectedDate));
+  }, [dispatch, selectedDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
-      dispatch(siteRequest(initialSiteId));
+      dispatch(siteRequest({ id: initialSiteId, date: selectedDate }));
       dispatch(surveysRequest(initialSiteId));
     } else if (siteOnMap) {
-      dispatch(siteRequest(`${siteOnMap.id}`));
+      dispatch(siteRequest({ id: `${siteOnMap.id}`, date: selectedDate }));
       dispatch(surveysRequest(`${siteOnMap.id}`));
     }
-  }, [dispatch, initialSiteId, siteOnMap]);
+  }, [dispatch, initialSiteId, selectedDate, siteOnMap]);
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 
@@ -111,6 +116,25 @@ function Homepage({ classes }: HomepageProps) {
         <HomepageNavBar searchLocation geocodingEnabled />
       </div>
       <div className={classes.root}>
+        <Box className={classes.dateToolbar}>
+          <DatePicker
+            value={displayDate}
+            timeZone={null}
+            dateName="Historical date"
+            onChange={(date) =>
+              setSelectedDate(
+                date ? DateTime.fromJSDate(date).toISODate() || undefined : undefined,
+              )
+            }
+          />
+          <Button
+            variant="outlined"
+            size="small"
+            onClick={() => setSelectedDate(undefined)}
+          >
+            Today
+          </Button>
+        </Box>
         <Grid container>
           <Grid
             className={classes.map}
@@ -161,6 +185,20 @@ const styles = () =>
       display: 'flex',
       flexGrow: 1,
       userSelect: 'none',
+      position: 'relative',
+    },
+    dateToolbar: {
+      position: 'absolute',
+      zIndex: 1000,
+      top: '5rem',
+      left: '1rem',
+      display: 'flex',
+      alignItems: 'center',
+      gap: '0.75rem',
+      padding: '0.5rem 0.75rem',
+      borderRadius: '0.5rem',
+      background: 'rgba(255,255,255,0.92)',
+      boxShadow: '0 2px 10px rgba(0,0,0,0.12)',
     },
     map: {
       display: 'flex',

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -121,6 +121,7 @@ function Site({ classes }: SiteProps) {
   const { id: siteId = '' } = useParams<{ id: string }>();
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
   const [querySurveyPointId] = useQueryParam('surveyPoint');
+  const [selectedDate] = useQueryParam('date');
   const [refresh, setRefresh] = useQueryParam('refresh');
   const { id: selectedSurveyPointId } =
     findSurveyPointFromList(querySurveyPointId, surveyPoints) || {};
@@ -162,16 +163,16 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
 
-      dispatch(siteRequest(siteId));
+      dispatch(siteRequest({ id: siteId, date: selectedDate }));
       dispatch(spotterPositionRequest(siteId));
       dispatch(surveysRequest(siteId));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [refresh]);
+  }, [refresh, selectedDate]);
 
   // Fetch site and surveys
   useEffect(() => {
-    dispatch(siteRequest(siteId));
+    dispatch(siteRequest({ id: siteId, date: selectedDate }));
     dispatch(spotterPositionRequest(siteId));
     dispatch(surveysRequest(siteId));
 
@@ -180,7 +181,7 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
     };
-  }, [dispatch, siteId]);
+  }, [dispatch, selectedDate, siteId]);
 
   // Fetch reef check surveys
   useEffect(() => {

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -27,10 +27,11 @@ import {
 import requests from 'helpers/requests';
 import { constructTimeSeriesDataRequestUrl } from 'helpers/siteUtils';
 
-const getSite = (id: string) =>
+const getSite = (id: string, date?: string) =>
   requests.send<Site>({
     url: `sites/${id}`,
     method: 'GET',
+    params: date ? { date } : undefined,
   });
 
 const getSiteDailyData = (id: string, start?: string, end?: string) =>
@@ -83,10 +84,11 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
     url: 'sites',
     method: 'GET',
+    params: date ? { date } : undefined,
   });
 
 const getSiteSurveyPoints = (

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -34,6 +34,7 @@ const selectedSiteInitialState: SelectedSiteState = {
   oceanSenseDataLoading: false,
   oceanSenseDataError: null,
   error: null,
+  date: undefined,
 };
 
 const AlreadyLoadingErrorMessage = 'Request already loading';
@@ -90,13 +91,15 @@ export const latestDataRequest = createAsyncThunk<
 
 export const siteRequest = createAsyncThunk<
   SelectedSiteState['details'],
-  string,
+  string | { id: string; date?: string },
   CreateAsyncThunkTypes
 >(
   'selectedSite/request',
-  async (id: string, { rejectWithValue }) => {
+  async (arg, { rejectWithValue }) => {
+    const id = typeof arg === 'string' ? arg : arg.id;
+    const date = typeof arg === 'string' ? undefined : arg.date;
     try {
-      const { data } = await siteServices.getSite(id);
+      const { data } = await siteServices.getSite(id, date);
       const { data: dailyData } = await siteServices.getSiteDailyData(id);
       const { data: surveyPoints } = await siteServices.getSiteSurveyPoints(id);
 
@@ -123,11 +126,13 @@ export const siteRequest = createAsyncThunk<
     }
   },
   {
-    condition(id: string, { getState }) {
+    condition(arg, { getState }) {
+      const id = typeof arg === 'string' ? arg : arg.id;
+      const date = typeof arg === 'string' ? undefined : arg.date;
       const {
-        selectedSite: { details },
+        selectedSite: { details, date: loadedDate },
       } = getState();
-      return `${details?.id}` !== id;
+      return `${details?.id}` !== id || loadedDate !== date;
     },
   },
 );
@@ -336,16 +341,18 @@ const selectedSiteSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(
       siteRequest.fulfilled,
-      (state, action: PayloadAction<SelectedSiteState['details']>) => ({
+      (state, action) => ({
         ...state,
         details: action.payload,
+        date:
+          typeof action.meta.arg === 'string' ? undefined : action.meta.arg.date,
         loading: false,
       }),
     );
 
     builder.addCase(
       siteRequest.rejected,
-      (state, action: PayloadAction<SelectedSiteState['error']>) => ({
+      (state, action) => ({
         ...state,
         error: action.payload,
         loading: false,

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -31,17 +31,18 @@ const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
   filters: {},
+  date: undefined,
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +50,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, date: loadedDate },
       } = getState();
-      return !list;
+      return !list || loadedDate !== date;
     },
   },
 );
@@ -108,6 +110,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,6 +396,7 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date?: string;
 }
 
 export interface SitesListState {
@@ -403,11 +404,13 @@ export interface SitesListState {
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;
+  date?: string;
 }
 
 export interface SelectedSiteState {
   draft: SiteUpdateParams | null;
   details?: Site | null;
+  date?: string;
   spotterPosition?: {
     position?: {
       longitude: number;


### PR DESCRIPTION
/claim #1162

Adds `date` query support to sites APIs, historical collectionData mapping from `daily_data`, and a homepage date picker/URL sync for map + site refetches. Includes API integration tests.