### PR TITLE
Add historical date support to home map

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsISO8601,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,12 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({
+    example: '2021-05-18T08:45:35.780Z',
+    required: false,
+  })
+  @IsOptional()
+  @IsISO8601()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.controller.ts
+++ b/packages/api/src/sites/sites.controller.ts
@@ -62,6 +62,11 @@ export class SitesController {
   }
 
   @ApiOperation({ summary: 'Returns sites filtered by provided filters' })
+  @ApiQuery({
+    name: 'date',
+    required: false,
+    example: '2021-05-18T08:45:35.780Z',
+  })
   @Public()
   @Get()
   find(@Query() filterSiteDto: FilterSiteDto): Promise<Site[]> {

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -198,9 +198,21 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
+    const collectionDataDate = filter.date
+      ? DateTime.fromISO(filter.date).endOf('day')
+      : undefined;
+
+    if (collectionDataDate && !collectionDataDate.isValid) {
+      throw new BadRequestException('Date is not a valid date');
+    }
+
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      {
+        dailyDataRepository: this.dailyDataRepository,
+        date: collectionDataDate?.toJSDate(),
+      },
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -101,9 +101,11 @@ export const siteTests = () => {
 
   it('GET / find all sites for a historical date', async () => {
     const historicalData = californiaDailyData[0];
-    const rsp = await request(app.getHttpServer()).get('/sites').query({
-      date: historicalData.date as string,
-    });
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({
+        date: historicalData.date as string,
+      });
 
     const site = rsp.body.find(
       ({ id }: { id: number }) => id === californiaSite.id,

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,25 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / find all sites for a historical date', async () => {
+    const historicalData = californiaDailyData[0];
+    const rsp = await request(app.getHttpServer()).get('/sites').query({
+      date: historicalData.date as string,
+    });
+
+    const site = rsp.body.find(
+      ({ id }: { id: number }) => id === californiaSite.id,
+    );
+
+    expect(rsp.status).toBe(200);
+    expect(site.collectionData).toMatchObject({
+      satelliteTemperature: historicalData.satelliteTemperature,
+      dhw: (historicalData.degreeHeatingDays as number) / 7,
+      tempAlert: historicalData.dailyAlertLevel,
+      tempWeeklyAlert: historicalData.dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -1,19 +1,82 @@
-import _, { camelCase } from 'lodash';
+import _, { camelCase, isNil, omitBy } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
+interface DailyCollectionData {
+  siteId: number;
+  satelliteTemperature: number | null;
+  degreeHeatingDays: number | null;
+  dailyAlertLevel: number | null;
+  weeklyAlertLevel: number | null;
+}
+
+const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .distinctOn(['daily_data.site_id'])
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany<DailyCollectionData>();
+
+  return dailyData.reduce<Record<number, CollectionDataDto>>(
+    (acc, siteData) => ({
+      ...acc,
+      [siteData.siteId]: omitBy(
+        {
+          satelliteTemperature: siteData.satelliteTemperature,
+          dhw:
+            siteData.degreeHeatingDays === null
+              ? undefined
+              : siteData.degreeHeatingDays / 7,
+          tempAlert: siteData.dailyAlertLevel,
+          tempWeeklyAlert:
+            siteData.weeklyAlertLevel ?? siteData.dailyAlertLevel,
+        },
+        isNil,
+      ) as CollectionDataDto,
+    }),
+    {},
+  );
+};
+
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  options?: {
+    dailyDataRepository?: Repository<DailyData>;
+    date?: Date;
+  },
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
   if (!siteIds.length) {
     return {};
+  }
+
+  if (options?.date && options.dailyDataRepository) {
+    return getHistoricalCollectionData(
+      sites,
+      options.dailyDataRepository,
+      options.date,
+    );
   }
 
   // Get latest data

--- a/packages/website/src/common/NavBar/index.tsx
+++ b/packages/website/src/common/NavBar/index.tsx
@@ -56,6 +56,7 @@ function NavBar({
   geocodingEnabled = false,
   routeButtons = false,
   loading = false,
+  sitesRequestDate,
   classes,
 }: NavBarProps) {
   const user = useSelector(userInfoSelector);
@@ -179,7 +180,10 @@ function NavBar({
             {searchLocation && (
               <Hidden smDown>
                 <Grid item sm={4} md={3}>
-                  <Search geocodingEnabled={geocodingEnabled} />
+                  <Search
+                    geocodingEnabled={geocodingEnabled}
+                    sitesRequestDate={sitesRequestDate}
+                  />
                 </Grid>
               </Hidden>
             )}
@@ -336,7 +340,10 @@ function NavBar({
             {searchLocation && (
               <Hidden smUp>
                 <Grid item xs={12} style={{ margin: 0, paddingTop: 0 }}>
-                  <Search geocodingEnabled={geocodingEnabled} />
+                  <Search
+                    geocodingEnabled={geocodingEnabled}
+                    sitesRequestDate={sitesRequestDate}
+                  />
                 </Grid>
               </Hidden>
             )}
@@ -431,6 +438,7 @@ interface NavBarIncomingProps {
   geocodingEnabled?: boolean;
   routeButtons?: boolean;
   loading?: boolean;
+  sitesRequestDate?: string;
 }
 
 type NavBarProps = NavBarIncomingProps & WithStyles<typeof styles>;

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -29,7 +29,11 @@ const siteAugmentedName = (site: Site) => {
   return name || region || '';
 };
 
-function Search({ geocodingEnabled = false, classes }: SearchProps) {
+function Search({
+  geocodingEnabled = false,
+  sitesRequestDate,
+  classes,
+}: SearchProps) {
   const navigate = useNavigate();
   const { id = '' } = useParams<{ id: string }>();
   const [searchedSite, setSearchedSite] = useState<Site | null>(null);
@@ -47,8 +51,8 @@ function Search({ geocodingEnabled = false, classes }: SearchProps) {
 
   // Fetch sites for the search bar
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(sitesRequestDate));
+  }, [dispatch, sitesRequestDate]);
 
   const onChangeSearchText = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,
@@ -205,6 +209,7 @@ const styles = () =>
 
 interface SearchIncomingProps {
   geocodingEnabled?: boolean;
+  sitesRequestDate?: string;
 }
 
 type SearchProps = SearchIncomingProps & WithStyles<typeof styles>;

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,6 +19,9 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
+        <div
+          class="MuiBox-root css-0 Homepage-dateControl-3"
+        />
         <mock-map
           initialcenter="LatLng(0, 121.3)"
           initialzoom="4"
@@ -29,7 +32,7 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
         mddown="true"
       >
         <div
-          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-3 css-1k7sk4d-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item MuiGrid-grid-md-6 Homepage-siteTable-4 css-1k7sk4d-MuiGrid-root"
         >
           <mock-sitetable />
         </div>

--- a/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/HomeMap/__snapshots__/index.test.tsx.snap
@@ -19,8 +19,8 @@ exports[`Homepage > should render with given state from Redux store 1`] = `
       <div
         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 Homepage-map-2 css-1fyyp8j-MuiGrid-root"
       >
-        <div
-          class="MuiBox-root css-0 Homepage-dateControl-3"
+        <mock-box
+          classname="Homepage-dateControl-3"
         />
         <mock-map
           initialcenter="LatLng(0, 121.3)"

--- a/packages/website/src/routes/HomeMap/index.test.tsx
+++ b/packages/website/src/routes/HomeMap/index.test.tsx
@@ -9,6 +9,7 @@ import { mockSite } from 'mocks/mockSite';
 import Homepage from '.';
 
 vi.mock('common/NavBar', () => ({ default: 'Mock-NavBar' }));
+vi.mock('common/Datepicker', () => ({ default: () => null }));
 vi.mock('./Map', () => ({ default: 'Mock-Map' }));
 vi.mock('./SiteTable', () => ({ default: 'Mock-SiteTable' }));
 

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,8 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import isISODate from 'validator/lib/isISO8601';
+import { Box, Button, Grid, Hidden } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -14,11 +15,14 @@ import { siteOnMapSelector } from 'store/Homepage/homepageSlice';
 
 import { surveysRequest } from 'store/Survey/surveyListSlice';
 import { findSiteById } from 'helpers/siteUtils';
+import DatePicker from 'common/Datepicker';
+import { useQueryParam } from 'hooks/useQueryParams';
 import HomepageNavBar from 'common/NavBar';
 import SiteTable from './SiteTable';
 import HomepageMap from './Map';
 
 enum QueryParamKeys {
+  DATE = 'date',
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
 }
@@ -67,13 +71,34 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [mapDate, setMapDate] = useQueryParam(QueryParamKeys.DATE, isISODate);
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
+  const mapDateValue = mapDate || new Date().toISOString();
+
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(mapDate));
+  }, [dispatch, mapDate]);
+
+  const handleMapDateChange = (date: Date | null) => {
+    if (!date || Number.isNaN(date.getTime())) {
+      return;
+    }
+
+    setMapDate(
+      new Date(
+        date.getFullYear(),
+        date.getMonth(),
+        date.getDate(),
+        23,
+        59,
+        59,
+        999,
+      ).toISOString(),
+    );
+  };
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -108,7 +133,11 @@ function Homepage({ classes }: HomepageProps) {
   return (
     <>
       <div role="presentation" onClick={isDrawerOpen ? toggleDrawer : () => {}}>
-        <HomepageNavBar searchLocation geocodingEnabled />
+        <HomepageNavBar
+          searchLocation
+          geocodingEnabled
+          sitesRequestDate={mapDate}
+        />
       </div>
       <div className={classes.root}>
         <Grid container>
@@ -118,6 +147,28 @@ function Homepage({ classes }: HomepageProps) {
             xs={12}
             md={showSiteTable ? 6 : 12}
           >
+            <Box
+              className={classes.dateControl}
+              onClick={(event) => event.stopPropagation()}
+            >
+              <DatePicker
+                value={mapDateValue}
+                dateName="Map date"
+                dateNameTextVariant="body2"
+                timeZone="UTC"
+                onChange={handleMapDateChange}
+              />
+              {mapDate && (
+                <Button
+                  color="primary"
+                  size="small"
+                  variant="contained"
+                  onClick={() => setMapDate(undefined)}
+                >
+                  Today
+                </Button>
+              )}
+            </Box>
             <HomepageMap
               onMapLoad={setMapInstance}
               setShowSiteTable={setShowSiteTable}
@@ -164,7 +215,21 @@ const styles = () =>
     },
     map: {
       display: 'flex',
+      position: 'relative',
       zIndex: 0,
+    },
+    dateControl: {
+      alignItems: 'center',
+      backgroundColor: '#fff',
+      border: '2px solid rgba(0, 0, 0, 0.2)',
+      borderRadius: 5,
+      display: 'flex',
+      gap: 8,
+      left: 10,
+      padding: '8px 10px',
+      position: 'absolute',
+      top: 10,
+      zIndex: 1000,
     },
     siteTable: {
       display: 'flex',

--- a/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
@@ -15,7 +15,7 @@ function SitesList({ classes }: SitesListProps) {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(sitesRequest());
+    dispatch(sitesRequest(undefined));
   }, [dispatch]);
 
   return (

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,10 +83,11 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
     url: 'sites',
     method: 'GET',
+    params: { date },
   });
 
 const getSiteSurveyPoints = (

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +49,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        dataDate: date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date: string | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, dataDate },
       } = getState();
-      return !list;
+      return !list || dataDate !== date;
     },
   },
 );
@@ -107,6 +108,7 @@ const sitesListSlice = createSlice({
       sitesRequest.fulfilled,
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
+        dataDate: action.payload.dataDate,
         list: action.payload.list,
         loading: false,
       }),

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  dataDate?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  dataDate?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
Closes #1162.

## Summary
- Add an optional `date` query parameter to `GET /sites`.
- Use the nearest daily satellite record on or before the selected date to populate map/table `collectionData`.
- Add a shareable `?date=` date picker to the home map and keep navbar search requests aligned with the selected map date.
- Add API regression coverage for historical site collection data.

## Validation
- `git diff --check HEAD~1 HEAD`

I also attempted a full dependency install with the repository's required Node 20/Yarn 1.22.21 runtime, but the install could not complete because package fetching repeatedly hit network reachability/timeouts in my local environment.