### PR TITLE
feat: add historical date viewing for map layers

### DIFF
--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -89,6 +89,7 @@ function HomepageMap({
   defaultLayerName,
   legendBottom,
   legendLeft,
+  selectedDate,
   classes,
   onMapLoad,
 }: HomepageMapProps) {
@@ -189,8 +190,8 @@ function HomepageMap({
 
   // Memoize the layers to prevent unnecessary re-renders
   const sofarLayers = useMemo(
-    () => <SofarLayers defaultLayerName={defaultLayerName} />,
-    [defaultLayerName],
+    () => <SofarLayers defaultLayerName={defaultLayerName} selectedDate={selectedDate} />,
+    [defaultLayerName, selectedDate],
   );
 
   const siteMarkers = useMemo(
@@ -384,6 +385,7 @@ interface HomepageMapIncomingProps {
   defaultLayerName?: MapLayerName;
   legendBottom?: number;
   legendLeft?: number;
+  selectedDate?: string;
   onMapLoad?: (map: L.Map) => void;
 }
 

--- a/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
+++ b/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
@@ -40,10 +40,18 @@ const WMS_LAYERS: WMSLayerDefinition[] = [
 
 const { REACT_APP_SOFAR_API_TOKEN: API_TOKEN } = process.env;
 
-const sofarUrlFromDef = ({ model, cmap, variableId }: SofarLayerDefinition) =>
-  `https://api.sofarocean.com/marine-weather/v1/models/${model}/tile/{z}/{x}/{y}.png?colormap=${cmap}&token=${API_TOKEN}&variableID=${variableId}`;
+const sofarUrlFromDef = (
+  { model, cmap, variableId }: SofarLayerDefinition,
+  selectedDate?: string,
+) => {
+  const baseUrl = `https://api.sofarocean.com/marine-weather/v1/models/${model}/tile/{z}/{x}/{y}.png?colormap=${cmap}&token=${API_TOKEN}&variableID=${variableId}`;
+  if (selectedDate) {
+    return `${baseUrl}&time=${selectedDate}T12:00:00Z`;
+  }
+  return baseUrl;
+};
 
-export function SofarLayers({ defaultLayerName }: SofarLayersProps) {
+export function SofarLayers({ defaultLayerName, selectedDate }: SofarLayersProps) {
   return (
     <LayersControl position="topright">
       <LayersControl.BaseLayer
@@ -62,8 +70,8 @@ export function SofarLayers({ defaultLayerName }: SofarLayersProps) {
           <TileLayer
             // Sofar tiles have a max native zoom of 9
             maxNativeZoom={9}
-            url={sofarUrlFromDef(def)}
-            key={def.variableId}
+            url={sofarUrlFromDef(def, selectedDate)}
+            key={`${def.variableId}-${selectedDate || 'latest'}`}
             opacity={0.5}
           />
         </LayersControl.BaseLayer>
@@ -90,6 +98,7 @@ export function SofarLayers({ defaultLayerName }: SofarLayersProps) {
 
 interface SofarLayersProps {
   defaultLayerName?: MapLayerName;
+  selectedDate?: string;
 }
 
 export default SofarLayers;

--- a/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
+++ b/packages/website/src/routes/HomeMap/Map/sofarLayers.tsx
@@ -51,7 +51,10 @@ const sofarUrlFromDef = (
   return baseUrl;
 };
 
-export function SofarLayers({ defaultLayerName, selectedDate }: SofarLayersProps) {
+export function SofarLayers({
+  defaultLayerName,
+  selectedDate,
+}: SofarLayersProps) {
   return (
     <LayersControl position="topright">
       <LayersControl.BaseLayer

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,10 +3,12 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Grid, Hidden, TextField, IconButton, Tooltip } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
+import ClearIcon from '@mui/icons-material/Clear';
+import DateRangeIcon from '@mui/icons-material/DateRange';
 import SwipeableBottomSheet from 'react-swipeable-bottom-sheet';
 import { sitesRequest, sitesListSelector } from 'store/Sites/sitesListSlice';
 import { siteRequest } from 'store/Sites/selectedSiteSlice';
@@ -67,6 +69,7 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string>('');
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
@@ -124,7 +127,38 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              selectedDate={selectedDate || undefined}
             />
+            <div className={classes.datePicker}>
+              <Tooltip title="View historical data">
+                <DateRangeIcon
+                  className={classes.datePickerIcon}
+                  fontSize="small"
+                />
+              </Tooltip>
+              <TextField
+                type="date"
+                size="small"
+                value={selectedDate}
+                onChange={(e) => setSelectedDate(e.target.value)}
+                InputLabelProps={{ shrink: true }}
+                inputProps={{
+                  max: new Date().toISOString().split('T')[0],
+                }}
+                variant="standard"
+              />
+              {selectedDate && (
+                <Tooltip title="Reset to latest">
+                  <IconButton
+                    size="small"
+                    onClick={() => setSelectedDate('')}
+                    className={classes.clearDateButton}
+                  >
+                    <ClearIcon fontSize="small" />
+                  </IconButton>
+                </Tooltip>
+              )}
+            </div>
           </Grid>
           {showSiteTable && (
             <Hidden mdDown>
@@ -165,6 +199,26 @@ const styles = () =>
     map: {
       display: 'flex',
       zIndex: 0,
+      position: 'relative',
+    },
+    datePicker: {
+      position: 'absolute',
+      bottom: 40,
+      right: 10,
+      zIndex: 1000,
+      display: 'flex',
+      alignItems: 'center',
+      gap: 4,
+      backgroundColor: 'white',
+      borderRadius: 4,
+      padding: '4px 8px',
+      boxShadow: '0 1px 5px rgba(0,0,0,0.3)',
+    },
+    datePickerIcon: {
+      color: 'rgba(0, 0, 0, 0.54)',
+    },
+    clearDateButton: {
+      padding: 2,
     },
     siteTable: {
       display: 'flex',


### PR DESCRIPTION
Closes #1162

Add a date picker to the homepage map allowing users to browse historical SOFAR data layers.

Changes:
- Date picker overlay positioned at bottom-right of the map
- Selected date passed as time query parameter to SOFAR API tile URLs
- Clear button to reset to latest real-time data
- Max date capped at today to prevent requesting future data
- Zero external dependencies (uses native HTML date input via MUI TextField)