### PR TITLE
Add historical as-of date support for sites

### DIFF
--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -62,10 +62,14 @@ export class SitesController {
   }
 
   @ApiOperation({ summary: 'Returns sites filtered by provided filters' })
+  @ApiQuery({ name: 'date', example: '2024-05-20', required: false })
   @Public()
   @Get()
-  find(@Query() filterSiteDto: FilterSiteDto): Promise<Site[]> {
-    return this.sitesService.find(filterSiteDto);
+  find(
+    @Query() filterSiteDto: FilterSiteDto,
+    @Query('date') date?: string,
+  ): Promise<Site[]> {
+    return this.sitesService.find(filterSiteDto, date);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -155,7 +155,7 @@ export class SitesService {
     });
   }
 
-  async find(filter: FilterSiteDto): Promise<Site[]> {
+  async find(filter: FilterSiteDto, date?: string): Promise<Site[]> {
     const query = this.sitesRepository.createQueryBuilder('site');
 
     if (filter.name) {
@@ -198,9 +198,15 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
+    if (date && !DateTime.fromISO(date).isValid) {
+      throw new BadRequestException('Date is not valid');
+    }
+
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      this.dailyDataRepository,
+      date ? DateTime.fromISO(date).endOf('day').toJSDate() : undefined,
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,25 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / find all sites with historical date', async () => {
+    const historicalDate = DateTime.fromISO(
+      californiaDailyData[0].date as string,
+    ).toISODate();
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({ date: historicalDate });
+
+    expect(rsp.status).toBe(200);
+
+    const california = rsp.body.find((site) => site.id === californiaSite.id);
+    expect(california.collectionData).toMatchObject({
+      dhw: californiaDailyData[0].degreeHeatingDays,
+      satelliteTemperature: californiaDailyData[0].satelliteTemperature,
+      tempAlert: californiaDailyData[0].dailyAlertLevel,
+      tempWeeklyAlert: californiaDailyData[0].dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,18 +2,82 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
+const mapLatestCollectionData = (latestData: LatestData[]) =>
+  _(latestData)
+    .groupBy((o) => o.siteId)
+    .mapValues<CollectionDataDto>((data) =>
+      data.reduce<CollectionDataDto>(
+        (acc, siteData): CollectionDataDto => ({
+          ...acc,
+          [camelCase(siteData.metric)]: siteData.value,
+        }),
+        {},
+      ),
+    )
+    .toJSON();
+
+const mapDailyCollectionData = (dailyData: DailyData[]) =>
+  _(dailyData)
+    .groupBy((o) => o.site.id)
+    .mapValues<CollectionDataDto>((data) => {
+      const latest = data[0];
+
+      return {
+        dhw: latest.degreeHeatingDays ?? undefined,
+        satelliteTemperature: latest.satelliteTemperature ?? undefined,
+        tempAlert: latest.dailyAlertLevel ?? undefined,
+        tempWeeklyAlert:
+          latest.weeklyAlertLevel ?? latest.dailyAlertLevel ?? undefined,
+      };
+    })
+    .toJSON();
+
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  dailyDataRepository?: Repository<DailyData>,
+  date?: string | Date,
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
   if (!siteIds.length) {
     return {};
+  }
+
+  if (date && dailyDataRepository) {
+    const dailyData: DailyData[] = await dailyDataRepository
+      .createQueryBuilder('daily_data')
+      .distinctOn(['daily_data.site_id'])
+      .select('daily_data.site_id', 'siteId')
+      .addSelect('daily_data.date', 'date')
+      .addSelect('daily_data.degreeHeatingDays', 'degreeHeatingDays')
+      .addSelect('daily_data.satelliteTemperature', 'satelliteTemperature')
+      .addSelect('daily_data.dailyAlertLevel', 'dailyAlertLevel')
+      .addSelect('daily_data.weeklyAlertLevel', 'weeklyAlertLevel')
+      .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+      .andWhere('daily_data.date <= :date', { date })
+      .orderBy('daily_data.site_id', 'ASC')
+      .addOrderBy('daily_data.date', 'DESC')
+      .getRawMany();
+
+    return mapDailyCollectionData(
+      dailyData.map(
+        (row) =>
+          ({
+            date: row.date,
+            degreeHeatingDays: row.degreeHeatingDays,
+            satelliteTemperature: row.satelliteTemperature,
+            dailyAlertLevel: row.dailyAlertLevel,
+            weeklyAlertLevel: row.weeklyAlertLevel,
+            site: { id: row.siteId },
+          }) as DailyData,
+      ),
+    );
   }
 
   // Get latest data
@@ -31,18 +95,7 @@ export const getCollectionData = async (
     .getRawMany();
 
   // Map data to each site and map each site's data to the CollectionDataDto
-  return _(latestData)
-    .groupBy((o) => o.siteId)
-    .mapValues<CollectionDataDto>((data) =>
-      data.reduce<CollectionDataDto>(
-        (acc, siteData): CollectionDataDto => ({
-          ...acc,
-          [camelCase(siteData.metric)]: siteData.value,
-        }),
-        {},
-      ),
-    )
-    .toJSON();
+  return mapLatestCollectionData(latestData);
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -34,7 +34,7 @@ function DatePicker({
                 .toJSDate()}
               minDate={DateTime.fromMillis(0).toJSDate()}
               closeOnSelect={autoOk}
-              value={parseISO(value ?? '')}
+              value={value ? parseISO(value) : null}
               onChange={(v) => onChange(v)}
               slotProps={{
                 textField: {

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,11 +3,13 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Box, Button, Grid, Hidden } from '@mui/material';
+import { DateTime } from 'luxon-extensions';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
+import { useQueryParam } from 'hooks/useQueryParams';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
@@ -15,12 +17,14 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import DatePicker from 'common/Datepicker';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
@@ -67,13 +71,17 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [selectedDate, setSelectedDate] = useQueryParam(
+    QueryParamKeys.DATE,
+    (value) => DateTime.fromISO(value).isValid,
+  );
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(selectedDate));
+  }, [dispatch, selectedDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -118,6 +126,23 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
+            <Box className={classes.dateControls}>
+              <DatePicker
+                value={selectedDate || null}
+                dateName="As-of"
+                timeZone="UTC"
+                onChange={(date) => {
+                  setSelectedDate(
+                    date
+                      ? (DateTime.fromJSDate(date).toISODate() ?? undefined)
+                      : undefined,
+                  );
+                }}
+              />
+              <Button onClick={() => setSelectedDate(undefined)} size="small">
+                Live
+              </Button>
+            </Box>
             <HomepageMap
               onMapLoad={setMapInstance}
               setShowSiteTable={setShowSiteTable}
@@ -164,7 +189,14 @@ const styles = () =>
     },
     map: {
       display: 'flex',
+      flexDirection: 'column',
       zIndex: 0,
+    },
+    dateControls: {
+      alignItems: 'center',
+      display: 'flex',
+      gap: '0.75rem',
+      margin: '0.75rem 1rem 0',
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,11 +55,11 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, selectedDate },
       } = getState();
-      return !list;
+      return !list || selectedDate !== arg;
     },
   },
 );
@@ -103,14 +103,12 @@ const sitesListSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      sitesRequest.fulfilled,
-      (state, action: PayloadAction<SitesRequestData>) => ({
-        ...state,
-        list: action.payload.list,
-        loading: false,
-      }),
-    );
+    builder.addCase(sitesRequest.fulfilled, (state, action) => ({
+      ...state,
+      list: action.payload.list,
+      loading: false,
+      selectedDate: action.meta.arg,
+    }));
 
     builder.addCase(sitesRequest.rejected, (state, action) => ({
       ...state,

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -403,6 +403,7 @@ export interface SitesListState {
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;
+  selectedDate?: string;
 }
 
 export interface SelectedSiteState {


### PR DESCRIPTION
/claim #1162

Adds as-of date support to the public sites list endpoint and HomeMap UI.

Changes:
- `/sites?date=YYYY-MM-DD` now resolves site collection data from `daily_data`
- HomeMap gets an as-of date picker + Live reset
- site list refetches when the date changes

Validation:
- `git diff --check`
- eslint on touched files
