### PR TITLE
Add historical date support to map site data

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,9 +5,10 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsISO8601,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SiteStatus } from '../sites.entity';
 
 export class FilterSiteDto {
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiPropertyOptional({ example: '2024-03-15' })
+  @IsOptional()
+  @IsISO8601({ strict: true })
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -71,10 +71,14 @@ export class SitesController {
   @ApiNestNotFoundResponse('No site was found with the specified id')
   @ApiOperation({ summary: 'Returns specified site' })
   @ApiParam({ name: 'id', example: 1 })
+  @ApiQuery({ name: 'date', example: '2024-03-15', required: false })
   @Public()
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Site> {
-    return this.sitesService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('date') date?: string,
+  ): Promise<Site> {
+    return this.sitesService.findOne(id, date);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -155,6 +155,19 @@ export class SitesService {
     });
   }
 
+  private parseHistoricalDate(date?: string): Date | undefined {
+    if (!date) {
+      return undefined;
+    }
+
+    const parsedDate = DateTime.fromISO(date);
+    if (!parsedDate.isValid) {
+      throw new BadRequestException('Date is not a valid ISO date');
+    }
+
+    return parsedDate.endOf('day').toJSDate();
+  }
+
   async find(filter: FilterSiteDto): Promise<Site[]> {
     const query = this.sitesRepository.createQueryBuilder('site');
 
@@ -198,9 +211,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
+    const historicalDate = this.parseHistoricalDate(filter.date);
+
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      this.dailyDataRepository,
+      historicalDate,
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
@@ -223,7 +240,7 @@ export class SitesService {
     }));
   }
 
