### PR TITLE
Add historical date support for map site data

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,9 +5,10 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsDateString,
 } from 'class-validator';
 import { Type } from 'class-transformer';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 import { SiteStatus } from '../sites.entity';
 
 export class FilterSiteDto {
@@ -37,4 +38,9 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiPropertyOptional({ example: '2024-04-01T00:00:00.000Z' })
+  @IsOptional()
+  @IsDateString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -201,6 +201,8 @@ export class SitesService {
     const mappedSiteData = await getCollectionData(
       res,
       this.latestDataRepository,
+      this.dailyDataRepository,
+      filter.date ? new Date(filter.date) : undefined,
     );
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -101,17 +101,15 @@ export const siteTests = () => {
   });
 
   it('GET / find all sites with historical collection data', async () => {
-    await dataSource.getRepository(DailyData).save({
-      date: new Date('2020-01-01T00:00:00.000Z'),
-      degreeHeatingDays: 12.5,
-      satelliteTemperature: 29.1,
-      dailyAlertLevel: 2,
-      weeklyAlertLevel: 4,
-      site: { id: californiaSite.id },
+    const historicalData = await dataSource.getRepository(DailyData).findOne({
+      where: { site: { id: californiaSite.id } },
+      order: { date: 'DESC' },
     });
 
+    expect(historicalData).toBeDefined();
+
     const rsp = await request(app.getHttpServer()).get('/sites').query({
-      date: '2020-01-02T00:00:00.000Z',
+      date: historicalData!.date.toISOString(),
     });
 
     expect(rsp.status).toBe(200);
@@ -119,10 +117,9 @@ export const siteTests = () => {
       (site: { id: number }) => site.id === californiaSite.id,
     );
     expect(california.collectionData).toMatchObject({
-      dhw: 12.5,
-      satelliteTemperature: 29.1,
-      tempAlert: 2,
-      tempWeeklyAlert: 4,
+      dhw: historicalData!.degreeHeatingDays,
+      satelliteTemperature: historicalData!.satelliteTemperature,
+      tempAlert: historicalData!.dailyAlertLevel,
     });
   });
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -19,6 +19,7 @@ import {
 import { createPoint } from '../utils/coordinates';
 import { AdminLevel } from '../users/users.entity';
 import { Site, SiteStatus } from './sites.entity';
+import { DailyData } from './daily-data.entity';
 import {
   athensSite,
   californiaSite,
@@ -97,6 +98,32 @@ export const siteTests = () => {
     });
     expect(testSite.id).toBeDefined();
     siteId = sortedSites[sortedSites.length - 1].id;
+  });
+
+  it('GET / find all sites with historical collection data', async () => {
+    await dataSource.getRepository(DailyData).save({
+      date: new Date('2020-01-01T00:00:00.000Z'),
+      degreeHeatingDays: 12.5,
+      satelliteTemperature: 29.1,
+      dailyAlertLevel: 2,
+      weeklyAlertLevel: 4,
+      site: { id: californiaSite.id },
+    });
+
+    const rsp = await request(app.getHttpServer()).get('/sites').query({
+      date: '2020-01-02T00:00:00.000Z',
+    });
+
+    expect(rsp.status).toBe(200);
+    const california = rsp.body.find(
+      (site: { id: number }) => site.id === californiaSite.id,
+    );
+    expect(california.collectionData).toMatchObject({
+      dhw: 12.5,
+      satelliteTemperature: 29.1,
+      tempAlert: 2,
+      tempWeeklyAlert: 4,
+    });
   });
 
   it('GET /:id retrieve one site', async () => {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,18 +2,66 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
 
+type DailyCollectionDataRow = {
+  siteId: number;
+  degreeHeatingDays: number | null;
+  satelliteTemperature: number | null;
+  dailyAlertLevel: number | null;
+  weeklyAlertLevel: number | null;
+};
+
+const getDailyCollectionData = async (
+  siteIds: number[],
+  dailyDataRepository: Repository<DailyData>,
+  date: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const dailyData: DailyCollectionDataRow[] = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany();
+
+  return _(dailyData)
+    .groupBy((row) => row.siteId)
+    .mapValues<CollectionDataDto>((rows) => {
+      const latestDailyData = rows[0];
+
+      return {
+        dhw: latestDailyData.degreeHeatingDays ?? undefined,
+        satelliteTemperature: latestDailyData.satelliteTemperature ?? undefined,
+        tempAlert: latestDailyData.dailyAlertLevel ?? undefined,
+        tempWeeklyAlert: latestDailyData.weeklyAlertLevel ?? undefined,
+      };
+    })
+    .toJSON();
+};
+
 export const getCollectionData = async (
   sites: Site[],
   latestDataRepository: Repository<LatestData>,
+  dailyDataRepository?: Repository<DailyData>,
+  date?: Date,
 ): Promise<Record<number, CollectionDataDto>> => {
   const siteIds = sites.map((site) => site.id);
 
   if (!siteIds.length) {
     return {};
+  }
+
+  if (dailyDataRepository && date) {
+    return getDailyCollectionData(siteIds, dailyDataRepository, date);
   }
 
   // Get latest data

--- a/packages/website/src/common/Search/index.tsx
+++ b/packages/website/src/common/Search/index.tsx
@@ -8,7 +8,7 @@ import withStyles from '@mui/styles/withStyles';
 import createStyles from '@mui/styles/createStyles';
 import SearchIcon from '@mui/icons-material/Search';
 import Autocomplete from '@mui/material/Autocomplete';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 
 import { setSiteOnMap, setSearchResult } from 'store/Homepage/homepageSlice';
 import type { Site } from 'store/Sites/types';
@@ -30,6 +30,7 @@ const siteAugmentedName = (site: Site) => {
 };
 
 function Search({ geocodingEnabled = false, classes }: SearchProps) {
+  const { search } = useLocation();
   const navigate = useNavigate();
   const { id = '' } = useParams<{ id: string }>();
   const [searchedSite, setSearchedSite] = useState<Site | null>(null);
@@ -47,8 +48,9 @@ function Search({ geocodingEnabled = false, classes }: SearchProps) {
 
   // Fetch sites for the search bar
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    const date = new URLSearchParams(search).get('date') || undefined;
+    dispatch(sitesRequest(date));
+  }, [dispatch, search]);
 
   const onChangeSearchText = (
     event: ChangeEvent<HTMLTextAreaElement | HTMLInputElement>,

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -21,12 +21,14 @@ import HomepageMap from './Map';
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
   initialCenter: LatLng;
   initialZoom: number;
   initialSiteId: string | undefined;
+  date: string | undefined;
 }
 
 const INITIAL_CENTER = new LatLng(0, 121.3);
@@ -36,6 +38,7 @@ function useQuery() {
   const urlParams: URLSearchParams = new URLSearchParams(useLocation().search);
   const zoomLevelParam = urlParams.get(QueryParamKeys.ZOOM_LEVEL);
   const initialZoom: number = zoomLevelParam ? +zoomLevelParam : INITIAL_ZOOM;
+  const date = urlParams.get(QueryParamKeys.DATE) || undefined;
   const queryParamSiteId = urlParams.get(QueryParamKeys.SITE_ID) || '';
   const sitesList = useSelector(sitesListSelector) || [];
   const featuredSiteId = process.env.REACT_APP_FEATURED_SITE_ID || '';
@@ -59,6 +62,7 @@ function useQuery() {
     initialCenter,
     initialSiteId,
     initialZoom,
+    date,
   };
 }
 
@@ -68,12 +72,12 @@ function Homepage({ classes }: HomepageProps) {
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
-  const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
+  const { initialZoom, initialSiteId, initialCenter, date }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(date));
+  }, [date, dispatch]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {

--- a/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
+++ b/packages/website/src/routes/SiteRoutes/SitesList/index.tsx
@@ -15,7 +15,7 @@ function SitesList({ classes }: SitesListProps) {
   const dispatch = useAppDispatch();
 
   useEffect(() => {
-    dispatch(sitesRequest());
+    dispatch(sitesRequest(undefined));
   }, [dispatch]);
 
   return (

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -35,13 +35,13 @@ const sitesListInitialState: SitesListState = {
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +49,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(date, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { date: currentDate, list },
       } = getState();
-      return !list;
+      return !list || currentDate !== date;
     },
   },
 );
@@ -108,6 +109,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -396,10 +396,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date?: string;
 }
 
 export interface SitesListState {
   list?: Site[];
+  date?: string;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
/claim #1162

Adds first-step historical map support for #1162.

- Adds optional `date` query support to `GET /sites`
- Uses `daily_data` on or before that date for map-facing `collectionData`
- Wires `/map?date=<ISO date>` through the HomeMap and search data fetch
- Adds API coverage for historical collection data

Checks:
- ESLint on changed backend files passed
- ESLint on changed frontend files passed
- `yarn workspace api build` passed
- `yarn workspace website build` passed

Note: Docker integration test was not run locally because Docker Desktop daemon was not running.