### PR TITLE
Ai assistant clean local storage

### DIFF
--- a/packages/website/src/common/AiChatWidget/ChatWindow.tsx
+++ b/packages/website/src/common/AiChatWidget/ChatWindow.tsx
@@ -25,6 +25,7 @@ const API_BASE_URL =
   process.env.REACT_APP_API_BASE_URL || 'http://localhost:8080/api';
 
 // How long to wait before showing the "Retrieving historical data..." message
+const CHAT_HISTORY_KEY = (siteId: number) => `chat-history-v2-${siteId}`;
 const RETRIEVING_MESSAGE_DELAY_MS = 8000;
 
 // Generate the initial greeting by calling the API with isFirstMessage: true
@@ -94,7 +95,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
   useEffect(() => {
     const initializeChat = async () => {
       // Try to load from localStorage first
-      const saved = localStorage.getItem(`chat-history-v2-${siteId}`);
+      const saved = localStorage.getItem(CHAT_HISTORY_KEY(siteId));
       if (saved) {
         try {
           const savedMessages = JSON.parse(saved);
@@ -107,7 +108,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
         } catch (error) {
           console.error('Failed to load chat history:', error);
           // NEW: Clear corrupted localStorage
-          localStorage.removeItem(`chat-history-${siteId}`);
+          localStorage.removeItem(CHAT_HISTORY_KEY(siteId));
         }
       }
 
@@ -128,10 +129,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
   // Save messages to localStorage whenever they change
   useEffect(() => {
     if (messages.length > 0) {
-      localStorage.setItem(
-        `chat-history-v2-${siteId}`,
-        JSON.stringify(messages),
-      );
+      localStorage.setItem(CHAT_HISTORY_KEY(siteId), JSON.stringify(messages));
     }
   }, [messages, siteId]);
 
@@ -153,7 +151,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
         id: `msg-${Date.now()}`,
       };
       setMessages([initialMessage]);
-      localStorage.removeItem(`chat-history-v2-${siteId}`);
+      localStorage.removeItem(CHAT_HISTORY_KEY(siteId));
       setIsLoadingGreeting(false);
     }
   };

--- a/packages/website/src/common/AiChatWidget/ChatWindow.tsx
+++ b/packages/website/src/common/AiChatWidget/ChatWindow.tsx
@@ -94,7 +94,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
   useEffect(() => {
     const initializeChat = async () => {
       // Try to load from localStorage first
-      const saved = localStorage.getItem(`chat-history-${siteId}`);
+      const saved = localStorage.getItem(`chat-history-v2-${siteId}`);
       if (saved) {
         try {
           const savedMessages = JSON.parse(saved);
@@ -128,7 +128,10 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
   // Save messages to localStorage whenever they change
   useEffect(() => {
     if (messages.length > 0) {
-      localStorage.setItem(`chat-history-${siteId}`, JSON.stringify(messages));
+      localStorage.setItem(
+        `chat-history-v2-${siteId}`,
+        JSON.stringify(messages),
+      );
     }
   }, [messages, siteId]);
 
@@ -150,7 +153,7 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
         id: `msg-${Date.now()}`,
       };
       setMessages([initialMessage]);
-      localStorage.removeItem(`chat-history-${siteId}`);
+      localStorage.removeItem(`chat-history-v2-${siteId}`);
       setIsLoadingGreeting(false);
     }
   };

--- a/packages/website/src/common/AiChatWidget/ChatWindow.tsx
+++ b/packages/website/src/common/AiChatWidget/ChatWindow.tsx
@@ -178,10 +178,17 @@ function ChatWindow({ classes, onClose, siteId }: ChatWindowProps) {
 
     try {
       // Build conversation history for context (last 10 messages)
-      const conversationHistory = messages.slice(-10).map((msg) => ({
-        sender: msg.sender,
-        text: msg.text,
-      }));
+      const conversationHistory = messages
+        .slice(-10)
+        .filter(
+          (msg) =>
+            msg.sender !== 'assistant' ||
+            !msg.text.startsWith('Here is the current reef status'),
+        )
+        .map((msg) => ({
+          sender: msg.sender,
+          text: msg.text,
+        }));
 
       const response = await fetch(`${API_BASE_URL}/ai-chat`, {
         method: 'POST',


### PR DESCRIPTION
Users who had chatted with the AI assistant during the period when the greeting bug was active have contaminated chat histories stored in localStorage. Those histories contain greeting-format responses which the model then reproduces for every follow-up message, even after the underlying prompt fix was deployed.

Changing the localStorage key from `chat-history-${siteId}` to `chat-history-v2-${siteId}` forces all existing users onto a clean history on their next visit. No data is deleted, and old entries are simply ignored.

A guard is also in place to prevent this bug in the future. 