### PR TITLE
Fix AI Assistant: greeting shown for follow-up messages

### DIFF
--- a/packages/api/src/utils/prompts/index.ts
+++ b/packages/api/src/utils/prompts/index.ts
@@ -63,7 +63,7 @@ export function buildPromptWithContext(
 
   const openingSection = isOpeningMessage
     ? `\n\n${INITIAL_GREETING}\n\n## CRITICAL: THIS IS THE INITIAL GREETING
-You are responding to the opening of a new conversation. You MUST generate the contextual greeting exactly as specified in the "INITIAL GREETING FOR NEW CONVERSATIONS" section above.
+You are responding to the opening of a new conversation. You MUST generate the contextual greeting exactly as specified in the initial greeting template above.
 
 DO NOT respond to the user message as a question. Instead, provide the greeting with the AI-generated site summary.
 

--- a/packages/api/src/utils/prompts/index.ts
+++ b/packages/api/src/utils/prompts/index.ts
@@ -25,8 +25,6 @@ ${SYSTEM_PROMPT}
 
 ${GUARDRAILS}
 
-${INITIAL_GREETING}
-
 ${DATA_GUIDE}
 
 ${SURVEY_GUIDE}
@@ -64,7 +62,7 @@ export function buildPromptWithContext(
       : '';
 
   const openingSection = isOpeningMessage
-    ? `\n\n## CRITICAL: THIS IS THE INITIAL GREETING
+    ? `\n\n${INITIAL_GREETING}\n\n## CRITICAL: THIS IS THE INITIAL GREETING
 You are responding to the opening of a new conversation. You MUST generate the contextual greeting exactly as specified in the "INITIAL GREETING FOR NEW CONVERSATIONS" section above.
 
 DO NOT respond to the user message as a question. Instead, provide the greeting with the AI-generated site summary.


### PR DESCRIPTION
The AI assistant was responding to follow-up questions with the greeting format ("Here is the current reef status for...") instead of direct answers.

Root cause: INITIAL_GREETING was included in COMPLETE_SYSTEM_PROMPT, which is sent on every request. The model had the greeting template in its context at all times and occasionally used it for non-greeting responses.

Fix: moved INITIAL_GREETING out of COMPLETE_SYSTEM_PROMPT and into the openingSection block, which is only included when isFirstMessage is true.

The openingSection is included when isFirstMessage is true OR when 
conversationHistory is empty/missing — both indicate a new conversation.