-  async findOne(id: number): Promise<Site> {
+  async findOne(id: number, date?: string): Promise<Site> {
     const site = await getSite(
       id,
       this.sitesRepository,
@@ -249,6 +266,8 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       [site],
       this.latestDataRepository,
+      this.dailyDataRepository,
+      this.parseHistoricalDate(date),
     );
 
     const maskedSpotterApiToken = site.spotterApiToken

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,25 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / find all sites for a historical date', async () => {
+    const historicalData = californiaDailyData[3];
+    const rsp = await request(app.getHttpServer()).get('/sites').query({
+      date: historicalData.date,
+    });
+
+    expect(rsp.status).toBe(200);
+    const california = rsp.body.find(
+      (site: Site) => site.name === californiaSite.name,
+    );
+
+    expect(california.collectionData).toMatchObject({
+      satelliteTemperature: historicalData.satelliteTemperature,
+      dhw: (historicalData.degreeHeatingDays as number) / 7,
+      tempAlert: historicalData.dailyAlertLevel,
+      tempWeeklyAlert: historicalData.dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 
@@ -111,6 +130,23 @@ export const siteTests = () => {
     expect(rsp.body.historicalMonthlyMean).toBeDefined();
     expect(rsp.body.historicalMonthlyMean.length).toBe(12);
     expect(rsp.body.maskedSpotterApiToken).toBeUndefined();
+  });
+
+  it('GET /:id retrieve one site for a historical date', async () => {
+    const historicalData = californiaDailyData[3];
+    const rsp = await request(app.getHttpServer())
+      .get(`/sites/${californiaSite.id}`)
+      .query({
+        date: historicalData.date,
+      });
+
+    expect(rsp.status).toBe(200);
+    expect(rsp.body.collectionData).toMatchObject({
+      satelliteTemperature: historicalData.satelliteTemperature,
+      dhw: (historicalData.degreeHeatingDays as number) / 7,
+      tempAlert: historicalData.dailyAlertLevel,
+      tempWeeklyAlert: historicalData.dailyAlertLevel,
+    });
   });
 
   it('GET /:id/daily_data', async () => {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,18 +2,72 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
+type HistoricalCollectionData = {
+  siteId: number;
+  satelliteTemperature: number | null;
+  degreeHeatingDays: number | null;
+  dailyAlertLevel: number | null;
+  weeklyAlertLevel: number | null;
+};
+
+const parseNullableNumber = (
+  value: number | string | null,
+): number | undefined => (value === null ? undefined : Number(value));
+
+const getHistoricalCollectionData = async (
+  siteIds: number[],
+  dailyDataRepository: Repository<DailyData>,
+  date: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('DISTINCT ON (daily_data.site_id) daily_data.site_id', 'siteId')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany<HistoricalCollectionData>();
+
+  return dailyData.reduce<Record<number, CollectionDataDto>>((acc, data) => {
+    const degreeHeatingDays = parseNullableNumber(data.degreeHeatingDays);
+    return {
+      ...acc,
+      [data.siteId]: {
+        satelliteTemperature: parseNullableNumber(data.satelliteTemperature),
+        dhw:
+          degreeHeatingDays === undefined ? undefined : degreeHeatingDays / 7,
+        tempAlert: parseNullableNumber(data.dailyAlertLevel),
+        tempWeeklyAlert:
+          parseNullableNumber(data.weeklyAlertLevel) ??
+          parseNullableNumber(data.dailyAlertLevel),
+      },
+    };
+  }, {});
+};
+
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  dailyDataRepository?: Repository<DailyData>,
+  date?: Date,
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
   if (!siteIds.length) {
     return {};
+  }
+
+  if (date && dailyDataRepository) {
+    return getHistoricalCollectionData(siteIds, dailyDataRepository, date);
   }
 
   // Get latest data

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -15,6 +15,7 @@ import {
   Hidden,
   Alert,
   Theme,
+  TextField,
 } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -87,6 +88,8 @@ function HomepageMap({
   showWaterMark = true,
   geolocationEnabled = true,
   defaultLayerName,
+  dataDate,
+  onDataDateChange,
   legendBottom,
   legendLeft,
   classes,
@@ -275,6 +278,23 @@ function HomepageMap({
           <InfoIcon color="primary" />
         </IconButton>
       </div>
+      {onDataDateChange && (
+        <div className={classes.dateControl}>
+          <TextField
+            label="Map date"
+            type="date"
+            size="small"
+            value={dataDate || ''}
+            onChange={(event) =>
+              onDataDateChange(event.target.value || undefined)
+            }
+            inputProps={{
+              max: new Date().toISOString().slice(0, 10),
+            }}
+            InputLabelProps={{ shrink: true }}
+          />
+        </div>
+      )}
       <InfoDialog
         infoDialogOpen={infoDialogOpen}
         handleInfoClose={handleInfoClose}
@@ -358,6 +378,15 @@ const styles = (theme: Theme) =>
         top: 50,
       },
     },
+    dateControl: {
+      ...mapButtonStyles,
+      left: 0,
+      top: 140,
+      zIndex: 400,
+      height: 'auto',
+      width: 170,
+      padding: theme.spacing(1),
+    },
     expandIcon: {
       fontSize: '34px',
     },
@@ -382,6 +411,8 @@ interface HomepageMapIncomingProps {
   showWaterMark?: boolean;
   geolocationEnabled?: boolean;
   defaultLayerName?: MapLayerName;
+  dataDate?: string;
+  onDataDateChange?: (date?: string) => void;
   legendBottom?: number;
   legendLeft?: number;
   onMapLoad?: (map: L.Map) => void;

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -2,7 +2,7 @@ import L, { LatLng } from 'leaflet';
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
-import { useLocation } from 'react-router-dom';
+import { useLocation, useNavigate } from 'react-router-dom';
 import { Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -11,6 +11,7 @@ import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
 import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
+import { DateTime } from 'luxon-extensions';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
@@ -21,21 +22,33 @@ import HomepageMap from './Map';
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
   initialCenter: LatLng;
   initialZoom: number;
   initialSiteId: string | undefined;
+  dataDate: string | undefined;
 }
 
 const INITIAL_CENTER = new LatLng(0, 121.3);
 const INITIAL_ZOOM = 4;
 
+const isValidDateParam = (date: string | null): date is string => {
+  if (!date || !/^\d{4}-\d{2}-\d{2}$/.test(date)) {
+    return false;
+  }
+
+  const parsedDate = DateTime.fromISO(date);
+  return parsedDate.isValid && parsedDate.toISODate() === date;
+};
+
 function useQuery() {
   const urlParams: URLSearchParams = new URLSearchParams(useLocation().search);
   const zoomLevelParam = urlParams.get(QueryParamKeys.ZOOM_LEVEL);
   const initialZoom: number = zoomLevelParam ? +zoomLevelParam : INITIAL_ZOOM;
+  const dateParam = urlParams.get(QueryParamKeys.DATE);
   const queryParamSiteId = urlParams.get(QueryParamKeys.SITE_ID) || '';
   const sitesList = useSelector(sitesListSelector) || [];
   const featuredSiteId = process.env.REACT_APP_FEATURED_SITE_ID || '';
@@ -59,36 +72,61 @@ function useQuery() {
     initialCenter,
     initialSiteId,
     initialZoom,
+    dataDate: isValidDateParam(dateParam) ? dateParam : undefined,
   };
 }
 
 function Homepage({ classes }: HomepageProps) {
   const dispatch = useAppDispatch();
+  const location = useLocation();
+  const navigate = useNavigate();
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
-  const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
-    useQuery();
+  const {
+    initialZoom,
+    initialSiteId,
+    initialCenter,
+    dataDate,
+  }: MapQueryParams = useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest({ date: dataDate }));
+  }, [dataDate, dispatch]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
-      dispatch(siteRequest(initialSiteId));
+      dispatch(siteRequest({ id: initialSiteId, date: dataDate }));
       dispatch(surveysRequest(initialSiteId));
     } else if (siteOnMap) {
-      dispatch(siteRequest(`${siteOnMap.id}`));
+      dispatch(siteRequest({ id: `${siteOnMap.id}`, date: dataDate }));
       dispatch(surveysRequest(`${siteOnMap.id}`));
     }
-  }, [dispatch, initialSiteId, siteOnMap]);
+  }, [dataDate, dispatch, initialSiteId, siteOnMap]);
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 
   const toggleDrawer = () => {
     setDrawerOpen(!isDrawerOpen);
+  };
+
+  const updateDataDate = (date?: string) => {
+    const urlParams = new URLSearchParams(location.search);
+    if (date) {
+      urlParams.set(QueryParamKeys.DATE, date);
+    } else {
+      urlParams.delete(QueryParamKeys.DATE);
+    }
+
+    const search = urlParams.toString();
+    navigate(
+      {
+        pathname: location.pathname,
+        search: search ? `?${search}` : '',
+      },
+      { replace: true },
+    );
   };
 
   // scroll drawer to top when its closed.
@@ -124,6 +162,8 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              dataDate={dataDate}
+              onDataDateChange={updateDataDate}
             />
           </Grid>
           {showSiteTable && (

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -27,9 +27,9 @@ import {
 import requests from 'helpers/requests';
 import { constructTimeSeriesDataRequestUrl } from 'helpers/siteUtils';
 
-const getSite = (id: string) =>
+const getSite = (id: string, date?: string) =>
   requests.send<Site>({
-    url: `sites/${id}`,
+    url: `sites/${id}${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -12,6 +12,7 @@ import type {
   TimeSeriesDataRequestParams,
   GetSiteContactInfoProps,
   Site,
+  SiteRequestParams,
   Metrics,
   TimeSeries,
 } from './types';
@@ -37,6 +38,9 @@ const selectedSiteInitialState: SelectedSiteState = {
 };
 
 const AlreadyLoadingErrorMessage = 'Request already loading';
+
+const normalizeSiteRequestParams = (params: SiteRequestParams) =>
+  typeof params === 'string' ? { id: params } : params;
 
 export const forecastDataRequest = createAsyncThunk<
   SelectedSiteState['forecastData'],
@@ -90,13 +94,14 @@ export const latestDataRequest = createAsyncThunk<
 
 export const siteRequest = createAsyncThunk<
   SelectedSiteState['details'],
-  string,
+  SiteRequestParams,
   CreateAsyncThunkTypes
 >(
   'selectedSite/request',
-  async (id: string, { rejectWithValue }) => {
+  async (params, { rejectWithValue }) => {
+    const { id, date } = normalizeSiteRequestParams(params);
     try {
-      const { data } = await siteServices.getSite(id);
+      const { data } = await siteServices.getSite(id, date);
       const { data: dailyData } = await siteServices.getSiteDailyData(id);
       const { data: surveyPoints } = await siteServices.getSiteSurveyPoints(id);
 
@@ -123,11 +128,12 @@ export const siteRequest = createAsyncThunk<
     }
   },
   {
-    condition(id: string, { getState }) {
+    condition(params: SiteRequestParams, { getState }) {
+      const { id, date } = normalizeSiteRequestParams(params);
       const {
-        selectedSite: { details },
+        selectedSite: { dataDate, details },
       } = getState();
-      return `${details?.id}` !== id;
+      return `${details?.id}` !== id || dataDate !== date;
     },
   },
 );
@@ -334,14 +340,12 @@ const selectedSiteSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      siteRequest.fulfilled,
-      (state, action: PayloadAction<SelectedSiteState['details']>) => ({
-        ...state,
-        details: action.payload,
-        loading: false,
-      }),
-    );
+    builder.addCase(siteRequest.fulfilled, (state, action) => ({
+      ...state,
+      details: action.payload,
+      dataDate: normalizeSiteRequestParams(action.meta.arg).date,
+      loading: false,
+    }));
 
     builder.addCase(
       siteRequest.rejected,

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -21,6 +21,7 @@ import type {
   PatchSiteFiltersPayload,
   SiteFilters,
   SitesListState,
+  SitesRequestParams,
   SitesRequestData,
   UpdateSiteNameFromListArgs,
 } from './types';
@@ -35,13 +36,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  SitesRequestParams | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(arg?.date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,11 +56,11 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: SitesRequestParams | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { dataDate, list },
       } = getState();
-      return !list;
+      return !list || dataDate !== arg?.date;
     },
   },
 );
@@ -103,14 +104,12 @@ const sitesListSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      sitesRequest.fulfilled,
-      (state, action: PayloadAction<SitesRequestData>) => ({
-        ...state,
-        list: action.payload.list,
-        loading: false,
-      }),
-    );
+    builder.addCase(sitesRequest.fulfilled, (state, action) => ({
+      ...state,
+      list: action.payload.list,
+      dataDate: action.meta.arg?.date,
+      loading: false,
+    }));
 
     builder.addCase(sitesRequest.rejected, (state, action) => ({
       ...state,

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -398,9 +398,21 @@ export interface SitesRequestData {
   list: Site[];
 }
 
+export interface SitesRequestParams {
+  date?: string;
+}
+
+export type SiteRequestParams =
+  | string
+  | {
+      id: string;
+      date?: string;
+    };
+
 export interface SitesListState {
   list?: Site[];
   filters: SiteFilters;
+  dataDate?: string;
   loading: boolean;
   error?: string | null;
 }
@@ -426,6 +438,7 @@ export interface SelectedSiteState {
   oceanSenseDataLoading: boolean;
   oceanSenseDataError?: string | null;
   granularDailyData?: DailyData[];
+  dataDate?: string;
   timeSeriesData?: TimeSeriesData;
   timeSeriesDataLoading: boolean;
   timeSeriesDataRange?: TimeSeriesDataRange;


### PR DESCRIPTION
## Summary

- Add optional `date` query support to the sites list and detail endpoints.
- Use historical `daily_data` values for map collection data when a date is provided.
- Add a map date picker that stores the selected date in the URL and refetches site data.

## Testing

- `PATH=/opt/homebrew/opt/node@20/bin:$PATH ./node_modules/.bin/eslint packages/api/src/sites/dto/filter-site.dto.ts packages/api/src/sites/sites.controller.ts packages/api/src/sites/sites.service.ts packages/api/src/sites/sites.spec.ts packages/api/src/utils/collections.utils.ts packages/website/src/routes/HomeMap/Map/index.tsx packages/website/src/routes/HomeMap/index.tsx packages/website/src/services/siteServices.ts packages/website/src/store/Sites/selectedSiteSlice.ts packages/website/src/store/Sites/sitesListSlice.ts packages/website/src/store/Sites/types.ts --max-warnings 0`
- `PATH=/opt/homebrew/opt/node@20/bin:$PATH ./node_modules/.bin/tsc -p packages/api/tsconfig.json --noEmit`
- `git diff --check HEAD~1 HEAD`

Note: website-wide `tsc` still fails on existing unrelated type issues outside this change. API e2e testing was blocked locally because PostgreSQL 16 could not load the installed PostGIS extension.

## Demo

![Historical date map demo](https://raw.githubusercontent.com/deanventor-max/aqualink-app/demo-assets/demo-assets/aqualink-historical-date-demo.gif)

/claim #1162

Closes #1162
