### PR TITLE
fix: preserve historical date in selected site header link

### DIFF
--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -128,6 +128,7 @@ const MINIMUM_SONDE_METRICS_TO_SHOW_CARD = 3;
 
 function SiteDetails({
   site,
+  historicalDate,
   selectedSurveyPointId,
   surveys,
   featuredSurveyId = null,
@@ -158,13 +159,13 @@ function SiteDetails({
     if (site && !spotterPosition) {
       dispatch(spotterPositionRequest(String(site.id)));
     }
-    if (site && !latestData) {
+    if (site && !latestData && !historicalDate) {
       dispatch(latestDataRequest(String(site.id)));
     }
     if (site && !forecastData) {
       dispatch(forecastDataRequest(String(site.id)));
     }
-  }, [dispatch, site, spotterPosition, latestData, forecastData]);
+  }, [dispatch, site, spotterPosition, latestData, forecastData, historicalDate]);
 
   useEffect(
     () => () => {
@@ -176,6 +177,22 @@ function SiteDetails({
   );
 
   useEffect(() => {
+    if (historicalDate && site?.dailyData?.[0]) {
+      const historicalDailyData = site.dailyData[0];
+      setLatestDataAsSofarValues((previous) => ({
+        ...previous,
+        satelliteTemperature: {
+          timestamp: historicalDailyData.date,
+          value: historicalDailyData.satelliteTemperature,
+        },
+        dhw: {
+          timestamp: historicalDailyData.date,
+          value: historicalDailyData.degreeHeatingDays / 7,
+        },
+      }));
+      return;
+    }
+
     if (forecastData && latestData) {
       const combinedArray = [...forecastData, ...latestData];
       const parsedData = parseLatestData(combinedArray);
@@ -281,7 +298,7 @@ function SiteDetails({
       setHasSeapHOxData(hasSeapHOx);
       setLatestDataAsSofarValues(parsedData);
     }
-  }, [forecastData, latestData, timeSeriesRange]);
+  }, [forecastData, historicalDate, latestData, site?.dailyData, timeSeriesRange]);
 
   const { videoStream } = site || {};
 
@@ -531,6 +548,7 @@ function SiteDetails({
 
 interface SiteDetailsProps {
   site?: Site;
+  historicalDate?: string;
   selectedSurveyPointId?: string;
   featuredSurveyId?: number | null;
   surveys: SurveyListItem[];

--- a/packages/website/src/common/SiteDetails/index.tsx
+++ b/packages/website/src/common/SiteDetails/index.tsx
@@ -165,7 +165,14 @@ function SiteDetails({
     if (site && !forecastData) {
       dispatch(forecastDataRequest(String(site.id)));
     }
-  }, [dispatch, site, spotterPosition, latestData, forecastData, historicalDate]);
+  }, [
+    dispatch,
+    site,
+    spotterPosition,
+    latestData,
+    forecastData,
+    historicalDate,
+  ]);
 
   useEffect(
     () => () => {
@@ -298,7 +305,13 @@ function SiteDetails({
       setHasSeapHOxData(hasSeapHOx);
       setLatestDataAsSofarValues(parsedData);
     }
-  }, [forecastData, historicalDate, latestData, site?.dailyData, timeSeriesRange]);
+  }, [
+    forecastData,
+    historicalDate,
+    latestData,
+    site?.dailyData,
+    timeSeriesRange,
+  ]);
 
   const { videoStream } = site || {};
 

--- a/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/Popup/index.tsx
@@ -32,6 +32,7 @@ function Popup({ site, classes, autoOpen = true }: PopupProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const popupRef = useRef<L.Popup>(null);
   const location = useLocation();
+  const sitePath = `/sites/${site.id}${location.search || ''}`;
   const { name, region } = getSiteNameAndRegion(site);
   const isNameLong = name?.length && name.length > maxLengths.SITE_NAME_POPUP;
 
@@ -143,7 +144,7 @@ function Popup({ site, classes, autoOpen = true }: PopupProps) {
             <Grid item>
               <Link
                 style={{ color: 'inherit', textDecoration: 'none' }}
-                to={`/sites/${site.id}`}
+                to={sitePath}
                 state={{ from: location.pathname }}
               >
                 <Button

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.test.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.test.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+
+import { mockSite } from 'mocks/mockSite';
+import { renderWithProviders } from 'utils/test-utils';
+import SelectedSiteCardContent from './CardContent';
+
+const historicalDate = '2026-05-31T23:59:59.999Z';
+
+describe('SelectedSiteCardContent', () => {
+  test('preserves the selected historical date in site links', () => {
+    renderWithProviders(
+      <SelectedSiteCardContent
+        site={mockSite}
+        loading={false}
+        historicalDate={historicalDate}
+      />,
+    );
+
+    const links = screen.getAllByRole('link');
+    const hrefs = links.map((link) => link.getAttribute('href'));
+
+    expect(hrefs).toContain(
+      `/sites/${mockSite.id}?date=${encodeURIComponent(historicalDate)}`,
+    );
+  });
+
+  test('shows historical daily metrics when a historical date is selected', () => {
+    renderWithProviders(
+      <SelectedSiteCardContent
+        site={mockSite}
+        loading={false}
+        historicalDate={historicalDate}
+      />,
+    );
+
+    expect(screen.getByText('As of:')).toBeInTheDocument();
+    expect(screen.getByText('23')).toBeInTheDocument();
+    expect(screen.getByText('4.9')).toBeInTheDocument();
+    expect(screen.getByText('38')).toBeInTheDocument();
+    expect(screen.queryByText('15.9')).not.toBeInTheDocument();
+  });
+});

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.test.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.test.tsx
@@ -1,11 +1,22 @@
 import React from 'react';
 import { screen } from '@testing-library/react';
+import configureStore from 'redux-mock-store';
 
 import { mockSite } from 'mocks/mockSite';
 import { renderWithProviders } from 'utils/test-utils';
 import SelectedSiteCardContent from './CardContent';
 
 const historicalDate = '2026-05-31T23:59:59.999Z';
+const mockStore = configureStore([]);
+const store = mockStore({
+  survey: {
+    selectedSurvey: {
+      details: null,
+    },
+  },
+});
+
+store.dispatch = vi.fn();
 
 describe('SelectedSiteCardContent', () => {
   test('preserves the selected historical date in site links', () => {
@@ -14,7 +25,9 @@ describe('SelectedSiteCardContent', () => {
         site={mockSite}
         loading={false}
         historicalDate={historicalDate}
+        imageUrl="https://example.com/site.jpg"
       />,
+      { store },
     );
 
     const links = screen.getAllByRole('link');
@@ -32,12 +45,13 @@ describe('SelectedSiteCardContent', () => {
         loading={false}
         historicalDate={historicalDate}
       />,
+      { store },
     );
 
     expect(screen.getByText('As of:')).toBeInTheDocument();
-    expect(screen.getByText('23')).toBeInTheDocument();
+    expect(screen.getByText('23.0')).toBeInTheDocument();
     expect(screen.getByText('4.9')).toBeInTheDocument();
-    expect(screen.getByText('38')).toBeInTheDocument();
+    expect(screen.getByText('38.0')).toBeInTheDocument();
     expect(screen.queryByText('15.9')).not.toBeInTheDocument();
   });
 });

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -15,13 +15,16 @@ import makeStyles from '@mui/styles/makeStyles';
 import { isNumber } from 'lodash';
 import { Link, useLocation } from 'react-router-dom';
 import classNames from 'classnames';
+import { DateTime } from 'luxon-extensions';
 
 import { Site } from 'store/Sites/types';
 import { getSiteNameAndRegion } from 'store/Sites/helpers';
+import { degreeHeatingWeeksCalculator } from 'helpers/degreeHeatingWeeks';
 import { formatNumber } from 'helpers/numberUtils';
 import Chart from 'common/Chart';
 import { standardDailyDataDataset } from 'common/Chart/MultipleSensorsCharts/helpers';
 import Chip from 'common/Chip';
+import DatePicker from 'common/Datepicker';
 import LoadingSkeleton from 'common/LoadingSkeleton';
 import { GaAction, GaCategory, trackButtonClick } from 'utils/google-analytics';
 import featuredImageLoading from '../../../../assets/img/loading-image.svg';
@@ -112,17 +115,28 @@ function SelectedSiteCardContent({
   site,
   loading,
   error,
+  historicalDate,
+  onHistoricalDateChange,
   imageUrl = null,
 }: SelectedSiteCardContentProps) {
   const classes = useStyles({ imageUrl, loading });
   const theme = useTheme();
   const location = useLocation();
   const isTablet = useMediaQuery(theme.breakpoints.down('md'));
+  const historicalDailyData = historicalDate ? site?.dailyData?.[0] : undefined;
   const {
-    bottomTemperature,
-    satelliteTemperature,
-    dhw: degreeHeatingWeek,
+    bottomTemperature: latestBottomTemperature,
+    satelliteTemperature: latestSatelliteTemperature,
+    dhw: latestDegreeHeatingWeek,
   } = site?.collectionData || {};
+  const bottomTemperature =
+    historicalDailyData?.avgBottomTemperature ?? latestBottomTemperature;
+  const satelliteTemperature =
+    historicalDailyData?.satelliteTemperature ?? latestSatelliteTemperature;
+  const degreeHeatingWeek =
+    historicalDailyData
+      ? degreeHeatingWeeksCalculator(historicalDailyData.degreeHeatingDays)
+      : latestDegreeHeatingWeek;
   const useCardWithImageLayout = Boolean(loading || imageUrl);
 
   const metrics = [
@@ -181,6 +195,24 @@ function SelectedSiteCardContent({
     );
   };
 
+  const handleHistoricalDateChange = (date: Date | null) => {
+    if (!onHistoricalDateChange) return;
+    onHistoricalDateChange(
+      date
+        ? DateTime.fromJSDate(date)
+            .setZone(site?.timezone || 'UTC')
+            .endOf('day')
+            .toISOString()
+        : undefined,
+    );
+  };
+
+  const sitePath = site
+    ? `/sites/${site.id}${
+        historicalDate ? `?date=${encodeURIComponent(historicalDate)}` : ''
+      }`
+    : '#';
+
   if (error) {
     return <Alert severity="error">{error}</Alert>;
   }
@@ -207,10 +239,7 @@ function SelectedSiteCardContent({
               height="100%"
             >
               {site && imageUrl && (
-                <Link
-                  to={`/sites/${site.id}`}
-                  state={{ from: location.pathname }}
-                >
+                <Link to={sitePath} state={{ from: location.pathname }}>
                   <CardMedia
                     className={classNames(
                       classes.cardImage,
@@ -259,7 +288,7 @@ function SelectedSiteCardContent({
                       <Chip
                         live
                         liveText="LIVE VIDEO"
-                        to={`/sites/${site.id}`}
+                        to={sitePath}
                         state={{ from: location.pathname }}
                         width={80}
                       />
@@ -268,7 +297,7 @@ function SelectedSiteCardContent({
                       <Button
                         className={classes.exploreButton}
                         component={Link}
-                        to={`/sites/${site.id}`}
+                        to={sitePath}
                         state={{ from: location.pathname }}
                         onClick={onExploreButtonClick}
                         size="small"
@@ -293,6 +322,20 @@ function SelectedSiteCardContent({
         className={classes.cardAnalyticsWrapper}
       >
         <Box pb="0.5rem" pl="0.5rem" pt="1.5rem" fontWeight={400}>
+          <Box display="flex" justifyContent="flex-end" pr="0.5rem">
+            <DatePicker
+              value={
+                historicalDate ||
+                DateTime.now()
+                  .setZone(site?.timezone || 'UTC')
+                  .endOf('day')
+                  .toISOString()
+              }
+              dateName="As of"
+              timeZone={site?.timezone}
+              onChange={handleHistoricalDateChange}
+            />
+          </Box>
           <Hidden mdDown={useCardWithImageLayout}>
             <LoadingSkeleton
               loading={loading}
@@ -315,7 +358,7 @@ function SelectedSiteCardContent({
                   <Chip
                     live
                     liveText="LIVE VIDEO"
-                    to={`/sites/${site.id}`}
+                    to={sitePath}
                     state={{ from: location.pathname }}
                     width={80}
                   />
@@ -421,6 +464,10 @@ interface SelectedSiteCardContentProps {
   site?: Site | null;
   loading: boolean;
   error?: string | null;
+  historicalDate?: string;
+  onHistoricalDateChange?: React.Dispatch<
+    React.SetStateAction<string | undefined>
+  >;
   imageUrl?: string | null;
 }
 

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/CardContent.tsx
@@ -133,10 +133,9 @@ function SelectedSiteCardContent({
     historicalDailyData?.avgBottomTemperature ?? latestBottomTemperature;
   const satelliteTemperature =
     historicalDailyData?.satelliteTemperature ?? latestSatelliteTemperature;
-  const degreeHeatingWeek =
-    historicalDailyData
-      ? degreeHeatingWeeksCalculator(historicalDailyData.degreeHeatingDays)
-      : latestDegreeHeatingWeek;
+  const degreeHeatingWeek = historicalDailyData
+    ? degreeHeatingWeeksCalculator(historicalDailyData.degreeHeatingDays)
+    : latestDegreeHeatingWeek;
   const useCardWithImageLayout = Boolean(loading || imageUrl);
 
   const metrics = [

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/__snapshots__/index.test.tsx.snap
@@ -44,6 +44,40 @@ exports[`renders as expected 1`] = `
             pl="0.5rem"
             pt="1.5rem"
           >
+            <mock-box
+              display="flex"
+              justifycontent="flex-end"
+              pr="0.5rem"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
+              >
+                <mock-box
+                  alignitems="flex-end"
+                  display="flex"
+                >
+                  <mock-typography
+                    color="textSecondary"
+                    variant="h6"
+                  >
+                    As of:
+                  </mock-typography>
+                  <div
+                    class="DatePicker-datePicker-22"
+                  >
+                    <mock-date-picker
+                      classname="DatePicker-textField-23"
+                      closeonselect="true"
+                      format="MM/dd/yyyy"
+                      maxdate="Sat Jun 20 2026 05:59:11 GMT+0000 (Coordinated Universal Time)"
+                      mindate="Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                      slotprops="[object Object]"
+                      value="Sat Jun 20 2026 23:59:59 GMT+0000 (Coordinated Universal Time)"
+                    />
+                  </div>
+                </mock-box>
+              </div>
+            </mock-box>
             <mock-hidden
               mddown="false"
             >
@@ -188,7 +222,7 @@ exports[`renders as expected 1`] = `
 exports[`renders loading as expected 1`] = `
 <div>
   <mock-box
-    classname="makeStyles-card-44"
+    classname="makeStyles-card-46"
   >
     <mock-box
       mb="2"
@@ -204,7 +238,7 @@ exports[`renders loading as expected 1`] = `
         >
           <svg
             aria-hidden="true"
-            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-launchIcon-45 css-1umw9bq-MuiSvgIcon-root"
+            class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium makeStyles-launchIcon-47 css-1umw9bq-MuiSvgIcon-root"
             data-testid="LaunchIcon"
             focusable="false"
             viewBox="0 0 24 24"
@@ -218,10 +252,10 @@ exports[`renders loading as expected 1`] = `
     </mock-box>
     <mock-card>
       <div
-        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 makeStyles-cardWrapper-52 makeStyles-cardWrapper-64 css-1h90obp-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 makeStyles-cardWrapper-54 makeStyles-cardWrapper-66 css-1h90obp-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-12 MuiGrid-grid-lg-10 makeStyles-cardAnalyticsWrapper-56 css-1nyv9pn-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-12 MuiGrid-grid-lg-10 makeStyles-cardAnalyticsWrapper-58 css-1nyv9pn-MuiGrid-root"
         >
           <mock-box
             fontweight="400"
@@ -229,6 +263,40 @@ exports[`renders loading as expected 1`] = `
             pl="0.5rem"
             pt="1.5rem"
           >
+            <mock-box
+              display="flex"
+              justifycontent="flex-end"
+              pr="0.5rem"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
+              >
+                <mock-box
+                  alignitems="flex-end"
+                  display="flex"
+                >
+                  <mock-typography
+                    color="textSecondary"
+                    variant="h6"
+                  >
+                    As of:
+                  </mock-typography>
+                  <div
+                    class="DatePicker-datePicker-67"
+                  >
+                    <mock-date-picker
+                      classname="DatePicker-textField-68"
+                      closeonselect="true"
+                      format="MM/dd/yyyy"
+                      maxdate="Sat Jun 20 2026 05:59:11 GMT+0000 (Coordinated Universal Time)"
+                      mindate="Thu Jan 01 1970 00:00:00 GMT+0000 (Coordinated Universal Time)"
+                      slotprops="[object Object]"
+                      value="Sat Jun 20 2026 23:59:59 GMT+0000 (Coordinated Universal Time)"
+                    />
+                  </div>
+                </mock-box>
+              </div>
+            </mock-box>
             <mock-hidden
               mddown="false"
             >
@@ -236,10 +304,10 @@ exports[`renders loading as expected 1`] = `
                 class="MuiGrid-root MuiGrid-container css-1rp4aer-MuiGrid-root"
               >
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-cardTitleWrapper-57 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-cardTitleWrapper-59 css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-cardTitle-58"
+                    classname="makeStyles-cardTitle-60"
                     color="textSecondary"
                     variant="h5"
                   >
@@ -252,7 +320,7 @@ exports[`renders loading as expected 1`] = `
                 </div>
               </div>
               <mock-typography
-                classname="makeStyles-cardTitle-58 makeStyles-siteRegionName-59"
+                classname="makeStyles-cardTitle-60 makeStyles-siteRegionName-61"
                 color="textSecondary"
                 variant="h6"
               >
@@ -291,10 +359,10 @@ exports[`renders loading as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-2 css-15vsh4j-MuiGrid-root"
         >
           <div
-            class="makeStyles-metricsContainer-60"
+            class="makeStyles-metricsContainer-62"
           >
             <div
-              class="makeStyles-metric-61"
+              class="makeStyles-metric-63"
             >
               <mock-typography
                 color="textSecondary"
@@ -317,7 +385,7 @@ exports[`renders loading as expected 1`] = `
               </mock-typography>
             </div>
             <div
-              class="makeStyles-metric-61"
+              class="makeStyles-metric-63"
             >
               <mock-typography
                 color="textSecondary"
@@ -340,7 +408,7 @@ exports[`renders loading as expected 1`] = `
               </mock-typography>
             </div>
             <div
-              class="makeStyles-metric-61"
+              class="makeStyles-metric-63"
             >
               <mock-typography
                 color="textSecondary"

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 
 import { useSelector } from 'react-redux';
 import makeStyles from '@mui/styles/makeStyles';
+import { DateTime } from 'luxon-extensions';
 
 import {
   siteDetailsSelector,
@@ -13,6 +14,7 @@ import {
 } from 'store/Sites/selectedSiteSlice';
 import { surveyListSelector } from 'store/Survey/surveyListSlice';
 import { sortByDate } from 'helpers/dates';
+import { useQueryParam } from 'hooks/useQueryParams';
 import LoadingSkeleton from 'common/LoadingSkeleton';
 import SelectedSiteCardContent from './CardContent';
 
@@ -41,6 +43,9 @@ function SelectedSiteCard() {
   const loading = useSelector(siteLoadingSelector);
   const error = useSelector(siteErrorSelector);
   const surveyList = useSelector(surveyListSelector);
+  const [historicalDate, setHistoricalDate] = useQueryParam('date', (value) =>
+    DateTime.fromISO(value).isValid,
+  );
 
   const isFeatured = (site?.id || '').toString() === featuredSiteId;
 
@@ -85,6 +90,8 @@ function SelectedSiteCard() {
           site={site}
           loading={loading}
           error={error}
+          historicalDate={historicalDate}
+          onHistoricalDateChange={setHistoricalDate}
           imageUrl={
             featuredSurveyMedia?.thumbnailUrl || featuredSurveyMedia?.url
           }

--- a/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
+++ b/packages/website/src/routes/HomeMap/SiteTable/SelectedSiteCard/index.tsx
@@ -43,8 +43,9 @@ function SelectedSiteCard() {
   const loading = useSelector(siteLoadingSelector);
   const error = useSelector(siteErrorSelector);
   const surveyList = useSelector(surveyListSelector);
-  const [historicalDate, setHistoricalDate] = useQueryParam('date', (value) =>
-    DateTime.fromISO(value).isValid,
+  const [historicalDate, setHistoricalDate] = useQueryParam(
+    'date',
+    (value) => DateTime.fromISO(value).isValid,
   );
 
   const isFeatured = (site?.id || '').toString() === featuredSiteId;
@@ -57,6 +58,11 @@ function SelectedSiteCard() {
     ) || {};
 
   const hasMedia = Boolean(featuredSurveyMedia?.url);
+  const sitePath = site
+    ? `/sites/${site.id}${
+        historicalDate ? `?date=${encodeURIComponent(historicalDate)}` : ''
+      }`
+    : '#';
 
   // If FEATURED_SITE is not setup, no card is displayed.
   if (featuredSiteId === '' && isFeatured) {
@@ -76,7 +82,7 @@ function SelectedSiteCard() {
             <Typography variant="h5" color="textSecondary">
               {isFeatured ? 'Featured Site' : 'Selected Site'}
               {!hasMedia && (
-                <Link to={`/sites/${site?.id}`}>
+                <Link to={sitePath}>
                   <LaunchIcon className={classes.launchIcon} />
                 </Link>
               )}

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -14,6 +14,8 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
+import { DateTime } from 'luxon-extensions';
+import { useQueryParam } from 'hooks/useQueryParams';
 import HomepageNavBar from 'common/NavBar';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
@@ -67,6 +69,9 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [historicalDate] = useQueryParam('date', (value) =>
+    DateTime.fromISO(value).isValid,
+  );
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
@@ -77,13 +82,15 @@ function Homepage({ classes }: HomepageProps) {
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
-      dispatch(siteRequest(initialSiteId));
+      dispatch(siteRequest({ id: initialSiteId, endDate: historicalDate }));
       dispatch(surveysRequest(initialSiteId));
     } else if (siteOnMap) {
-      dispatch(siteRequest(`${siteOnMap.id}`));
+      dispatch(
+        siteRequest({ id: `${siteOnMap.id}`, endDate: historicalDate }),
+      );
       dispatch(surveysRequest(`${siteOnMap.id}`));
     }
-  }, [dispatch, initialSiteId, siteOnMap]);
+  }, [dispatch, historicalDate, initialSiteId, siteOnMap]);
 
   const [isDrawerOpen, setDrawerOpen] = useState(false);
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -69,8 +69,9 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
-  const [historicalDate] = useQueryParam('date', (value) =>
-    DateTime.fromISO(value).isValid,
+  const [historicalDate] = useQueryParam(
+    'date',
+    (value) => DateTime.fromISO(value).isValid,
   );
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
@@ -85,9 +86,7 @@ function Homepage({ classes }: HomepageProps) {
       dispatch(siteRequest({ id: initialSiteId, endDate: historicalDate }));
       dispatch(surveysRequest(initialSiteId));
     } else if (siteOnMap) {
-      dispatch(
-        siteRequest({ id: `${siteOnMap.id}`, endDate: historicalDate }),
-      );
+      dispatch(siteRequest({ id: `${siteOnMap.id}`, endDate: historicalDate }));
       dispatch(surveysRequest(`${siteOnMap.id}`));
     }
   }, [dispatch, historicalDate, initialSiteId, siteOnMap]);

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -121,6 +121,9 @@ function Site({ classes }: SiteProps) {
   const { id: siteId = '' } = useParams<{ id: string }>();
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
   const [querySurveyPointId] = useQueryParam('surveyPoint');
+  const [historicalDate] = useQueryParam('date', (value) =>
+    DateTime.fromISO(value).isValid,
+  );
   const [refresh, setRefresh] = useQueryParam('refresh');
   const { id: selectedSurveyPointId } =
     findSurveyPointFromList(querySurveyPointId, surveyPoints) || {};
@@ -145,7 +148,7 @@ function Site({ classes }: SiteProps) {
 
   const hasDailyData = Boolean(dailyData && dailyData.length > 0);
 
-  const today = localizedEndOfDay(undefined, timezone);
+  const today = localizedEndOfDay(historicalDate, timezone);
 
   const siteWithFeaturedImage: SiteType | undefined =
     siteDetails && (siteId === siteDetails.id.toString() || !siteId)
@@ -162,7 +165,7 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
 
-      dispatch(siteRequest(siteId));
+      dispatch(siteRequest({ id: siteId, endDate: historicalDate }));
       dispatch(spotterPositionRequest(siteId));
       dispatch(surveysRequest(siteId));
     }
@@ -171,7 +174,7 @@ function Site({ classes }: SiteProps) {
 
   // Fetch site and surveys
   useEffect(() => {
-    dispatch(siteRequest(siteId));
+    dispatch(siteRequest({ id: siteId, endDate: historicalDate }));
     dispatch(spotterPositionRequest(siteId));
     dispatch(surveysRequest(siteId));
 
@@ -180,7 +183,7 @@ function Site({ classes }: SiteProps) {
       dispatch(clearTimeSeriesData());
       dispatch(clearOceanSenseData());
     };
-  }, [dispatch, siteId]);
+  }, [dispatch, historicalDate, siteId]);
 
   // Fetch reef check surveys
   useEffect(() => {
@@ -247,6 +250,7 @@ function Site({ classes }: SiteProps) {
           <div key={siteId}>
             <SiteDetails
               site={siteWithFeaturedImage}
+              historicalDate={historicalDate}
               selectedSurveyPointId={selectedSurveyPointId}
               featuredSurveyId={featuredSurveyId}
               surveys={surveyList}

--- a/packages/website/src/routes/SiteRoutes/Site/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/Site/index.tsx
@@ -121,8 +121,9 @@ function Site({ classes }: SiteProps) {
   const { id: siteId = '' } = useParams<{ id: string }>();
   const { id, dailyData, surveyPoints, timezone } = siteDetails || {};
   const [querySurveyPointId] = useQueryParam('surveyPoint');
-  const [historicalDate] = useQueryParam('date', (value) =>
-    DateTime.fromISO(value).isValid,
+  const [historicalDate] = useQueryParam(
+    'date',
+    (value) => DateTime.fromISO(value).isValid,
   );
   const [refresh, setRefresh] = useQueryParam('refresh');
   const { id: selectedSurveyPointId } =

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -33,11 +33,17 @@ const getSite = (id: string) =>
     method: 'GET',
   });
 
+const buildDailyDataQuery = (start?: string, end?: string) => {
+  const params = new URLSearchParams();
+  if (start) params.set('start', start);
+  if (end) params.set('end', end);
+  const query = params.toString();
+  return query ? `?${query}` : '';
+};
+
 const getSiteDailyData = (id: string, start?: string, end?: string) =>
   requests.send<DailyData[]>({
-    url: `sites/${id}/daily_data${
-      start && end ? `?end=${end}&start=${start}` : ''
-    }`,
+    url: `sites/${id}/daily_data${buildDailyDataQuery(start, end)}`,
     method: 'GET',
   });
 

--- a/packages/website/src/setupTests.tsx
+++ b/packages/website/src/setupTests.tsx
@@ -14,6 +14,9 @@ Object.defineProperties(globalThis, {
   ReadableStream: { value: ReadableStream },
 });
 
+vi.useFakeTimers();
+vi.setSystemTime(new Date('2026-06-20T05:59:11.000Z'));
+
 vi.mock('@mui/icons-material', () => ({
   ArrowBack: 'mock-ArrowBack',
   Build: 'mock-Build',

--- a/packages/website/src/store/Sites/selectedSiteSlice.ts
+++ b/packages/website/src/store/Sites/selectedSiteSlice.ts
@@ -22,6 +22,13 @@ import {
   timeSeriesRequest,
 } from './helpers';
 
+type SiteRequestArg = string | { id: string; endDate?: string };
+
+const normalizeSiteRequestArg = (
+  arg: SiteRequestArg,
+): { id: string; endDate?: string } =>
+  typeof arg === 'string' ? { id: arg } : arg;
+
 const selectedSiteInitialState: SelectedSiteState = {
   draft: null,
   loading: true,
@@ -90,14 +97,19 @@ export const latestDataRequest = createAsyncThunk<
 
 export const siteRequest = createAsyncThunk<
   SelectedSiteState['details'],
-  string,
+  SiteRequestArg,
   CreateAsyncThunkTypes
 >(
   'selectedSite/request',
-  async (id: string, { rejectWithValue }) => {
+  async (arg, { rejectWithValue }) => {
+    const { id, endDate } = normalizeSiteRequestArg(arg);
     try {
       const { data } = await siteServices.getSite(id);
-      const { data: dailyData } = await siteServices.getSiteDailyData(id);
+      const { data: dailyData } = await siteServices.getSiteDailyData(
+        id,
+        undefined,
+        endDate,
+      );
       const { data: surveyPoints } = await siteServices.getSiteSurveyPoints(id);
 
       return {
@@ -123,11 +135,12 @@ export const siteRequest = createAsyncThunk<
     }
   },
   {
-    condition(id: string, { getState }) {
+    condition(arg, { getState }) {
+      const { id, endDate } = normalizeSiteRequestArg(arg);
       const {
         selectedSite: { details },
       } = getState();
-      return `${details?.id}` !== id;
+      return `${details?.id}` !== id || Boolean(endDate);
     },
   },
 );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,11 +1078,6 @@
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.10.8.tgz#1be0c81dc58cf81481a6fedbf7927962caba725e"
   integrity sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==
-  dependencies:
-    "@firebase/component" "0.6.18"
-    "@firebase/logger" "0.4.4"
-    "@firebase/util" "1.12.1"
-    tslib "^2.1.0"
 
 "@firebase/component@0.6.18":
   version "0.6.18"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1078,6 +1078,11 @@
   version "1.10.8"
   resolved "https://registry.yarnpkg.com/@firebase/auth/-/auth-1.10.8.tgz#1be0c81dc58cf81481a6fedbf7927962caba725e"
   integrity sha512-GpuTz5ap8zumr/ocnPY57ZanX02COsXloY6Y/2LYPAuXYiaJRf6BAGDEdRq1BMjP93kqQnKNuKZUTMZbQ8MNYA==
+  dependencies:
+    "@firebase/component" "0.6.18"
+    "@firebase/logger" "0.4.4"
+    "@firebase/util" "1.12.1"
+    tslib "^2.1.0"
 
 "@firebase/component@0.6.18":
   version "0.6.18"


### PR DESCRIPTION
## Summary
- support `date` query params when fetching selected site daily data
- preserve historical `date` through map selected-site links and popup `EXPLORE` links
- make site-page historical views use the historical daily row for summary metrics
- add coverage for historical selected-site card link/metric behavior

## Verification
- ran `npm run build` in `packages/website` under Node 20
- verified locally in browser that `/map?date=...` updates selected-site historical metrics
- verified popup `EXPLORE` preserves `date` into `/sites/:id`
- verified `/sites/:id?date=...` shows historical summary values instead of current ones

Updated to preserve the historical date query parameter on the selected-site header launch link as well.

Validation:
- ESLint passes on the changed website files with --max-warnings 0
- YARN_IGNORE_ENGINES=1 yarn.cmd workspace website test CardContent.test.tsx