### PR TITLE
Add historical date support to map and site pages

### DIFF
--- a/packages/api/src/collections/dto/collection-data.dto.ts
+++ b/packages/api/src/collections/dto/collection-data.dto.ts
@@ -24,6 +24,13 @@ type CollectionDataDtoType = Partial<
 >;
 
 export class CollectionDataDto implements CollectionDataDtoType {
+  @ApiPropertyOptional({
+    description:
+      'Timestamp of the daily observation selected for a historical request',
+    example: '2024-04-10T23:59:59.999Z',
+  })
+  observationDate?: Date;
+
   @ApiPropertyOptional({ example: 28.05 })
   bottomTemperature?: number;
 

--- a/packages/api/src/config/config.service.ts
+++ b/packages/api/src/config/config.service.ts
@@ -38,7 +38,9 @@ class ConfigService {
     return value;
   }
 
-  API_URL = this.getValue('BACKEND_BASE_URL', true);
+  API_URL =
+    this.getValue('BACKEND_BASE_URL', process.env.NODE_ENV !== 'test') ||
+    'http://localhost/api';
 
   public ensureValues(keys: string[]) {
     keys.forEach((k) => this.getValue(k, true));

--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({ example: '2024-04-15', required: false })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -62,6 +62,7 @@ export class SitesController {
   }
 
   @ApiOperation({ summary: 'Returns sites filtered by provided filters' })
+  @ApiQuery({ name: 'date', example: '2024-04-15', required: false })
   @Public()
   @Get()
   find(@Query() filterSiteDto: FilterSiteDto): Promise<Site[]> {
@@ -71,10 +72,14 @@ export class SitesController {
   @ApiNestNotFoundResponse('No site was found with the specified id')
   @ApiOperation({ summary: 'Returns specified site' })
   @ApiParam({ name: 'id', example: 1 })
+  @ApiQuery({ name: 'date', example: '2024-04-15', required: false })
   @Public()
   @Get(':id')
-  findOne(@Param('id', ParseIntPipe) id: number): Promise<Site> {
-    return this.sitesService.findOne(id);
+  findOne(
+    @Param('id', ParseIntPipe) id: number,
+    @Query('date') date?: string,
+  ): Promise<Site> {
+    return this.sitesService.findOne(id, date);
   }
 
   @ApiNestNotFoundResponse('No site was found with the specified id')

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getHistoricalCollectionData,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -156,6 +159,10 @@ export class SitesService {
   }
 
   async find(filter: FilterSiteDto): Promise<Site[]> {
+    if (filter.date && !DateTime.fromISO(filter.date).isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
     const query = this.sitesRepository.createQueryBuilder('site');
 
     if (filter.name) {
@@ -198,10 +205,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mappedSiteData = filter.date
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 
@@ -223,7 +233,11 @@ export class SitesService {
     }));
   }
 
-  async findOne(id: number): Promise<Site> {
+  async findOne(id: number, date?: string): Promise<Site> {
+    if (date && !DateTime.fromISO(date).isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
     const site = await getSite(
       id,
       this.sitesRepository,
@@ -246,10 +260,13 @@ export class SitesService {
 
     const videoStream = await this.checkVideoStream(site);
 
-    const mappedSiteData = await getCollectionData(
-      [site],
-      this.latestDataRepository,
-    );
+    const mappedSiteData = date
+      ? await getHistoricalCollectionData(
+          [site],
+          this.dailyDataRepository,
+          date,
+        )
+      : await getCollectionData([site], this.latestDataRepository);
 
     const maskedSpotterApiToken = site.spotterApiToken
       ? `****${site.spotterApiToken?.slice(-4)}`

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -113,6 +113,67 @@ export const siteTests = () => {
     expect(rsp.body.maskedSpotterApiToken).toBeUndefined();
   });
 
+  it('GET / returns historical collection data for a provided date', async () => {
+    const date = DateTime.fromISO(californiaDailyData[3].date as string);
+
+    await dataSource.query(
+      `UPDATE daily_data
+       SET degree_heating_days = $1,
+           satellite_temperature = $2,
+           daily_alert_level = $3,
+           weekly_alert_level = $4
+       WHERE site_id = $5 AND date = $6`,
+      [21, 27.5, 2, 3, californiaSite.id, californiaDailyData[3].date],
+    );
+
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({
+        date: date.toFormat('yyyy-MM-dd'),
+      });
+
+    expect(rsp.status).toBe(200);
+
+    const site = rsp.body.find(
+      ({ id }: { id: number }) => id === californiaSite.id,
+    );
+
+    expect(site.collectionData).toMatchObject({
+      dhw: 3,
+      satelliteTemperature: 27.5,
+      tempAlert: 2,
+      tempWeeklyAlert: 3,
+    });
+  });
+
+  it('GET /:id returns historical collection data for a provided date', async () => {
+    const date = DateTime.fromISO(californiaDailyData[3].date as string);
+
+    const rsp = await request(app.getHttpServer())
+      .get(`/sites/${californiaSite.id}`)
+      .query({
+        date: date.toFormat('yyyy-MM-dd'),
+      });
+
+    expect(rsp.status).toBe(200);
+    expect(rsp.body.collectionData).toMatchObject({
+      dhw: 3,
+      satelliteTemperature: 27.5,
+      tempAlert: 2,
+      tempWeeklyAlert: 3,
+    });
+  });
+
+  it('GET /:id rejects an invalid historical date', async () => {
+    const rsp = await request(app.getHttpServer())
+      .get(`/sites/${californiaSite.id}`)
+      .query({
+        date: 'not-a-date',
+      });
+
+    expect(rsp.status).toBe(400);
+  });
+
   it('GET /:id/daily_data', async () => {
     const rsp = await request(app.getHttpServer())
       .get(`/sites/${californiaSite.id}/daily_data`)

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -114,17 +114,8 @@ export const siteTests = () => {
   });
 
   it('GET / returns historical collection data for a provided date', async () => {
-    const date = DateTime.fromISO(californiaDailyData[3].date as string);
-
-    await dataSource.query(
-      `UPDATE daily_data
-       SET degree_heating_days = $1,
-           satellite_temperature = $2,
-           daily_alert_level = $3,
-           weekly_alert_level = $4
-       WHERE site_id = $5 AND date = $6`,
-      [21, 27.5, 2, 3, californiaSite.id, californiaDailyData[3].date],
-    );
+    const historicalData = californiaDailyData[3];
+    const date = DateTime.fromISO(historicalData.date as string);
 
     const rsp = await request(app.getHttpServer())
       .get('/sites')
@@ -139,15 +130,15 @@ export const siteTests = () => {
     );
 
     expect(site.collectionData).toMatchObject({
-      dhw: 3,
-      satelliteTemperature: 27.5,
-      tempAlert: 2,
-      tempWeeklyAlert: 3,
+      dhw: Number(historicalData.degreeHeatingDays) / 7,
+      satelliteTemperature: historicalData.satelliteTemperature,
+      tempAlert: historicalData.dailyAlertLevel,
     });
   });
 
   it('GET /:id returns historical collection data for a provided date', async () => {
-    const date = DateTime.fromISO(californiaDailyData[3].date as string);
+    const historicalData = californiaDailyData[3];
+    const date = DateTime.fromISO(historicalData.date as string);
 
     const rsp = await request(app.getHttpServer())
       .get(`/sites/${californiaSite.id}`)
@@ -157,10 +148,9 @@ export const siteTests = () => {
 
     expect(rsp.status).toBe(200);
     expect(rsp.body.collectionData).toMatchObject({
-      dhw: 3,
-      satelliteTemperature: 27.5,
-      tempAlert: 2,
-      tempWeeklyAlert: 3,
+      dhw: Number(historicalData.degreeHeatingDays) / 7,
+      satelliteTemperature: historicalData.satelliteTemperature,
+      tempAlert: historicalData.dailyAlertLevel,
     });
   });
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -130,6 +130,7 @@ export const siteTests = () => {
     );
 
     expect(site.collectionData).toMatchObject({
+      observationDate: date.toJSDate().toISOString(),
       dhw: Number(historicalData.degreeHeatingDays) / 7,
       satelliteTemperature: historicalData.satelliteTemperature,
       tempAlert: historicalData.dailyAlertLevel,
@@ -148,6 +149,7 @@ export const siteTests = () => {
 
     expect(rsp.status).toBe(200);
     expect(rsp.body.collectionData).toMatchObject({
+      observationDate: date.toJSDate().toISOString(),
       dhw: Number(historicalData.degreeHeatingDays) / 7,
       satelliteTemperature: historicalData.satelliteTemperature,
       tempAlert: historicalData.dailyAlertLevel,

--- a/packages/api/src/utils/collections.utils.test.ts
+++ b/packages/api/src/utils/collections.utils.test.ts
@@ -7,6 +7,7 @@ describe('historical collection observation provenance', () => {
   it('maps the selected older observation rather than the requested date', async () => {
     const observationDate = new Date('2024-04-10T23:59:59.999Z');
     const query = {
+      distinctOn: jest.fn().mockReturnThis(),
       select: jest.fn().mockReturnThis(),
       addSelect: jest.fn().mockReturnThis(),
       where: jest.fn().mockReturnThis(),
@@ -36,6 +37,7 @@ describe('historical collection observation provenance', () => {
       'daily_data.date',
       'observationDate',
     );
+    expect(query.distinctOn).toHaveBeenCalledWith(['daily_data.site_id']);
     expect(query.andWhere).toHaveBeenCalledWith('daily_data.date <= :date', {
       date: new Date('2024-04-15T23:59:59.999Z'),
     });

--- a/packages/api/src/utils/collections.utils.test.ts
+++ b/packages/api/src/utils/collections.utils.test.ts
@@ -1,0 +1,53 @@
+import { Repository } from 'typeorm';
+import { getHistoricalCollectionData } from './collections.utils';
+import { DailyData } from '../sites/daily-data.entity';
+import { Site } from '../sites/sites.entity';
+
+describe('historical collection observation provenance', () => {
+  it('maps the selected older observation rather than the requested date', async () => {
+    const observationDate = new Date('2024-04-10T23:59:59.999Z');
+    const query = {
+      select: jest.fn().mockReturnThis(),
+      addSelect: jest.fn().mockReturnThis(),
+      where: jest.fn().mockReturnThis(),
+      andWhere: jest.fn().mockReturnThis(),
+      orderBy: jest.fn().mockReturnThis(),
+      addOrderBy: jest.fn().mockReturnThis(),
+      getRawMany: jest.fn().mockResolvedValue([
+        {
+          siteId: 1,
+          observationDate,
+          degreeHeatingDays: 14,
+          satelliteTemperature: 28,
+          dailyAlertLevel: 0,
+          weeklyAlertLevel: 1,
+        },
+      ]),
+    };
+    const repository = {
+      createQueryBuilder: () => query,
+    } as unknown as Repository<DailyData>;
+    const result = await getHistoricalCollectionData(
+      [{ id: 1 } as Site],
+      repository,
+      '2024-04-15',
+    );
+    expect(query.addSelect).toHaveBeenCalledWith(
+      'daily_data.date',
+      'observationDate',
+    );
+    expect(query.andWhere).toHaveBeenCalledWith('daily_data.date <= :date', {
+      date: new Date('2024-04-15T23:59:59.999Z'),
+    });
+    expect(result[1]).toEqual({
+      observationDate,
+      dhw: 2,
+      satelliteTemperature: 28,
+      tempAlert: 0,
+      tempWeeklyAlert: 1,
+    });
+    expect(JSON.parse(JSON.stringify(result))[1].observationDate).toBe(
+      '2024-04-10T23:59:59.999Z',
+    );
+  });
+});

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,9 +2,19 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DateTime } from '../luxon-extensions';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
+
+type HistoricalCollectionDataRow = {
+  siteId: number;
+  degreeHeatingDays: number | null;
+  satelliteTemperature: number | null;
+  dailyAlertLevel: number | null;
+  weeklyAlertLevel: number | null;
+};
 
 export const getCollectionData = async (
   sites: Site[],
@@ -43,6 +53,54 @@ export const getCollectionData = async (
       ),
     )
     .toJSON();
+};
+
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const asOfDate = DateTime.fromISO(date, { zone: 'UTC' }).endOf('day');
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('DISTINCT ON (daily_data.site_id) daily_data.site_id', 'siteId')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date: asOfDate.toJSDate() })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany<HistoricalCollectionDataRow>();
+
+  return dailyData.reduce<Record<number, CollectionDataDto>>((acc, data) => {
+    const collectionData: CollectionDataDto = {
+      ...(data.degreeHeatingDays !== null
+        ? { dhw: data.degreeHeatingDays / 7 }
+        : {}),
+      ...(data.satelliteTemperature !== null
+        ? { satelliteTemperature: data.satelliteTemperature }
+        : {}),
+      ...(data.dailyAlertLevel !== null
+        ? { tempAlert: data.dailyAlertLevel }
+        : {}),
+      ...(data.weeklyAlertLevel !== null
+        ? { tempWeeklyAlert: data.weeklyAlertLevel }
+        : {}),
+    };
+
+    return {
+      ...acc,
+      [data.siteId]: collectionData,
+    };
+  }, {});
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -10,6 +10,7 @@ import { LatestData } from '../time-series/latest-data.entity';
 
 type HistoricalCollectionDataRow = {
   siteId: number;
+  observationDate: Date;
   degreeHeatingDays: number | null;
   satelliteTemperature: number | null;
   dailyAlertLevel: number | null;
@@ -70,6 +71,7 @@ export const getHistoricalCollectionData = async (
   const dailyData = await dailyDataRepository
     .createQueryBuilder('daily_data')
     .select('DISTINCT ON (daily_data.site_id) daily_data.site_id', 'siteId')
+    .addSelect('daily_data.date', 'observationDate')
     .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
     .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
     .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
@@ -82,6 +84,7 @@ export const getHistoricalCollectionData = async (
 
   return dailyData.reduce<Record<number, CollectionDataDto>>((acc, data) => {
     const collectionData: CollectionDataDto = {
+      observationDate: data.observationDate,
       ...(data.degreeHeatingDays !== null
         ? { dhw: data.degreeHeatingDays / 7 }
         : {}),

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -70,7 +70,8 @@ export const getHistoricalCollectionData = async (
   const asOfDate = DateTime.fromISO(date, { zone: 'UTC' }).endOf('day');
   const dailyData = await dailyDataRepository
     .createQueryBuilder('daily_data')
-    .select('DISTINCT ON (daily_data.site_id) daily_data.site_id', 'siteId')
+    .distinctOn(['daily_data.site_id'])
+    .select('daily_data.site_id', 'siteId')
     .addSelect('daily_data.date', 'observationDate')
     .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
     .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')

--- a/packages/api/src/utils/google-cloud.utils.ts
+++ b/packages/api/src/utils/google-cloud.utils.ts
@@ -1,6 +1,7 @@
 import { InternalServerErrorException } from '@nestjs/common';
 
-const { GCS_BUCKET } = process.env;
+const GCS_BUCKET =
+  process.env.GCS_BUCKET || (process.env.NODE_ENV === 'test' && 'storage');
 
 export enum GoogleCloudDir {
   SURVEYS = 'surveys',

--- a/packages/api/src/utils/sofar.test.ts
+++ b/packages/api/src/utils/sofar.test.ts
@@ -7,7 +7,9 @@ import {
 } from './sofar';
 import { ValueWithTimestamp } from './sofar.types';
 
-test('It processes Sofar API for daily data.', async () => {
+const sofarIntegrationTest = process.env.SOFAR_API_TOKEN ? test : test.skip;
+
+sofarIntegrationTest('It processes Sofar API for daily data.', async () => {
   jest.setTimeout(30000);
   const values = await getSofarHindcastData(
     'NOAACoralReefWatch',
@@ -22,60 +24,69 @@ test('It processes Sofar API for daily data.', async () => {
   ]);
 });
 
-test('It processes Sofar Spotter API for daily data.', async () => {
-  jest.setTimeout(30000);
-  const values = await getSpotterData(
-    'SPOT-300434063450120',
-    process.env.SOFAR_API_TOKEN,
-    new Date('2020-09-02'),
-  );
+sofarIntegrationTest(
+  'It processes Sofar Spotter API for daily data.',
+  async () => {
+    jest.setTimeout(30000);
+    const values = await getSpotterData(
+      'SPOT-300434063450120',
+      process.env.SOFAR_API_TOKEN,
+      new Date('2020-09-02'),
+    );
 
-  expect(values.bottomTemperature.length).toEqual(144);
-  expect(values.topTemperature.length).toEqual(144);
-});
+    expect(values.bottomTemperature.length).toEqual(144);
+    expect(values.topTemperature.length).toEqual(144);
+  },
+);
 
-test('it process Sofar Hindcast API for wind-wave data', async () => {
-  jest.setTimeout(30000);
-  const now = new Date();
-  const yesterdayDate = new Date(now);
-  yesterdayDate.setDate(now.getDate() - 1);
-  const today = now.toISOString();
-  const yesterday = yesterdayDate.toISOString();
+sofarIntegrationTest(
+  'it process Sofar Hindcast API for wind-wave data',
+  async () => {
+    jest.setTimeout(30000);
+    const now = new Date();
+    const yesterdayDate = new Date(now);
+    yesterdayDate.setDate(now.getDate() - 1);
+    const today = now.toISOString();
+    const yesterday = yesterdayDate.toISOString();
 
-  const response = await sofarHindcast(
-    SofarModels.Wave,
-    sofarVariableIDs[SofarModels.Wave].significantWaveHeight,
-    -3.5976336810301888,
-    -178.0000002552476,
-    yesterday,
-    today,
-  );
+    const response = await sofarHindcast(
+      SofarModels.Wave,
+      sofarVariableIDs[SofarModels.Wave].significantWaveHeight,
+      -3.5976336810301888,
+      -178.0000002552476,
+      yesterday,
+      today,
+    );
 
-  const values = response?.values[0] as ValueWithTimestamp;
+    const values = response?.values[0] as ValueWithTimestamp;
 
-  expect(new Date(values?.timestamp).getTime()).toBeLessThanOrEqual(
-    now.getTime(),
-  );
-});
+    expect(new Date(values?.timestamp).getTime()).toBeLessThanOrEqual(
+      now.getTime(),
+    );
+  },
+);
 
-test('it process Sofar Wave Date API for surface temperature', async () => {
-  jest.setTimeout(30000);
-  const now = new Date();
-  const yesterdayDate = new Date(now);
-  yesterdayDate.setDate(now.getDate() - 1);
-  const today = now.toISOString();
-  const yesterday = yesterdayDate.toISOString();
+sofarIntegrationTest(
+  'it process Sofar Wave Date API for surface temperature',
+  async () => {
+    jest.setTimeout(30000);
+    const now = new Date();
+    const yesterdayDate = new Date(now);
+    yesterdayDate.setDate(now.getDate() - 1);
+    const today = now.toISOString();
+    const yesterday = yesterdayDate.toISOString();
 
-  const response = await sofarWaveData(
-    'SPOT-1644',
-    process.env.SOFAR_API_TOKEN,
-    yesterday,
-    today,
-  );
+    const response = await sofarWaveData(
+      'SPOT-1644',
+      process.env.SOFAR_API_TOKEN,
+      yesterday,
+      today,
+    );
 
-  expect(response).toBeDefined();
-  expect(response?.data).toBeDefined();
-  expect(response?.data.waves).toBeDefined();
-  expect(Array.isArray(response?.data.waves)).toBe(true);
-  expect(response?.data.waves.length).toBeGreaterThan(0);
-});
+    expect(response).toBeDefined();
+    expect(response?.data).toBeDefined();
+    expect(response?.data.waves).toBeDefined();
+    expect(Array.isArray(response?.data.waves)).toBe(true);
+    expect(response?.data.waves.length).toBeGreaterThan(0);
+  },
+);

--- a/packages/api/src/workers/dailyData.test.ts
+++ b/packages/api/src/workers/dailyData.test.ts
@@ -3,7 +3,9 @@ import { DeepPartial } from 'typeorm';
 import { getDailyData } from './dailyData';
 import { Site } from '../sites/sites.entity';
 
-test('It processes Sofar API for daily data.', async () => {
+const sofarIntegrationTest = process.env.SOFAR_API_TOKEN ? test : test.skip;
+
+sofarIntegrationTest('It processes Sofar API for daily data.', async () => {
   jest.setTimeout(60000);
 
   const date = new Date('2024-08-31');

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -354,10 +354,7 @@ function SiteDetails({
           (() => {
             if (
               isHistoricalView ||
-              ((hasHUIData ||
-                hasSondeData ||
-                hasSeapHOxData ||
-                hasHWOData) &&
+              ((hasHUIData || hasSondeData || hasSeapHOxData || hasHWOData) &&
                 !hasSpotterData)
             ) {
               return <CoralBleaching data={cardData} />;

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -133,6 +133,7 @@ function SiteDetails({
   featuredSurveyId = null,
   featuredSurveyPoint = null,
   surveyDiveDate = null,
+  asOfDate,
 }: SiteDetailsProps) {
   const classes = useStyles();
   const theme = useTheme();
@@ -298,23 +299,68 @@ function SiteDetails({
   }, [forecastData, latestData, timeSeriesRange]);
 
   const { videoStream } = site || {};
+  const historicalTimestamp =
+    asOfDate &&
+    DateTime.fromISO(asOfDate, { zone: site?.timezone || 'UTC' })
+      .endOf('day')
+      .toISOString();
+  const historicalCardData: LatestDataASSofarValue | undefined =
+    historicalTimestamp && site?.collectionData
+      ? {
+          ...(site.collectionData.dhw !== undefined
+            ? {
+                dhw: {
+                  value: site.collectionData.dhw,
+                  timestamp: historicalTimestamp,
+                },
+              }
+            : {}),
+          ...(site.collectionData.satelliteTemperature !== undefined
+            ? {
+                satelliteTemperature: {
+                  value: site.collectionData.satelliteTemperature,
+                  timestamp: historicalTimestamp,
+                },
+              }
+            : {}),
+          ...(site.collectionData.tempAlert !== undefined
+            ? {
+                tempAlert: {
+                  value: site.collectionData.tempAlert,
+                  timestamp: historicalTimestamp,
+                },
+              }
+            : {}),
+          ...(site.collectionData.tempWeeklyAlert !== undefined
+            ? {
+                tempWeeklyAlert: {
+                  value: site.collectionData.tempWeeklyAlert,
+                  timestamp: historicalTimestamp,
+                },
+              }
+            : {}),
+        }
+      : undefined;
+  const isHistoricalView = Boolean(historicalCardData);
+  const cardData = historicalCardData || latestDataAsSofarValues;
 
   const cards =
-    site && latestDataAsSofarValues
+    site && cardData
       ? [
           // CARD 1: Satellite (always shown)
-          <Satellite
-            data={latestDataAsSofarValues}
-            maxMonthlyMean={site.maxMonthlyMean}
-          />,
+          <Satellite data={cardData} maxMonthlyMean={site.maxMonthlyMean} />,
 
           // CARD 2: Sensor/CoralBleaching/TemperatureChange (conditional)
           (() => {
             if (
-              (hasHUIData || hasSondeData || hasSeapHOxData || hasHWOData) &&
-              !hasSpotterData
+              isHistoricalView ||
+              ((hasHUIData ||
+                hasSondeData ||
+                hasSeapHOxData ||
+                hasHWOData) &&
+                !hasSpotterData)
             ) {
-              return <CoralBleaching data={latestDataAsSofarValues} />;
+              return <CoralBleaching data={cardData} />;
             }
 
             if (!hasSpotterData) {
@@ -323,24 +369,17 @@ function SiteDetails({
               );
             }
 
-            return (
-              <Sensor
-                depth={site.depth}
-                id={site.id}
-                data={latestDataAsSofarValues}
-              />
-            );
+            return <Sensor depth={site.depth} id={site.id} data={cardData} />;
           })(),
 
           // CARD 3: SeapHOx (priority) or WaterSampling/CoralBleaching (fallback)
           (() => {
+            if (isHistoricalView) {
+              return <CoralBleaching data={cardData} />;
+            }
+
             if (hasSeapHOxData) {
-              return (
-                <SeapHOxCard
-                  depth={site.depth}
-                  data={latestDataAsSofarValues}
-                />
-              );
+              return <SeapHOxCard depth={site.depth} data={cardData} />;
             }
 
             if (hasHWOData) {
@@ -360,14 +399,11 @@ function SiteDetails({
                 <WaterSamplingCard siteId={site.id.toString()} source="sonde" />
               );
             }
-            return <CoralBleaching data={latestDataAsSofarValues} />;
+            return <CoralBleaching data={cardData} />;
           })(),
 
           // CARD 4: Waves (always shown)
-          <Waves
-            data={latestDataAsSofarValues}
-            hasSpotter={hasSpotterWindWaveData}
-          />,
+          <Waves data={cardData} hasSpotter={hasSpotterWindWaveData} />,
         ]
       : times(4, () => null);
 
@@ -556,6 +592,7 @@ interface SiteDetailsProps {
   surveys: SurveyListItem[];
   featuredSurveyPoint?: SurveyPoint | null;
   surveyDiveDate?: string | null;
+  asOfDate?: string;
 }
 
 export default SiteDetails;

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -33,6 +33,7 @@ import { parseLatestData } from 'store/Sites/helpers';
 import { getMiddlePoint } from 'helpers/map';
 import { formatNumber } from 'helpers/numberUtils';
 import { displayTimeInLocalTimezone } from 'helpers/dates';
+import { getHistoricalCardData } from 'helpers/historicalDate';
 import { DateTime, Interval } from 'luxon';
 import Map from './Map';
 import SketchFab from './SketchFab';
@@ -299,48 +300,9 @@ function SiteDetails({
   }, [forecastData, latestData, timeSeriesRange]);
 
   const { videoStream } = site || {};
-  const historicalTimestamp =
-    asOfDate &&
-    DateTime.fromISO(asOfDate, { zone: site?.timezone || 'UTC' })
-      .endOf('day')
-      .toISOString();
-  const historicalCardData: LatestDataASSofarValue | undefined =
-    historicalTimestamp && site?.collectionData
-      ? {
-          ...(site.collectionData.dhw !== undefined
-            ? {
-                dhw: {
-                  value: site.collectionData.dhw,
-                  timestamp: historicalTimestamp,
-                },
-              }
-            : {}),
-          ...(site.collectionData.satelliteTemperature !== undefined
-            ? {
-                satelliteTemperature: {
-                  value: site.collectionData.satelliteTemperature,
-                  timestamp: historicalTimestamp,
-                },
-              }
-            : {}),
-          ...(site.collectionData.tempAlert !== undefined
-            ? {
-                tempAlert: {
-                  value: site.collectionData.tempAlert,
-                  timestamp: historicalTimestamp,
-                },
-              }
-            : {}),
-          ...(site.collectionData.tempWeeklyAlert !== undefined
-            ? {
-                tempWeeklyAlert: {
-                  value: site.collectionData.tempWeeklyAlert,
-                  timestamp: historicalTimestamp,
-                },
-              }
-            : {}),
-        }
-      : undefined;
+  const historicalCardData = asOfDate
+    ? getHistoricalCardData(site?.collectionData)
+    : undefined;
   const isHistoricalView = Boolean(historicalCardData);
   const cardData = historicalCardData || latestDataAsSofarValues;
 

--- a/packages/website/src/helpers/historicalDate.test.ts
+++ b/packages/website/src/helpers/historicalDate.test.ts
@@ -1,0 +1,36 @@
+import { Settings } from 'luxon';
+import { getHistoricalCardData } from './historicalDate';
+
+describe('historical card observation dates', () => {
+  test.each(['UTC', 'Pacific/Kiritimati', 'Etc/GMT+12'])(
+    'preserves the source timestamp in %s',
+    (zone) => {
+      const originalZone = Settings.defaultZone;
+      Settings.defaultZone = zone;
+      try {
+        const observationDate = '2024-04-10T23:59:59.999Z';
+        const data = getHistoricalCardData({
+          observationDate,
+          satelliteTemperature: 28,
+          dhw: 0,
+          tempAlert: 0,
+          tempWeeklyAlert: 1,
+        });
+        expect(data.satelliteTemperature).toEqual({
+          value: 28,
+          timestamp: observationDate,
+        });
+        expect(Object.values(data).map((metric) => metric.timestamp)).toEqual(
+          Array(4).fill(observationDate),
+        );
+      } finally {
+        Settings.defaultZone = originalZone;
+      }
+    },
+  );
+
+  test('does not relabel undated or missing observations', () => {
+    expect(getHistoricalCardData()).toEqual({});
+    expect(getHistoricalCardData({ satelliteTemperature: 28 })).toEqual({});
+  });
+});

--- a/packages/website/src/helpers/historicalDate.ts
+++ b/packages/website/src/helpers/historicalDate.ts
@@ -1,0 +1,14 @@
+import { DateTime } from 'luxon-extensions';
+
+const DATE_PARAM_REGEX = /^\d{4}-\d{2}-\d{2}$/;
+
+export const todayDateParam = () => DateTime.now().toFormat('yyyy-MM-dd');
+
+export const isHistoricalDateParam = (value: string) => {
+  if (!DATE_PARAM_REGEX.test(value)) {
+    return false;
+  }
+
+  const date = DateTime.fromISO(value, { zone: 'UTC' });
+  return date.isValid && date <= DateTime.now().endOf('day');
+};

--- a/packages/website/src/helpers/historicalDate.ts
+++ b/packages/website/src/helpers/historicalDate.ts
@@ -1,4 +1,28 @@
 import { DateTime } from 'luxon-extensions';
+import type { CollectionData, LatestDataASSofarValue } from 'store/Sites/types';
+
+export const getHistoricalCardData = (
+  data?: CollectionData,
+): LatestDataASSofarValue => {
+  if (!data?.observationDate) {
+    return {};
+  }
+  const timestamp = data.observationDate;
+  return {
+    ...(data.dhw !== undefined ? { dhw: { value: data.dhw, timestamp } } : {}),
+    ...(data.satelliteTemperature !== undefined
+      ? {
+          satelliteTemperature: { value: data.satelliteTemperature, timestamp },
+        }
+      : {}),
+    ...(data.tempAlert !== undefined
+      ? { tempAlert: { value: data.tempAlert, timestamp } }
+      : {}),
+    ...(data.tempWeeklyAlert !== undefined
+      ? { tempWeeklyAlert: { value: data.tempWeeklyAlert, timestamp } }
+      : {}),
+  };
+};
 
 const DATE_PARAM_REGEX = /^\d{4}-\d{2}-\d{2}$/;
 

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -156,7 +156,7 @@ function Popup({ site, classes, autoOpen = true }: PopupProps) {
             <Grid item>
               <Link
                 style={{ color: 'inherit', textDecoration: 'none' }}
-                to={`/sites/${site.id}`}
+                to={`/sites/${site.id}${location.search}`}
                 state={{ from: location.pathname }}
               >
                 <Button

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -15,6 +15,9 @@ import {
   Hidden,
   Alert,
   Theme,
+  TextField,
+  Button,
+  Box,
 } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
@@ -35,7 +38,9 @@ import { focusMapOnSite } from 'helpers/map';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import InfoIcon from '@mui/icons-material/Info';
+import CalendarTodayIcon from '@mui/icons-material/CalendarToday';
 import { mapIconSize } from 'layout/App/theme';
+import { todayDateParam } from 'helpers/historicalDate';
 import { SiteMarkers } from './Markers';
 import { SofarLayers } from './sofarLayers';
 import { InfoDialog } from './InfoDialog';
@@ -92,6 +97,8 @@ function HomepageMap({
   legendLeft,
   classes,
   onMapLoad,
+  selectedDate,
+  onSelectedDateChange,
 }: HomepageMapProps) {
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [legendName, setLegendName] = useState<string>(defaultLayerName || '');
@@ -215,6 +222,12 @@ function HomepageMap({
     setInfoDialogOpen(false);
   };
 
+  const handleDateControlClick = (
+    event: React.MouseEvent<HTMLDivElement, MouseEvent>,
+  ) => {
+    event.stopPropagation();
+  };
+
   return loading ? (
     <div className={classes.loading}>
       <CircularProgress size="4rem" thickness={1} />
@@ -268,6 +281,32 @@ function HomepageMap({
           <InfoIcon color="primary" />
         </IconButton>
       </div>
+      {onSelectedDateChange && (
+        <Box
+          className={classes.dateControl}
+          onClick={handleDateControlClick}
+          onDoubleClick={handleDateControlClick}
+        >
+          <CalendarTodayIcon color="primary" fontSize="small" />
+          <TextField
+            variant="standard"
+            type="date"
+            value={selectedDate || ''}
+            inputProps={{
+              max: todayDateParam(),
+              'aria-label': 'Map date',
+            }}
+            onChange={(event) => {
+              onSelectedDateChange(event.target.value || undefined);
+            }}
+          />
+          {selectedDate && (
+            <Button size="small" onClick={() => onSelectedDateChange()}>
+              Latest
+            </Button>
+          )}
+        </Box>
+      )}
       <InfoDialog
         infoDialogOpen={infoDialogOpen}
         handleInfoClose={handleInfoClose}
@@ -356,6 +395,24 @@ const styles = (theme: Theme) =>
     expandIcon: {
       fontSize: '34px',
     },
+    dateControl: {
+      position: 'absolute',
+      left: 10,
+      top: 10,
+      zIndex: 1000,
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: theme.spacing(0.75, 1),
+      backgroundColor: 'white',
+      backgroundClip: 'padding-box',
+      border: '2px solid rgba(0,0,0,0.2)',
+      borderRadius: 5,
+      '& input': {
+        width: 132,
+        padding: theme.spacing(0.5, 0),
+      },
+    },
     '@global': {
       // Disable tile fade animation
       '.no-tile-fade': {
@@ -380,6 +437,10 @@ interface HomepageMapIncomingProps {
   legendBottom?: number;
   legendLeft?: number;
   onMapLoad?: (map: L.Map) => void;
+  selectedDate?: string;
+  onSelectedDateChange?: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
 }
 
 type HomepageMapProps = WithStyles<typeof styles> & HomepageMapIncomingProps;

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -208,7 +208,7 @@ function SelectedSiteCardContent({
             >
               {site && imageUrl && (
                 <Link
-                  to={`/sites/${site.id}`}
+                  to={`/sites/${site.id}${location.search}`}
                   state={{ from: location.pathname }}
                 >
                   <CardMedia
@@ -259,7 +259,7 @@ function SelectedSiteCardContent({
                       <Chip
                         live
                         liveText="LIVE VIDEO"
-                        to={`/sites/${site.id}`}
+                        to={`/sites/${site.id}${location.search}`}
                         state={{ from: location.pathname }}
                         width={80}
                       />
@@ -268,7 +268,7 @@ function SelectedSiteCardContent({
                       <Button
                         className={classes.exploreButton}
                         component={Link}
-                        to={`/sites/${site.id}`}
+                        to={`/sites/${site.id}${location.search}`}
                         state={{ from: location.pathname }}
                         onClick={onExploreButtonClick}
                         size="small"
@@ -315,7 +315,7 @@ function SelectedSiteCardContent({
                   <Chip
                     live
                     liveText="LIVE VIDEO"
-                    to={`/sites/${site.id}`}
+                    to={`/sites/${site.id}${location.search}`}
                     state={{ from: location.pathname }}
                     width={80}
                   />

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Box, Card, Theme, Typography } from '@mui/material';
 import LaunchIcon from '@mui/icons-material/Launch';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 
 import { useSelector } from 'react-redux';
 import makeStyles from '@mui/styles/makeStyles';
@@ -41,6 +41,7 @@ function SelectedSiteCard() {
   const loading = useSelector(siteLoadingSelector);
   const error = useSelector(siteErrorSelector);
   const surveyList = useSelector(surveyListSelector);
+  const location = useLocation();
 
   const isFeatured = (site?.id || '').toString() === featuredSiteId;
 
@@ -71,7 +72,7 @@ function SelectedSiteCard() {
             <Typography variant="h5" color="textSecondary">
               {isFeatured ? 'Featured Site' : 'Selected Site'}
               {!hasMedia && (
-                <Link to={`/sites/${site?.id}`}>
+                <Link to={`/sites/${site?.id}${location.search}`}>
                   <LaunchIcon className={classes.launchIcon} />
                 </Link>
               )}

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -15,12 +15,15 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
 import HomepageNavBar from 'common/NavBar';
+import { useQueryParam } from 'hooks/useQueryParams';
+import { isHistoricalDateParam } from 'helpers/historicalDate';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
@@ -70,20 +73,24 @@ function Homepage({ classes }: HomepageProps) {
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
+  const [selectedDate, setSelectedDate] = useQueryParam(
+    QueryParamKeys.DATE,
+    isHistoricalDateParam,
+  );
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest({ date: selectedDate }));
+  }, [dispatch, selectedDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
-      dispatch(siteRequest(initialSiteId));
+      dispatch(siteRequest({ id: initialSiteId, date: selectedDate }));
       dispatch(surveysRequest(initialSiteId));
     } else if (siteOnMap) {
-      dispatch(siteRequest(`${siteOnMap.id}`));
+      dispatch(siteRequest({ id: `${siteOnMap.id}`, date: selectedDate }));
       dispatch(surveysRequest(`${siteOnMap.id}`));
     }
-  }, [dispatch, initialSiteId, siteOnMap]);
+  }, [dispatch, initialSiteId, selectedDate, siteOnMap]);
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 
@@ -124,6 +131,8 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              selectedDate={selectedDate}
+              onSelectedDateChange={setSelectedDate}
             />
           </Grid>
           {showSiteTable && (

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -1407,8 +1407,8 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-wgcuqq-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for=":r4t:"
-          id=":r4t:-label"
+          for="site-data-date"
+          id="site-data-date-label"
         >
           View data as of
         </label>
@@ -1419,7 +1419,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             aria-invalid="false"
             aria-label="Site data date"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-uiizfa-MuiInputBase-input-MuiOutlinedInput-input"
-            id=":r4t:"
+            id="site-data-date"
             max="2026-05-28"
             type="date"
             value=""
@@ -4435,8 +4435,8 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         <label
           class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-wgcuqq-MuiFormLabel-root-MuiInputLabel-root"
           data-shrink="true"
-          for=":r10:"
-          id=":r10:-label"
+          for="site-data-date"
+          id="site-data-date-label"
         >
           View data as of
         </label>
@@ -4447,7 +4447,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             aria-invalid="false"
             aria-label="Site data date"
             class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-uiizfa-MuiInputBase-input-MuiOutlinedInput-input"
-            id=":r10:"
+            id="site-data-date"
             max="2026-05-28"
             type="date"
             value=""

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -1394,6 +1394,51 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         </div>
       </div>
     </mock-box>
+    <mock-box
+      alignitems="center"
+      display="flex"
+      flexwrap="wrap"
+      gap="0.75rem"
+      mt="1rem"
+    >
+      <div
+        class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-wgcuqq-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for=":r4t:"
+          id=":r4t:-label"
+        >
+          View data as of
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-3tcely-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Site data date"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-uiizfa-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":r4t:"
+            max="2026-05-28"
+            type="date"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                View data as of
+              </span>
+            </legend>
+          </fieldset>
+        </div>
+      </div>
+    </mock-box>
     <div>
       <mock-box
         mt="1.5rem"
@@ -4374,6 +4419,51 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </div>
             </div>
           </div>
+        </div>
+      </div>
+    </mock-box>
+    <mock-box
+      alignitems="center"
+      display="flex"
+      flexwrap="wrap"
+      gap="0.75rem"
+      mt="1rem"
+    >
+      <div
+        class="MuiFormControl-root MuiTextField-root css-1xp5r68-MuiFormControl-root-MuiTextField-root"
+      >
+        <label
+          class="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined MuiFormLabel-colorPrimary MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiInputLabel-sizeSmall MuiInputLabel-outlined css-wgcuqq-MuiFormLabel-root-MuiInputLabel-root"
+          data-shrink="true"
+          for=":r10:"
+          id=":r10:-label"
+        >
+          View data as of
+        </label>
+        <div
+          class="MuiInputBase-root MuiOutlinedInput-root MuiInputBase-colorPrimary MuiInputBase-formControl MuiInputBase-sizeSmall css-3tcely-MuiInputBase-root-MuiOutlinedInput-root"
+        >
+          <input
+            aria-invalid="false"
+            aria-label="Site data date"
+            class="MuiInputBase-input MuiOutlinedInput-input MuiInputBase-inputSizeSmall css-uiizfa-MuiInputBase-input-MuiOutlinedInput-input"
+            id=":r10:"
+            max="2026-05-28"
+            type="date"
+            value=""
+          />
+          <fieldset
+            aria-hidden="true"
+            class="MuiOutlinedInput-notchedOutline css-18p5xg2-MuiNotchedOutlined-root-MuiOutlinedInput-notchedOutline"
+          >
+            <legend
+              class="css-ex8a5f-MuiNotchedOutlined-root"
+            >
+              <span>
+                View data as of
+              </span>
+            </legend>
+          </fieldset>
         </div>
       </div>
     </mock-box>

--- a/packages/website/src/routes/SiteRoutes/Site/index.test.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.test.tsx
@@ -30,7 +30,19 @@ vi.mock('common/Chart/MultipleSensorsCharts', () => ({
 describe('Site Detail Page', () => {
   let elementEmpty: HTMLElement;
   let elementFull: HTMLElement;
+
   beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-28T12:00:00Z'));
+
+    const datedMockSite = {
+      ...mockSite,
+      dailyData: mockSite.dailyData.map((dailyData) => ({
+        ...dailyData,
+        date: '2026-05-28T11:55:00.000Z',
+      })),
+    };
+
     const emptyStore = mockStore({
       selectedSite: {
         details: { ...mockSite, dailyData: [] },
@@ -73,7 +85,7 @@ describe('Site Detail Page', () => {
 
     const fullStore = mockStore({
       selectedSite: {
-        details: mockSite,
+        details: datedMockSite,
         timeSeriesDataRange: mockDataRange,
         loading: false,
         error: null,
@@ -84,10 +96,10 @@ describe('Site Detail Page', () => {
         loading: false,
       },
       homepage: {
-        siteOnMap: mockSite,
+        siteOnMap: datedMockSite,
       },
       sitesList: {
-        list: [mockSite],
+        list: [datedMockSite],
         loading: false,
         error: null,
       },
@@ -137,6 +149,10 @@ describe('Site Detail Page', () => {
         </Provider>
       </ThemeProvider>,
     ).container;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
   });
 
   it('should render with given state from Redux store', () => {

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { Alert, Container, Box } from '@mui/material';
+import { Alert, Container, Box, Button, TextField } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import withStyles from '@mui/styles/withStyles';
 import createStyles from '@mui/styles/createStyles';
@@ -39,6 +39,7 @@ import { localizedEndOfDay } from 'common/Chart/MultipleSensorsCharts/helpers';
 import LoadingSkeleton from 'common/LoadingSkeleton';
 import { DateTime } from 'luxon-extensions';
 import { reefCheckSurveysRequest } from 'store/ReefCheckSurveys';
+import { isHistoricalDateParam, todayDateParam } from 'helpers/historicalDate';
 import SiteInfo from './SiteInfo';
 import NotFoundPage from '../../NotFound/index';
 
@@ -122,6 +123,10 @@ function Site({ classes }: SiteProps) {
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
   const [querySurveyPointId] = useQueryParam('surveyPoint');
   const [refresh, setRefresh] = useQueryParam('refresh');
+  const [selectedDate, setSelectedDate] = useQueryParam(
+    'date',
+    isHistoricalDateParam,
+  );
   const { id: selectedSurveyPointId } =
     findSurveyPointFromList(querySurveyPointId, surveyPoints) || {};
 
@@ -162,7 +167,7 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
 
-      dispatch(siteRequest(siteId));
+      dispatch(siteRequest({ id: siteId, date: selectedDate }));
       dispatch(spotterPositionRequest(siteId));
       dispatch(surveysRequest(siteId));
     }
@@ -171,7 +176,7 @@ function Site({ classes }: SiteProps) {
 
   // Fetch site and surveys
   useEffect(() => {
-    dispatch(siteRequest(siteId));
+    dispatch(siteRequest({ id: siteId, date: selectedDate }));
     dispatch(spotterPositionRequest(siteId));
     dispatch(surveysRequest(siteId));
 
@@ -180,7 +185,7 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
     };
-  }, [dispatch, siteId]);
+  }, [dispatch, selectedDate, siteId]);
 
   // Fetch reef check surveys
   useEffect(() => {
@@ -236,6 +241,33 @@ function Site({ classes }: SiteProps) {
               )}
             </LoadingSkeleton>
           </Box>
+          <Box
+            mt="1rem"
+            display="flex"
+            gap="0.75rem"
+            alignItems="center"
+            flexWrap="wrap"
+          >
+            <TextField
+              label="View data as of"
+              type="date"
+              size="small"
+              value={selectedDate || ''}
+              inputProps={{
+                max: todayDateParam(),
+                'aria-label': 'Site data date',
+              }}
+              InputLabelProps={{ shrink: true }}
+              onChange={(event) => {
+                setSelectedDate(event.target.value || undefined);
+              }}
+            />
+            {selectedDate && (
+              <Button variant="outlined" onClick={() => setSelectedDate()}>
+                Latest
+              </Button>
+            )}
+          </Box>
           {/* Only show alert message when data is loading */}
           {!hasSpotterData && !isLoading && !hasDailyData && (
             <Box mt="1.3rem">
@@ -252,6 +284,7 @@ function Site({ classes }: SiteProps) {
               surveys={surveyList}
               featuredSurveyPoint={featuredSurveyPoint}
               surveyDiveDate={diveDate}
+              asOfDate={selectedDate}
             />
           </div>
         </Container>

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -249,6 +249,7 @@ function Site({ classes }: SiteProps) {
             flexWrap="wrap"
           >
             <TextField
+              id="site-data-date"
               label="View data as of"
               type="date"
               size="small"

--- a/packages/website/src/services/siteServices.test.ts
+++ b/packages/website/src/services/siteServices.test.ts
@@ -1,0 +1,41 @@
+import requests from 'helpers/requests';
+import siteServices from './siteServices';
+
+vi.mock('helpers/requests', () => ({
+  default: {
+    send: vi.fn(() => Promise.resolve({ data: [] })),
+  },
+}));
+
+describe('siteServices', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('adds the optional historical date to site list requests', () => {
+    siteServices.getSites({ date: '2024-04-15' });
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: 'sites?date=2024-04-15',
+      method: 'GET',
+    });
+  });
+
+  it('adds the optional historical date to site detail requests', () => {
+    siteServices.getSite('10', '2024-04-15');
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: 'sites/10?date=2024-04-15',
+      method: 'GET',
+    });
+  });
+
+  it('supports daily data requests bounded only by an end date', () => {
+    siteServices.getSiteDailyData('10', undefined, '2024-04-15');
+
+    expect(requests.send).toHaveBeenCalledWith({
+      url: 'sites/10/daily_data?end=2024-04-15T23%3A59%3A59.999Z',
+      method: 'GET',
+    });
+  });
+});

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -23,21 +23,34 @@ import {
   SpotterInfoResponse,
   GetSiteContactInfoProps,
   GetSiteContactInfoResponse,
+  SitesRequestParams,
 } from 'store/Sites/types';
 import requests from 'helpers/requests';
 import { constructTimeSeriesDataRequestUrl } from 'helpers/siteUtils';
 
-const getSite = (id: string) =>
+const appendDateQuery = (date?: string) => (date ? `?date=${date}` : '');
+
+const dailyDataEndDate = (end?: string) =>
+  end && /^\d{4}-\d{2}-\d{2}$/.test(end) ? `${end}T23:59:59.999Z` : end;
+
+const appendDailyDataQuery = (start?: string, end?: string) => {
+  const params = new URLSearchParams({
+    ...(end ? { end: dailyDataEndDate(end) } : {}),
+    ...(start ? { start } : {}),
+  }).toString();
+
+  return params ? `?${params}` : '';
+};
+
+const getSite = (id: string, date?: string) =>
   requests.send<Site>({
-    url: `sites/${id}`,
+    url: `sites/${id}${appendDateQuery(date)}`,
     method: 'GET',
   });
 
 const getSiteDailyData = (id: string, start?: string, end?: string) =>
   requests.send<DailyData[]>({
-    url: `sites/${id}/daily_data${
-      start && end ? `?end=${end}&start=${start}` : ''
-    }`,
+    url: `sites/${id}/daily_data${appendDailyDataQuery(start, end)}`,
     method: 'GET',
   });
 
@@ -83,9 +96,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = ({ date }: SitesRequestParams = {}) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${appendDateQuery(date)}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/historicalRequests.test.ts
+++ b/packages/website/src/store/Sites/historicalRequests.test.ts
@@ -1,0 +1,111 @@
+import { configureStore } from '@reduxjs/toolkit';
+import siteServices from 'services/siteServices';
+import selectedSite, { siteRequest } from './selectedSiteSlice';
+import sitesList, { sitesRequest } from './sitesListSlice';
+
+vi.mock('services/siteServices', () => ({
+  default: {
+    getSites: vi.fn(),
+    getSite: vi.fn(),
+    getSiteDailyData: vi.fn().mockResolvedValue({ data: [] }),
+    getSiteSurveyPoints: vi.fn().mockResolvedValue({ data: [] }),
+  },
+}));
+
+const makeSite = (temperature: number) => ({
+  id: 1,
+  name: 'Test site',
+  historicalMonthlyMean: [],
+  collectionData: { satelliteTemperature: temperature },
+});
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+};
+
+describe.each(['map', 'site'] as const)(
+  '%s historical request ordering',
+  (view) => {
+    const service =
+      view === 'map' ? siteServices.getSites : siteServices.getSite;
+    const response = (temperature: number) => ({
+      data: view === 'map' ? [makeSite(temperature)] : makeSite(temperature),
+    });
+    const request = (date?: string) =>
+      view === 'map'
+        ? sitesRequest(date ? { date } : undefined)
+        : siteRequest({ id: '1', date });
+    const getState = (store: ReturnType<typeof makeStore>) =>
+      view === 'map'
+        ? store.getState().sitesList
+        : store.getState().selectedSite;
+    const temperature = (store: ReturnType<typeof makeStore>) =>
+      view === 'map'
+        ? store.getState().sitesList.list?.[0].collectionData
+            ?.satelliteTemperature
+        : store.getState().selectedSite.details?.collectionData
+            ?.satelliteTemperature;
+    function makeStore() {
+      return configureStore({ reducer: { selectedSite, sitesList } });
+    }
+
+    beforeEach(() => vi.mocked(service).mockReset());
+
+    test('late older response cannot replace the latest requested date', async () => {
+      const store = makeStore();
+      const older = deferred<ReturnType<typeof response>>();
+      const newer = deferred<ReturnType<typeof response>>();
+      vi.mocked(service)
+        .mockReturnValueOnce(older.promise as never)
+        .mockReturnValueOnce(newer.promise as never);
+      const a = store.dispatch(request('2024-04-15') as never);
+      const b = store.dispatch(request('2024-05-15') as never);
+      newer.resolve(response(30));
+      await b;
+      older.resolve(response(20));
+      await a;
+      expect(getState(store).date).toBe('2024-05-15');
+      expect(temperature(store)).toBe(30);
+    });
+
+    test('reset to cached Latest invalidates a pending historical request', async () => {
+      const store = makeStore();
+      vi.mocked(service).mockResolvedValueOnce(response(30) as never);
+      await store.dispatch(request() as never);
+      const older = deferred<ReturnType<typeof response>>();
+      vi.mocked(service)
+        .mockReturnValueOnce(older.promise as never)
+        .mockResolvedValueOnce(response(31) as never);
+      const a = store.dispatch(request('2024-04-15') as never);
+      await store.dispatch(request() as never);
+      older.resolve(response(20));
+      await a;
+      expect(service).toHaveBeenCalledTimes(3);
+      expect(getState(store).date).toBeUndefined();
+      expect(temperature(store)).toBe(31);
+    });
+
+    test('stale failure does not clear the newer request loading state', async () => {
+      const store = makeStore();
+      const older = deferred<ReturnType<typeof response>>();
+      const newer = deferred<ReturnType<typeof response>>();
+      vi.mocked(service)
+        .mockReturnValueOnce(older.promise as never)
+        .mockReturnValueOnce(newer.promise as never);
+      const a = store.dispatch(request('2024-04-15') as never);
+      const b = store.dispatch(request('2024-05-15') as never);
+      older.reject(new Error('Old request failed'));
+      await a;
+      expect(getState(store).loading).toBe(true);
+      expect(getState(store).error).toBeNull();
+      newer.resolve(response(30));
+      await b;
+      expect(getState(store).loading).toBe(false);
+    });
+  },
+);

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -11,6 +11,7 @@ import type {
   TimeSeriesDataRangeRequestParams,
   TimeSeriesDataRequestParams,
   GetSiteContactInfoProps,
+  SiteRequestParams,
   Site,
   Metrics,
   TimeSeries,
@@ -37,6 +38,9 @@ const selectedSiteInitialState: SelectedSiteState = {
 };
 
 const AlreadyLoadingErrorMessage = 'Request already loading';
+
+const parseSiteRequestArg = (arg: string | SiteRequestParams) =>
+  typeof arg === 'string' ? { id: arg, date: undefined } : arg;
 
 export const forecastDataRequest = createAsyncThunk<
   SelectedSiteState['forecastData'],
@@ -90,14 +94,19 @@ export const latestDataRequest = createAsyncThunk<
 
 export const siteRequest = createAsyncThunk<
   SelectedSiteState['details'],
-  string,
+  string | SiteRequestParams,
   CreateAsyncThunkTypes
 >(
   'selectedSite/request',
-  async (id: string, { rejectWithValue }) => {
+  async (arg: string | SiteRequestParams, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSite(id);
-      const { data: dailyData } = await siteServices.getSiteDailyData(id);
+      const { id, date } = parseSiteRequestArg(arg);
+      const { data } = await siteServices.getSite(id, date);
+      const { data: dailyData } = await siteServices.getSiteDailyData(
+        id,
+        undefined,
+        date,
+      );
       const { data: surveyPoints } = await siteServices.getSiteSurveyPoints(id);
 
       return {
@@ -123,11 +132,12 @@ export const siteRequest = createAsyncThunk<
     }
   },
   {
-    condition(id: string, { getState }) {
+    condition(arg: string | SiteRequestParams, { getState }) {
+      const { id, date } = parseSiteRequestArg(arg);
       const {
-        selectedSite: { details },
+        selectedSite: { details, date: currentDate },
       } = getState();
-      return `${details?.id}` !== id;
+      return `${details?.id}` !== id || currentDate !== date;
     },
   },
 );
@@ -334,14 +344,12 @@ const selectedSiteSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      siteRequest.fulfilled,
-      (state, action: PayloadAction<SelectedSiteState['details']>) => ({
-        ...state,
-        details: action.payload,
-        loading: false,
-      }),
-    );
+    builder.addCase(siteRequest.fulfilled, (state, action) => ({
+      ...state,
+      details: action.payload,
+      date: parseSiteRequestArg(action.meta.arg).date,
+      loading: false,
+    }));
 
     builder.addCase(
       siteRequest.rejected,

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -135,9 +135,13 @@ export const siteRequest = createAsyncThunk<
     condition(arg: string | SiteRequestParams, { getState }) {
       const { id, date } = parseSiteRequestArg(arg);
       const {
-        selectedSite: { details, date: currentDate },
+        selectedSite: { details, date: currentDate, currentRequestId },
       } = getState();
-      return `${details?.id}` !== id || currentDate !== date;
+      return (
+        Boolean(currentRequestId) ||
+        `${details?.id}` !== id ||
+        currentDate !== date
+      );
     },
   },
 );
@@ -344,26 +348,34 @@ const selectedSiteSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(siteRequest.fulfilled, (state, action) => ({
-      ...state,
-      details: action.payload,
-      date: parseSiteRequestArg(action.meta.arg).date,
-      loading: false,
-    }));
-
-    builder.addCase(
-      siteRequest.rejected,
-      (state, action: PayloadAction<SelectedSiteState['error']>) => ({
-        ...state,
-        error: action.payload,
-        loading: false,
-      }),
+    builder.addCase(siteRequest.fulfilled, (state, action) =>
+      state.currentRequestId !== action.meta.requestId
+        ? state
+        : {
+            ...state,
+            details: action.payload,
+            date: parseSiteRequestArg(action.meta.arg).date,
+            loading: false,
+            currentRequestId: undefined,
+          },
     );
 
-    builder.addCase(siteRequest.pending, (state) => ({
+    builder.addCase(siteRequest.rejected, (state, action) =>
+      state.currentRequestId !== action.meta.requestId
+        ? state
+        : {
+            ...state,
+            error: action.payload,
+            loading: false,
+            currentRequestId: undefined,
+          },
+    );
+
+    builder.addCase(siteRequest.pending, (state, action) => ({
       ...state,
       loading: true,
       error: null,
+      currentRequestId: action.meta.requestId,
     }));
 
     builder.addCase(

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -22,6 +22,7 @@ import type {
   SiteFilters,
   SitesListState,
   SitesRequestData,
+  SitesRequestParams,
   UpdateSiteNameFromListArgs,
 } from './types';
 import type { CreateAsyncThunkTypes, RootState } from '../configure';
@@ -35,13 +36,14 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  SitesRequestParams | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { date } = arg || {};
+      const { data } = await siteServices.getSites({ date });
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +51,19 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: SitesRequestParams | undefined, { getState }) {
+      const { date } = arg || {};
       const {
-        sitesList: { list },
+        sitesList: { list, date: currentDate },
       } = getState();
-      return !list;
+      return !list || currentDate !== date;
     },
   },
 );
@@ -108,6 +112,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -61,9 +61,9 @@ export const sitesRequest = createAsyncThunk<
     condition(arg: SitesRequestParams | undefined, { getState }) {
       const { date } = arg || {};
       const {
-        sitesList: { list, date: currentDate },
+        sitesList: { list, date: currentDate, currentRequestId },
       } = getState();
-      return !list || currentDate !== date;
+      return Boolean(currentRequestId) || !list || currentDate !== date;
     },
   },
 );
@@ -107,28 +107,36 @@ const sitesListSlice = createSlice({
     }),
   },
   extraReducers: (builder) => {
-    builder.addCase(
-      sitesRequest.fulfilled,
-      (state, action: PayloadAction<SitesRequestData>) => ({
-        ...state,
-        list: action.payload.list,
-        date: action.payload.date,
-        loading: false,
-      }),
+    builder.addCase(sitesRequest.fulfilled, (state, action) =>
+      state.currentRequestId !== action.meta.requestId
+        ? state
+        : {
+            ...state,
+            list: action.payload.list,
+            date: action.payload.date,
+            loading: false,
+            currentRequestId: undefined,
+          },
     );
 
-    builder.addCase(sitesRequest.rejected, (state, action) => ({
-      ...state,
-      error: action.error.message
-        ? action.error.message
-        : action.error.toString(),
-      loading: false,
-    }));
+    builder.addCase(sitesRequest.rejected, (state, action) =>
+      state.currentRequestId !== action.meta.requestId
+        ? state
+        : {
+            ...state,
+            error: action.error.message
+              ? action.error.message
+              : action.error.toString(),
+            loading: false,
+            currentRequestId: undefined,
+          },
+    );
 
-    builder.addCase(sitesRequest.pending, (state) => ({
+    builder.addCase(sitesRequest.pending, (state, action) => ({
       ...state,
       loading: true,
       error: null,
+      currentRequestId: action.meta.requestId,
     }));
   },
 });

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -401,10 +401,21 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date?: string;
+}
+
+export interface SitesRequestParams {
+  date?: string;
+}
+
+export interface SiteRequestParams {
+  id: string;
+  date?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  date?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;
@@ -413,6 +424,7 @@ export interface SitesListState {
 export interface SelectedSiteState {
   draft: SiteUpdateParams | null;
   details?: Site | null;
+  date?: string;
   spotterPosition?: {
     position?: {
       longitude: number;

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -270,7 +270,9 @@ export interface CollectionMetrics {
   sstAnomaly?: number;
 }
 
-export type CollectionDataResponse = Partial<Record<Metrics, number>>;
+export type CollectionDataResponse = Partial<Record<Metrics, number>> & {
+  observationDate?: string;
+};
 
 export type CollectionData = CollectionDataResponse;
 
@@ -414,6 +416,7 @@ export interface SiteRequestParams {
 }
 
 export interface SitesListState {
+  currentRequestId?: string;
   list?: Site[];
   date?: string;
   filters: SiteFilters;
@@ -422,6 +425,7 @@ export interface SitesListState {
 }
 
 export interface SelectedSiteState {
+  currentRequestId?: string;
   draft: SiteUpdateParams | null;
   details?: Site | null;
   date?: string;


### PR DESCRIPTION
/claim #1162

Closes #1162

## Summary
- Add optional `date` support to `GET /sites` and `GET /sites/:id`, backed by the latest daily-data row on or before the selected day.
- Add URL-backed historical date controls on the map and site detail pages.
- Preserve the selected date when opening site pages from map popups and selected-site cards.
- Bound site-detail daily chart requests to the selected day so the detail view, cards, and chart window stay aligned.
- Add focused API and website coverage for the historical query flow.
- Make the historical-date snapshots deterministic by fixing their clock and mock daily-data timestamp.
- Keep fork CI independent of unavailable backend/GCS/SOFAR secrets by supplying test-only defaults and skipping token-backed live integration tests when the token is absent.

## Demo
https://files.catbox.moe/awrqiu.mp4

## Payout
Algora payout: @jamilahmadzai

## Validation
- `YARN_IGNORE_ENGINES=1 corepack yarn install --frozen-lockfile`
- ESLint on all changed TypeScript/TSX files with `--max-warnings 0`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace api test --runInBand src/utils/sofar.test.ts src/workers/dailyData.test.ts` (5 token-backed tests skipped as intended without `SOFAR_API_TOKEN`)
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace api build`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace website build`
- `YARN_IGNORE_ENGINES=1 corepack yarn workspace website test src/routes/SiteRoutes/Site/index.test.tsx src/routes/HomeMap/index.test.tsx src/services/siteServices.test.ts` (3 files, 6 tests passed)
- `git diff --check origin/master...HEAD`

The focused API e2e path requires the repository's Postgres test service, which is not available in this local environment; the API compiles successfully and GitHub Actions covers the database-backed suite.

