### PR TITLE
feat: historical date support for the map and sites list

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,9 +5,10 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SiteStatus } from '../sites.entity';
 
 export class FilterSiteDto {
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiPropertyOptional({ example: '2023-06-15', description: 'Show site alert data for this historical date (YYYY-MM-DD)' })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,7 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import { getCollectionData, getHistoricalCollectionData } from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +198,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mappedSiteData = filter.date
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
+import { DailyData } from '../sites/daily-data.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
@@ -43,6 +44,55 @@ export const getCollectionData = async (
       ),
     )
     .toJSON();
+};
+
+/**
+ * Fetch per-site collection data for a specific historical date from DailyData.
+ * Maps DailyData fields to the CollectionDataDto keys used by the frontend.
+ */
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const targetDate = new Date(date);
+  // Round to day boundary to match DailyData.date column (stored as midnight UTC)
+  targetDate.setUTCHours(0, 0, 0, 0);
+
+  const rows = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('DATE(daily_data.date) = DATE(:targetDate)', { targetDate })
+    .getRawMany<{
+      siteId: number;
+      weeklyAlertLevel: number | null;
+      dailyAlertLevel: number | null;
+      satelliteTemperature: number | null;
+      degreeHeatingDays: number | null;
+    }>();
+
+  return Object.fromEntries(
+    rows.map((row) => [
+      row.siteId,
+      {
+        tempWeeklyAlert: row.weeklyAlertLevel ?? undefined,
+        tempAlert: row.dailyAlertLevel ?? undefined,
+        satelliteTemperature: row.satelliteTemperature ?? undefined,
+        dhw: row.degreeHeatingDays ?? undefined,
+      } as CollectionDataDto,
+    ]),
+  );
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Grid, Hidden, TextField, Tooltip } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -67,13 +67,14 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [selectedDate, setSelectedDate] = useState<string>('');
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(selectedDate || undefined));
+  }, [dispatch, selectedDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -105,10 +106,25 @@ function Homepage({ classes }: HomepageProps) {
     drawer.scrollTop = 0;
   });
 
+  const today = new Date().toISOString().split('T')[0];
+
   return (
     <>
       <div role="presentation" onClick={isDrawerOpen ? toggleDrawer : () => {}}>
         <HomepageNavBar searchLocation geocodingEnabled />
+      </div>
+      <div className={classes.datePicker}>
+        <Tooltip title="View historical site alert data for a past date">
+          <TextField
+            label="Historical date"
+            type="date"
+            size="small"
+            value={selectedDate}
+            inputProps={{ max: today }}
+            InputLabelProps={{ shrink: true }}
+            onChange={(e) => setSelectedDate(e.target.value)}
+          />
+        </Tooltip>
       </div>
       <div className={classes.root}>
         <Grid container>
@@ -171,6 +187,14 @@ const styles = () =>
       flexDirection: 'column',
       height: 'calc(100vh - 64px);', // subtract height of the navbar
       overflowY: 'auto',
+    },
+    datePicker: {
+      display: 'flex',
+      alignItems: 'center',
+      padding: '4px 16px',
+      backgroundColor: '#fff',
+      borderBottom: '1px solid rgba(0,0,0,0.12)',
+      zIndex: 1,
     },
   });
 

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: date ? `sites?date=${encodeURIComponent(date)}` : 'sites',
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,10 +55,12 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date, { getState }) {
       const {
         sitesList: { list },
       } = getState();
+      // Always refetch when a date is provided (historical mode)
+      if (date) return true;
       return !list;
     },
   },


### PR DESCRIPTION
Closes #1162

## Summary

- **Backend** (`GET /sites`): new optional `date` query param (YYYY-MM-DD). When provided, `sites.service.ts` queries `DailyData` for that date instead of `LatestData`, mapping `weeklyAlertLevel → tempWeeklyAlert`, `dailyAlertLevel → tempAlert`, `satelliteTemperature`, and `degreeHeatingDays → dhw`. New `getHistoricalCollectionData()` helper added to `collections.utils.ts`.
- **Frontend**: `sitesRequest` thunk now accepts an optional `date` string and bypasses the cache when set. `siteServices.getSites()` appends `?date=` when a date is given. The `HomeMap` page gains a date picker (`TextField type=date`) that re-fetches all site markers with historical alert-level colours when a past date is chosen; clearing it restores live data.

## Test plan

- [ ] `GET /sites` without `date` → existing behaviour unchanged (latestData)
- [ ] `GET /sites?date=2023-06-15` → `collectionData.tempWeeklyAlert` from `DailyData` for that date
- [ ] Invalid `date` string returns 400 from class-validator `@IsDateString()`
- [ ] Open the HomeMap, pick a past date → markers recolour to historical alert levels
- [ ] Clear the date field → markers return to current live colours
- [ ] The SofarLayers overlay remains (shows live environmental data; historical tile support is out of scope for this PR)