### PR TITLE
Wave data: Add Open-Meteo API and replace Sofar Wave Model

### DIFF
--- a/.github/workflows/build_api.yml
+++ b/.github/workflows/build_api.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v3-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-v2-
+            ${{ runner.os }}-yarn-v3-
 
       - name: Install dependencies if needed.
         id: install

--- a/.github/workflows/build_api.yml
+++ b/.github/workflows/build_api.yml
@@ -50,9 +50,9 @@ jobs:
         with:
           path: |
             **/node_modules
-          key: ${{ runner.os }}-yarn-v1-${{ hashFiles('yarn.lock') }}
+          key: ${{ runner.os }}-yarn-v2-${{ hashFiles('yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-v1-
+            ${{ runner.os }}-yarn-v2-
 
       - name: Install dependencies if needed.
         id: install

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "yaml": "^1.10.3",
     "@grpc/grpc-js": "^1.14.4",
     "form-data": "^4.0.6",
-    "multer": "^2.2.0"
+    "multer": "^2.2.0",
+    "websocket-driver": "^0.7.5"
   },
   "devDependencies": {
     "@babel/core": "^7.29.6",

--- a/package.json
+++ b/package.json
@@ -35,10 +35,13 @@
     "node-forge": "^1.4.0",
     "picomatch": "^2.3.2",
     "protocol-buffers-schema": "^3.6.1",
-    "protobufjs": "^7.5.5",
+    "protobufjs": "^7.6.3",
     "qs": "^6.15.2",
     "uuid": "^11.1.1",
-    "yaml": "^1.10.3"
+    "yaml": "^1.10.3",
+    "@grpc/grpc-js": "^1.14.4",
+    "form-data": "^4.0.6",
+    "multer": "^2.2.0"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "axios": "^1.15.0",
     "basic-ftp": "^5.2.0",
     "brace-expansion": "^1.1.13",
-    "fast-xml-parser": "^5.7.0",
+    "fast-xml-parser": "^5.10.1",
     "file-type": "^21.3.2",
     "follow-redirects": "^1.16.0",
     "js-yaml": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "@babel/runtime": "^7.26.10",
     "axios": "^1.15.0",
     "basic-ftp": "^5.2.0",
-    "brace-expansion": "^1.1.13",
     "fast-xml-parser": "^5.10.1",
     "file-type": "^21.3.2",
     "follow-redirects": "^1.16.0",

--- a/packages/api/cloud-functions/index.ts
+++ b/packages/api/cloud-functions/index.ts
@@ -168,18 +168,23 @@ exports.scheduledSpotterTimeSeriesUpdate = functions
 
 exports.scheduledWindWaveTimeSeriesUpdate = functions
   .runWith({ timeoutSeconds: 540, memory: '512MB' })
-  // Run spotter data update every hour
-  .pubsub.schedule('30 * * * *')
+  // Wave data now sourced from Open-Meteo, which only updates every
+  // 6 hours (00/06/12/18 UTC). Hourly fetching was wasteful and also
+  // exceeded the Open-Meteo free tier rate limit. Schedule shifted to
+  // ~4x/day, timed after each model cycle typically finishes publishing.
+  // Wind (still Sofar/GFS) is unaffected by this schedule change.
+  .pubsub.schedule('20 4,10,16,22 * * *')
   .timeZone('America/Los_Angeles')
   .retryConfig({ retryCount: 2 })
   .onRun(async () => {
     process.env.SOFAR_API_TOKEN = functions.config().sofar_api.token;
+    process.env.OPEN_METEO_API_KEY = functions.config().open_meteo?.api_key;
 
     await runWithDataSource(
       'scheduledWindWaveTimeSeriesUpdate',
       async (conn: DataSource) => {
         await runWindWaveTimeSeriesUpdate(conn);
-        console.log(`Wind and Wave data hourly update on ${new Date()}`);
+        console.log(`Wind and Wave data update on ${new Date()}`);
       },
     );
   });

--- a/packages/api/cloud-functions/index.ts
+++ b/packages/api/cloud-functions/index.ts
@@ -6,7 +6,8 @@ import { DataSource } from 'typeorm';
 import { runDailyUpdate } from '../src/workers/dailyData';
 import {
   runSpotterTimeSeriesUpdate,
-  runWindWaveTimeSeriesUpdate,
+  runWaveTimeSeriesUpdate,
+  runWindTimeSeriesUpdate,
 } from '../src/workers/spotterTimeSeries';
 import { runSSTTimeSeriesUpdate } from '../src/workers/sstTimeSeries';
 import { checkVideoStreams } from '../src/workers/check-video-streams';
@@ -166,25 +167,42 @@ exports.scheduledSpotterTimeSeriesUpdate = functions
     );
   });
 
-exports.scheduledWindWaveTimeSeriesUpdate = functions
+// Wave (Open-Meteo) and wind (Sofar GFS) run as separate scheduled
+// functions so each stays under the 540s Cloud Function timeout. The
+// previous combined job timed out mid Sofar-wind loop and left ~30% of
+// sites without a fresh open_meteo row. Wind is staggered +10 min.
+exports.scheduledWaveTimeSeriesUpdate = functions
   .runWith({ timeoutSeconds: 540, memory: '512MB' })
-  // Wave data now sourced from Open-Meteo, which only updates every
-  // 6 hours (00/06/12/18 UTC). Hourly fetching was wasteful and also
-  // exceeded the Open-Meteo free tier rate limit. Schedule shifted to
+  // Open-Meteo Marine updates every 6 hours (00/06/12/18 UTC). Schedule
   // ~4x/day, timed after each model cycle typically finishes publishing.
-  // Wind (still Sofar/GFS) is unaffected by this schedule change.
   .pubsub.schedule('20 4,10,16,22 * * *')
   .timeZone('America/Los_Angeles')
   .retryConfig({ retryCount: 2 })
   .onRun(async () => {
-    process.env.SOFAR_API_TOKEN = functions.config().sofar_api.token;
     process.env.OPEN_METEO_API_KEY = functions.config().open_meteo?.api_key;
 
     await runWithDataSource(
-      'scheduledWindWaveTimeSeriesUpdate',
+      'scheduledWaveTimeSeriesUpdate',
       async (conn: DataSource) => {
-        await runWindWaveTimeSeriesUpdate(conn);
-        console.log(`Wind and Wave data update on ${new Date()}`);
+        await runWaveTimeSeriesUpdate(conn);
+        console.log(`Wave data update on ${new Date()}`);
+      },
+    );
+  });
+
+exports.scheduledWindTimeSeriesUpdate = functions
+  .runWith({ timeoutSeconds: 540, memory: '512MB' })
+  .pubsub.schedule('30 4,10,16,22 * * *')
+  .timeZone('America/Los_Angeles')
+  .retryConfig({ retryCount: 2 })
+  .onRun(async () => {
+    process.env.SOFAR_API_TOKEN = functions.config().sofar_api.token;
+
+    await runWithDataSource(
+      'scheduledWindTimeSeriesUpdate',
+      async (conn: DataSource) => {
+        await runWindTimeSeriesUpdate(conn);
+        console.log(`Wind data update on ${new Date()}`);
       },
     );
   });

--- a/packages/api/functionsConfig.ts
+++ b/packages/api/functionsConfig.ts
@@ -1,6 +1,6 @@
 try {
   // eslint-disable-next-line import/no-extraneous-dependencies, global-require
-  require('dotenv').config();
+  require('dotenv').config({ quiet: true });
 } catch {
   // Pass
 }

--- a/packages/api/functionsConfig.ts
+++ b/packages/api/functionsConfig.ts
@@ -13,6 +13,9 @@ export const functionsConfig = {
   sofar_api: {
     token: process.env.SOFAR_API_TOKEN,
   },
+  open_meteo: {
+    api_key: process.env.OPEN_METEO_API_KEY,
+  },
   front: {
     base_url: process.env.FRONT_END_BASE_URL,
   },

--- a/packages/api/migration/1783013965319-AddOpenMeteoSourceType.ts
+++ b/packages/api/migration/1783013965319-AddOpenMeteoSourceType.ts
@@ -1,0 +1,40 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddOpenMeteoSourceType1783013965319 implements MigrationInterface {
+  name = 'AddOpenMeteoSourceType1783013965319';
+
+  transaction = false as const;
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // Add 'open_meteo' to every enum type that already contains
+    // 'sofar_model'. Existing rows are intentionally left untouched —
+    // their `source` will only change to 'open_meteo' once the ingestion
+    // pipeline actually re-fetches that site's data from Open-Meteo,
+    // keeping the label always accurate to the underlying value.
+    await queryRunner.query(`
+      DO $$
+      DECLARE
+          enum_type RECORD;
+      BEGIN
+          FOR enum_type IN
+              SELECT DISTINCT t.typname
+              FROM pg_type t
+              JOIN pg_enum e ON e.enumtypid = t.oid
+              WHERE e.enumlabel = 'sofar_model'
+          LOOP
+              EXECUTE format(
+                'ALTER TYPE %I ADD VALUE IF NOT EXISTS %L',
+                enum_type.typname, 'open_meteo'
+              );
+          END LOOP;
+      END $$;
+    `);
+  }
+
+  public async down(): Promise<void> {
+    // PostgreSQL does not allow removing a value from an enum type
+    // without recreating it, which requires temporarily detaching all
+    // referencing columns. Not handled here — the 'open_meteo' value is
+    // left in place but unused on rollback.
+  }
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -19,7 +19,7 @@
     "deploy:prod": "cross-env DEPLOY_ENV=prod yarn deploy:app && yarn deploy:cloud-functions",
     "deploy:staging": "cross-env DEPLOY_ENV=staging yarn deploy:app && yarn deploy:cloud-functions:staging",
     "deploy:programize": "cross-env DEPLOY_ENV=programize yarn deploy:app && yarn deploy:cloud-functions:programize",
-    "deploy:cloud-functions": "yarn build:cloud-functions && firebase deploy --only functions:pingService,functions:scheduledDailyUpdate,functions:scheduledSpotterTimeSeriesUpdate,functions:scheduledWindWaveTimeSeriesUpdate,functions:scheduledSSTTimeSeriesUpdate,functions:scheduledVideoStreamsCheck,functions:scheduledBuoysStatusCheck,functions:scheduledNOAALocationUpdate",
+    "deploy:cloud-functions": "yarn build:cloud-functions && firebase deploy --only functions:pingService,functions:scheduledDailyUpdate,functions:scheduledSpotterTimeSeriesUpdate,functions:scheduledWaveTimeSeriesUpdate,functions:scheduledWindTimeSeriesUpdate,functions:scheduledSSTTimeSeriesUpdate,functions:scheduledVideoStreamsCheck,functions:scheduledBuoysStatusCheck,functions:scheduledNOAALocationUpdate",
     "deploy:cloud-functions:prod": "yarn deploy:cloud-functions -P ocean-systems",
     "deploy:cloud-functions:staging": "yarn deploy:cloud-functions -P aqualink-dev",
     "deploy:cloud-functions:programize": "yarn deploy:cloud-functions -P aqualink-programize",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -101,7 +101,7 @@
     "lodash": "^4.18.0",
     "luxon": "^3.5.0",
     "md5-file": "^5.0.0",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "node-xlsx": "^0.24.0",
     "objects-to-csv": "^1.3.6",
     "p-limit": "^7.2.0",
@@ -112,7 +112,7 @@
     "rxjs": "^7",
     "sharp": "^0.33.5",
     "ts-exif-parser": "^0.2.1",
-    "typeorm": "^0.3.20",
+    "typeorm": "^0.3.29",
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -115,6 +115,10 @@
     "typeorm": "^0.3.31",
     "typeorm-naming-strategies": "^4.1.0"
   },
+  "optionalDependencies": {
+    "@img/sharp-libvips-linux-x64": "1.3.2",
+    "@img/sharp-linux-x64": "0.35.3"
+  },
   "devDependencies": {
     "@nestjs/cli": "^11.0.21",
     "@nestjs/schematics": "^11.1.0",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -110,9 +110,9 @@
     "pg": "^8.2.1",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7",
-    "sharp": "^0.33.5",
+    "sharp": "^0.35.0",
     "ts-exif-parser": "^0.2.1",
-    "typeorm": "^0.3.29",
+    "typeorm": "^0.3.31",
     "typeorm-naming-strategies": "^4.1.0"
   },
   "devDependencies": {

--- a/packages/api/src/sites/schemas/source-type.enum.ts
+++ b/packages/api/src/sites/schemas/source-type.enum.ts
@@ -9,4 +9,5 @@ export enum SourceType {
   HUI = 'hui',
   SHEET_DATA = 'sheet_data',
   SEAPHOX = 'seaphox',
+  OPEN_METEO = 'open_meteo',
 }

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -35,9 +35,10 @@ export const OPEN_METEO_CUSTOMER_URL =
 // 100 keeps URL length safely under typical proxy limits (~8KB).
 export const OPEN_METEO_BATCH_SIZE = 100;
 
-// Concurrency cap for parallel Open-Meteo batch calls. The free tier allows
-// 600 calls/min; this leaves plenty of headroom.
-export const OPEN_METEO_CONCURRENCY = 20;
+// Minimum pause between sequential Open-Meteo Marine API requests, to
+// stay under the free tier's per-minute rate limit when processing
+// the full site list across ~60 batches.
+export const OPEN_METEO_REQUEST_DELAY_MS = 1200;
 
 export enum SofarModels {
   NOAACoralReefWatch = 'NOAACoralReefWatch',

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -22,6 +22,23 @@ export const SOFAR_SENSOR_DATA_URL =
 export const SOFAR_LATEST_DATA_URL =
   'https://api.sofarocean.com/api/latest-data';
 
+// Open-Meteo Marine API
+// https://open-meteo.com/en/docs/marine-weather-api
+// Free tier (default) requires no auth. Setting OPEN_METEO_API_KEY routes
+// requests to the customer endpoint. Setting OPEN_METEO_BASE_URL overrides both.
+export const OPEN_METEO_FREE_URL =
+  'https://marine-api.open-meteo.com/v1/marine';
+export const OPEN_METEO_CUSTOMER_URL =
+  'https://customer-marine-api.open-meteo.com/v1/marine';
+
+// Number of sites to bundle into a single multi-coordinate Marine API call.
+// 100 keeps URL length safely under typical proxy limits (~8KB).
+export const OPEN_METEO_BATCH_SIZE = 100;
+
+// Concurrency cap for parallel Open-Meteo batch calls. The free tier allows
+// 600 calls/min; this leaves plenty of headroom.
+export const OPEN_METEO_CONCURRENCY = 20;
+
 export enum SofarModels {
   NOAACoralReefWatch = 'NOAACoralReefWatch',
   Wave = 'Wave',

--- a/packages/api/src/utils/constants.ts
+++ b/packages/api/src/utils/constants.ts
@@ -32,13 +32,14 @@ export const OPEN_METEO_CUSTOMER_URL =
   'https://customer-marine-api.open-meteo.com/v1/marine';
 
 // Number of sites to bundle into a single multi-coordinate Marine API call.
-// 100 keeps URL length safely under typical proxy limits (~8KB).
-export const OPEN_METEO_BATCH_SIZE = 100;
+export const OPEN_METEO_BATCH_SIZE = 150;
 
-// Minimum pause between sequential Open-Meteo Marine API requests, to
-// stay under the free tier's per-minute rate limit when processing
-// the full site list across ~60 batches.
-export const OPEN_METEO_REQUEST_DELAY_MS = 1200;
+// Now on the paid Standard tier, which tolerates concurrent requests
+// without the free tier's rate limiting. This concurrency + batch size
+// keeps a full ~6,000 site run well under the 540s Cloud Function
+// timeout, versus the fully sequential free-tier-safe approach which
+// was completing less than half the site list per run before timing out.
+export const OPEN_METEO_CONCURRENCY = 5;
 
 export enum SofarModels {
   NOAACoralReefWatch = 'NOAACoralReefWatch',

--- a/packages/api/src/utils/hindcast-wind-wave.ts
+++ b/packages/api/src/utils/hindcast-wind-wave.ts
@@ -10,27 +10,12 @@ import { ForecastData } from '../wind-wave-data/forecast-data.entity';
 import { WindWaveMetric } from '../wind-wave-data/wind-wave-data.types';
 import { SofarModels, sofarVariableIDs } from './constants';
 import { getWindDirection, getWindSpeed } from './math';
+import { openMeteoMarineBatch } from './open-meteo';
 import { sofarHindcast } from './sofar';
 import { getSofarNearestAvailablePoint } from './sofar-availability';
-import { ValueWithTimestamp, SpotterData } from './sofar.types';
+import { ValueWithTimestamp } from './sofar.types';
 
 const logger = new Logger('hindcastWindWaveData');
-
-const dataLabels: [keyof SpotterData, WindWaveMetric, SourceType][] = [
-  [
-    'significantWaveHeight',
-    WindWaveMetric.SIGNIFICANT_WAVE_HEIGHT,
-    SourceType.SOFAR_MODEL,
-  ],
-  [
-    'waveMeanDirection',
-    WindWaveMetric.WAVE_MEAN_DIRECTION,
-    SourceType.SOFAR_MODEL,
-  ],
-  ['waveMeanPeriod', WindWaveMetric.WAVE_MEAN_PERIOD, SourceType.SOFAR_MODEL],
-  ['windDirection', WindWaveMetric.WIND_DIRECTION, SourceType.GFS],
-  ['windSpeed', WindWaveMetric.WIND_SPEED, SourceType.GFS],
-];
 
 interface Repositories {
   siteRepository: Repository<Site>;
@@ -46,6 +31,12 @@ const getTodayYesterdayDates = () => {
   return { today, yesterday };
 };
 
+/**
+ * Original combined Sofar wave+wind fetch, kept unchanged and exported for
+ * backward compatibility with scripts/generate-stormglass-csv.ts, which
+ * depends on this exact function. Not used by addWindWaveData below —
+ * that now sources wave data from Open-Meteo instead (see getWindData).
+ */
 export const getForecastData = async (latitude: number, longitude: number) => {
   const { today, yesterday } = getTodayYesterdayDates();
   const hindcastOptions = [
@@ -89,7 +80,6 @@ export const getForecastData = async (latitude: number, longitude: number) => {
     return x.values[x.values.length - 1]; // latest available forecast in the past
   });
 
-  // Calculate wind speed and direction from velocity
   const windNorthwardVelocity = windVelocity10MeterNorthward?.value;
   const windEastwardVelocity = windVelocity10MeterEastward?.value;
   const sameTimestamps =
@@ -120,17 +110,105 @@ export const getForecastData = async (latitude: number, longitude: number) => {
 };
 
 /**
- * Fetch spotter and wave data from sofar and save them on time_series table
- * @param siteIds The siteIds for which to perform the update
- * @param connection An active typeorm connection object
- * @param repositories The needed repositories, as defined by the interface
+ * Fetch wind data (eastward/northward velocity) from Sofar's GFS-backed
+ * Atmosphere model and derive speed + direction. Used by addWindWaveData
+ * below. Wave data is fetched separately, in bulk, via Open-Meteo.
+ */
+const getWindData = async (latitude: number, longitude: number) => {
+  const { today, yesterday } = getTodayYesterdayDates();
+
+  const [windEastwardRaw, windNorthwardRaw] = await Promise.all([
+    sofarHindcast(
+      SofarModels.Atmosphere,
+      sofarVariableIDs[SofarModels.Atmosphere].windVelocity10MeterEastward,
+      latitude,
+      longitude,
+      yesterday,
+      today,
+    ),
+    sofarHindcast(
+      SofarModels.Atmosphere,
+      sofarVariableIDs[SofarModels.Atmosphere].windVelocity10MeterNorthward,
+      latitude,
+      longitude,
+      yesterday,
+      today,
+    ),
+  ]);
+
+  const windVelocity10MeterEastward =
+    windEastwardRaw && windEastwardRaw.values.length > 0
+      ? windEastwardRaw.values[windEastwardRaw.values.length - 1]
+      : undefined;
+  const windVelocity10MeterNorthward =
+    windNorthwardRaw && windNorthwardRaw.values.length > 0
+      ? windNorthwardRaw.values[windNorthwardRaw.values.length - 1]
+      : undefined;
+
+  const eastward = windVelocity10MeterEastward?.value;
+  const northward = windVelocity10MeterNorthward?.value;
+  const sameTimestamps =
+    windVelocity10MeterEastward?.timestamp ===
+    windVelocity10MeterNorthward?.timestamp;
+
+  const windSpeed: ValueWithTimestamp | undefined =
+    eastward !== undefined && northward !== undefined && sameTimestamps
+      ? {
+          timestamp: windVelocity10MeterNorthward!.timestamp,
+          value: getWindSpeed(eastward, northward),
+        }
+      : undefined;
+  const windDirection: ValueWithTimestamp | undefined =
+    eastward !== undefined && northward !== undefined && sameTimestamps
+      ? {
+          timestamp: windVelocity10MeterNorthward!.timestamp,
+          value: getWindDirection(eastward, northward),
+        }
+      : undefined;
+
+  return { windSpeed, windDirection };
+};
+
+interface CombinedWindWaveData {
+  significantWaveHeight?: ValueWithTimestamp;
+  waveMeanDirection?: ValueWithTimestamp;
+  waveMeanPeriod?: ValueWithTimestamp;
+  windSpeed?: ValueWithTimestamp;
+  windDirection?: ValueWithTimestamp;
+}
+
+const dataLabels: [keyof CombinedWindWaveData, WindWaveMetric, SourceType][] = [
+  [
+    'significantWaveHeight',
+    WindWaveMetric.SIGNIFICANT_WAVE_HEIGHT,
+    SourceType.OPEN_METEO,
+  ],
+  [
+    'waveMeanDirection',
+    WindWaveMetric.WAVE_MEAN_DIRECTION,
+    SourceType.OPEN_METEO,
+  ],
+  ['waveMeanPeriod', WindWaveMetric.WAVE_MEAN_PERIOD, SourceType.OPEN_METEO],
+  ['windDirection', WindWaveMetric.WIND_DIRECTION, SourceType.GFS],
+  ['windSpeed', WindWaveMetric.WIND_SPEED, SourceType.GFS],
+];
+
+/**
+ * Fetch wave and wind forecast data and persist it to forecast_data.
+ *
+ * Wave data is fetched in batched multi-coordinate calls to the Open-Meteo
+ * Marine API. Wind data is fetched per site from Sofar's GFS-backed
+ * Atmosphere model (unchanged from prior behaviour).
+ *
+ * @param siteIds The siteIds for which to perform the update. If empty,
+ *                all sites are updated.
+ * @param repositories The needed repositories, as defined by the interface.
  */
 export const addWindWaveData = async (
   siteIds: number[],
   repositories: Repositories,
 ) => {
   logger.log('Fetching sites');
-  // Fetch all sites
   const sites = await repositories.siteRepository.find({
     where: {
       ...(siteIds.length > 0 ? { id: In(siteIds) } : {}),
@@ -139,41 +217,56 @@ export const addWindWaveData = async (
 
   const { today } = getTodayYesterdayDates();
 
+  logger.log(`Fetching wave data from Open-Meteo for ${sites.length} sites`);
+  const waveCoordinates: Array<[number, number]> = sites.map((site) => {
+    const [longitude, latitude] = (site.polygon as Point).coordinates;
+    return [latitude, longitude];
+  });
+  const waveResults = await openMeteoMarineBatch(waveCoordinates);
+
   logger.log('Saving wind & wave forecast data');
   const limit = pLimit(10);
   await Promise.all(
-    sites.map((site) =>
+    sites.map((site, idx) =>
       limit(async () => {
         const { polygon } = site;
 
-        const [longitude, latitude] = getSofarNearestAvailablePoint(
+        const [sofarLongitude, sofarLatitude] = getSofarNearestAvailablePoint(
           polygon as Point,
         );
 
         logger.log(
-          `Saving wind & wave forecast data for ${site.id} at ${latitude} - ${longitude}`,
+          `Saving wind & wave forecast data for ${site.id} at ${sofarLatitude} - ${sofarLongitude}`,
         );
 
-        const forecastData = await getForecastData(latitude, longitude);
+        const waveData = waveResults[idx];
+        const windData = await getWindData(sofarLatitude, sofarLongitude);
 
-        // Save wind wave data to forecast_data
+        const combinedData: CombinedWindWaveData = {
+          significantWaveHeight: waveData?.waveHeight,
+          waveMeanDirection: waveData?.waveDirection,
+          waveMeanPeriod: waveData?.wavePeriod,
+          windSpeed: windData.windSpeed,
+          windDirection: windData.windDirection,
+        };
+
         await Promise.all(
           // eslint-disable-next-line array-callback-return, consistent-return
           dataLabels.map(([dataLabel, metric, source]) => {
-            const sofarValue = forecastData[dataLabel] as ValueWithTimestamp;
-            if (!isNil(sofarValue?.value) && !Number.isNaN(sofarValue?.value)) {
+            const value = combinedData[dataLabel];
+            if (!isNil(value?.value) && !Number.isNaN(value?.value)) {
               return repositories.hindcastRepository
                 .createQueryBuilder('forecast_data')
                 .insert()
                 .values([
                   {
                     site,
-                    timestamp: DateTime.fromISO(sofarValue.timestamp)
+                    timestamp: DateTime.fromISO(value!.timestamp)
                       .startOf('minute')
                       .toJSDate(),
                     metric,
                     source,
-                    value: sofarValue.value,
+                    value: value!.value,
                     updatedAt: today,
                   },
                 ])

--- a/packages/api/src/utils/hindcast-wind-wave.ts
+++ b/packages/api/src/utils/hindcast-wind-wave.ts
@@ -261,7 +261,7 @@ export const addWindWaveData = async (
                 .values([
                   {
                     site,
-                    timestamp: DateTime.fromISO(value!.timestamp)
+                    timestamp: DateTime.fromISO(value!.timestamp, { zone: 'utc' })
                       .startOf('minute')
                       .toJSDate(),
                     metric,

--- a/packages/api/src/utils/hindcast-wind-wave.ts
+++ b/packages/api/src/utils/hindcast-wind-wave.ts
@@ -34,8 +34,8 @@ const getTodayYesterdayDates = () => {
 /**
  * Original combined Sofar wave+wind fetch, kept unchanged and exported for
  * backward compatibility with scripts/generate-stormglass-csv.ts, which
- * depends on this exact function. Not used by addWindWaveData below —
- * that now sources wave data from Open-Meteo instead (see getWindData).
+ * depends on this exact function. Not used by the scheduled ingest paths
+ * below — waves come from Open-Meteo and wind from getWindData.
  */
 export const getForecastData = async (latitude: number, longitude: number) => {
   const { today, yesterday } = getTodayYesterdayDates();
@@ -111,8 +111,7 @@ export const getForecastData = async (latitude: number, longitude: number) => {
 
 /**
  * Fetch wind data (eastward/northward velocity) from Sofar's GFS-backed
- * Atmosphere model and derive speed + direction. Used by addWindWaveData
- * below. Wave data is fetched separately, in bulk, via Open-Meteo.
+ * Atmosphere model and derive speed + direction.
  */
 const getWindData = async (latitude: number, longitude: number) => {
   const { today, yesterday } = getTodayYesterdayDates();
@@ -169,52 +168,68 @@ const getWindData = async (latitude: number, longitude: number) => {
   return { windSpeed, windDirection };
 };
 
-interface CombinedWindWaveData {
-  significantWaveHeight?: ValueWithTimestamp;
-  waveMeanDirection?: ValueWithTimestamp;
-  waveMeanPeriod?: ValueWithTimestamp;
-  windSpeed?: ValueWithTimestamp;
-  windDirection?: ValueWithTimestamp;
-}
+type ForecastMetricValue = {
+  metric: WindWaveMetric;
+  source: SourceType;
+  value: ValueWithTimestamp;
+};
 
-const dataLabels: [keyof CombinedWindWaveData, WindWaveMetric, SourceType][] = [
-  [
-    'significantWaveHeight',
-    WindWaveMetric.SIGNIFICANT_WAVE_HEIGHT,
-    SourceType.OPEN_METEO,
-  ],
-  [
-    'waveMeanDirection',
-    WindWaveMetric.WAVE_MEAN_DIRECTION,
-    SourceType.OPEN_METEO,
-  ],
-  ['waveMeanPeriod', WindWaveMetric.WAVE_MEAN_PERIOD, SourceType.OPEN_METEO],
-  ['windDirection', WindWaveMetric.WIND_DIRECTION, SourceType.GFS],
-  ['windSpeed', WindWaveMetric.WIND_SPEED, SourceType.GFS],
-];
-
-/**
- * Fetch wave and wind forecast data and persist it to forecast_data.
- *
- * Wave data is fetched in batched multi-coordinate calls to the Open-Meteo
- * Marine API. Wind data is fetched per site from Sofar's GFS-backed
- * Atmosphere model (unchanged from prior behaviour).
- *
- * @param siteIds The siteIds for which to perform the update. If empty,
- *                all sites are updated.
- * @param repositories The needed repositories, as defined by the interface.
- */
-export const addWindWaveData = async (
-  siteIds: number[],
+const upsertForecastMetrics = async (
+  site: Site,
+  metrics: ForecastMetricValue[],
   repositories: Repositories,
+  updatedAt: string,
 ) => {
+  await Promise.all(
+    // eslint-disable-next-line array-callback-return, consistent-return
+    metrics.map(({ metric, source, value }) => {
+      if (!isNil(value?.value) && !Number.isNaN(value?.value)) {
+        return repositories.hindcastRepository
+          .createQueryBuilder('forecast_data')
+          .insert()
+          .values([
+            {
+              site,
+              timestamp: DateTime.fromISO(value.timestamp, {
+                zone: 'utc',
+              })
+                .startOf('minute')
+                .toJSDate(),
+              metric,
+              source,
+              value: value.value,
+              updatedAt,
+            },
+          ])
+          .onConflict(
+            `ON CONSTRAINT "one_row_per_site_per_metric_per_source" DO UPDATE SET "timestamp" = excluded."timestamp", "updated_at" = excluded."updated_at", "value" = excluded."value"`,
+          )
+          .execute();
+      }
+    }),
+  );
+};
+
+const fetchSites = async (siteIds: number[], repositories: Repositories) => {
   logger.log('Fetching sites');
-  const sites = await repositories.siteRepository.find({
+  return repositories.siteRepository.find({
     where: {
       ...(siteIds.length > 0 ? { id: In(siteIds) } : {}),
     },
   });
+};
 
+/**
+ * Fetch wave forecast data from Open-Meteo and persist it to forecast_data.
+ *
+ * @param siteIds The siteIds for which to perform the update. If empty,
+ *                all sites are updated.
+ */
+export const addWaveData = async (
+  siteIds: number[],
+  repositories: Repositories,
+) => {
+  const sites = await fetchSites(siteIds, repositories);
   const { today } = getTodayYesterdayDates();
 
   logger.log(`Fetching wave data from Open-Meteo for ${sites.length} sites`);
@@ -224,63 +239,126 @@ export const addWindWaveData = async (
   });
   const waveResults = await openMeteoMarineBatch(waveCoordinates);
 
-  logger.log('Saving wind & wave forecast data');
-  const limit = pLimit(10);
+  logger.log('Saving wave forecast data');
+  const limit = pLimit(20);
   await Promise.all(
     sites.map((site, idx) =>
       limit(async () => {
-        const { polygon } = site;
+        const waveData = waveResults[idx];
+        if (!waveData) {
+          return;
+        }
 
+        logger.log(`Saving wave forecast data for ${site.id}`);
+
+        await upsertForecastMetrics(
+          site,
+          [
+            {
+              metric: WindWaveMetric.SIGNIFICANT_WAVE_HEIGHT,
+              source: SourceType.OPEN_METEO,
+              value: waveData.waveHeight!,
+            },
+            {
+              metric: WindWaveMetric.WAVE_MEAN_DIRECTION,
+              source: SourceType.OPEN_METEO,
+              value: waveData.waveDirection!,
+            },
+            {
+              metric: WindWaveMetric.WAVE_MEAN_PERIOD,
+              source: SourceType.OPEN_METEO,
+              value: waveData.wavePeriod!,
+            },
+          ].filter((entry) => !isNil(entry.value?.value)),
+          repositories,
+          today,
+        );
+      }),
+    ),
+  );
+  logger.log('Completed updating wave hindcast data');
+};
+
+/**
+ * Fetch wind forecast data from Sofar GFS and persist it to forecast_data.
+ * Dedupes Sofar requests by nearest available grid point — many sites share
+ * the same point, which keeps a full run under the Cloud Function timeout.
+ *
+ * @param siteIds The siteIds for which to perform the update. If empty,
+ *                all sites are updated.
+ */
+export const addWindData = async (
+  siteIds: number[],
+  repositories: Repositories,
+) => {
+  const sites = await fetchSites(siteIds, repositories);
+  const { today } = getTodayYesterdayDates();
+
+  logger.log(`Fetching wind data from Sofar for ${sites.length} sites`);
+
+  type WindResult = Awaited<ReturnType<typeof getWindData>>;
+  const windByGridPoint = new Map<string, Promise<WindResult>>();
+
+  const getCachedWindData = (latitude: number, longitude: number) => {
+    const key = `${latitude},${longitude}`;
+    const cached = windByGridPoint.get(key);
+    if (cached) {
+      return cached;
+    }
+    const request = getWindData(latitude, longitude);
+    windByGridPoint.set(key, request);
+    return request;
+  };
+
+  const limit = pLimit(10);
+  await Promise.all(
+    sites.map((site) =>
+      limit(async () => {
+        const { polygon } = site;
         const [sofarLongitude, sofarLatitude] = getSofarNearestAvailablePoint(
           polygon as Point,
         );
 
         logger.log(
-          `Saving wind & wave forecast data for ${site.id} at ${sofarLatitude} - ${sofarLongitude}`,
+          `Saving wind forecast data for ${site.id} at ${sofarLatitude} - ${sofarLongitude}`,
         );
 
-        const waveData = waveResults[idx];
-        const windData = await getWindData(sofarLatitude, sofarLongitude);
+        const windData = await getCachedWindData(sofarLatitude, sofarLongitude);
 
-        const combinedData: CombinedWindWaveData = {
-          significantWaveHeight: waveData?.waveHeight,
-          waveMeanDirection: waveData?.waveDirection,
-          waveMeanPeriod: waveData?.wavePeriod,
-          windSpeed: windData.windSpeed,
-          windDirection: windData.windDirection,
-        };
-
-        await Promise.all(
-          // eslint-disable-next-line array-callback-return, consistent-return
-          dataLabels.map(([dataLabel, metric, source]) => {
-            const value = combinedData[dataLabel];
-            if (!isNil(value?.value) && !Number.isNaN(value?.value)) {
-              return repositories.hindcastRepository
-                .createQueryBuilder('forecast_data')
-                .insert()
-                .values([
-                  {
-                    site,
-                    timestamp: DateTime.fromISO(value!.timestamp, {
-                      zone: 'utc',
-                    })
-                      .startOf('minute')
-                      .toJSDate(),
-                    metric,
-                    source,
-                    value: value!.value,
-                    updatedAt: today,
-                  },
-                ])
-                .onConflict(
-                  `ON CONSTRAINT "one_row_per_site_per_metric_per_source" DO UPDATE SET "timestamp" = excluded."timestamp", "updated_at" = excluded."updated_at", "value" = excluded."value"`,
-                )
-                .execute();
-            }
-          }),
+        await upsertForecastMetrics(
+          site,
+          [
+            {
+              metric: WindWaveMetric.WIND_SPEED,
+              source: SourceType.GFS,
+              value: windData.windSpeed!,
+            },
+            {
+              metric: WindWaveMetric.WIND_DIRECTION,
+              source: SourceType.GFS,
+              value: windData.windDirection!,
+            },
+          ].filter((entry) => !isNil(entry.value?.value)),
+          repositories,
+          today,
         );
       }),
     ),
   );
-  logger.log('Completed updating hindcast data');
+  logger.log(
+    `Completed updating wind hindcast data (${windByGridPoint.size} unique Sofar grid points)`,
+  );
+};
+
+/**
+ * Fetch wave and wind forecast data and persist both. Kept for the CLI
+ * script; scheduled Cloud Functions call addWaveData / addWindData separately
+ * so each stays under the 540s timeout.
+ */
+export const addWindWaveData = async (
+  siteIds: number[],
+  repositories: Repositories,
+) => {
+  await addWaveData(siteIds, repositories);
+  await addWindData(siteIds, repositories);
 };

--- a/packages/api/src/utils/hindcast-wind-wave.ts
+++ b/packages/api/src/utils/hindcast-wind-wave.ts
@@ -261,7 +261,9 @@ export const addWindWaveData = async (
                 .values([
                   {
                     site,
-                    timestamp: DateTime.fromISO(value!.timestamp, { zone: 'utc' })
+                    timestamp: DateTime.fromISO(value!.timestamp, {
+                      zone: 'utc',
+                    })
                       .startOf('minute')
                       .toJSDate(),
                     metric,

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -1,6 +1,7 @@
 /* eslint-disable no-console */
 /** Utility functions to access the Open-Meteo Marine API for wave data. */
 import { chunk, isNil } from 'lodash';
+import pLimit from 'p-limit';
 import axios from './retry-axios';
 import {
   OPEN_METEO_BATCH_SIZE,
@@ -11,7 +12,6 @@ import {
 import { OpenMeteoMarineResponse, OpenMeteoWaveData } from './open-meteo.types';
 import { sendSlackMessage, SlackMessage } from './slack.utils';
 import { ValueWithTimestamp } from './sofar.types';
-import pLimit from 'p-limit';
 
 /**
  * Resolve the Marine API endpoint based on env config.

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -73,6 +73,10 @@ function extractLatestValue(
   if (!values || values.length === 0) return undefined;
 
   const now = Date.now();
+  const toEpochMs = (ts: string) => {
+    const hasTzInfo = /[zZ]|[+-]\d{2}:?\d{2}$/.test(ts);
+    return new Date(hasTzInfo ? ts : `${ts}Z`).getTime();
+  };
 
   const validEntries = values
     .map((value, index) => ({ value, timestamp: times[index] }))
@@ -80,7 +84,7 @@ function extractLatestValue(
       (entry): entry is { value: number; timestamp: string } =>
         !isNil(entry.value) &&
         !Number.isNaN(entry.value) &&
-        new Date(entry.timestamp).getTime() <= now,
+        toEpochMs(entry.timestamp) <= now,
     );
 
   return validEntries.length > 0

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -112,6 +112,7 @@ async function openMeteoMarineFetch(
         longitude: longitudes,
         hourly: 'wave_height,wave_direction,wave_period',
         cell_selection: 'sea',
+        timezone: 'UTC',
         past_days: 1,
         forecast_days: 1,
         ...(process.env.OPEN_METEO_API_KEY && {

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -1,17 +1,21 @@
 /* eslint-disable no-console */
 /** Utility functions to access the Open-Meteo Marine API for wave data. */
 import { chunk, isNil } from 'lodash';
-import pLimit from 'p-limit';
 import axios from './retry-axios';
 import {
   OPEN_METEO_BATCH_SIZE,
-  OPEN_METEO_CONCURRENCY,
   OPEN_METEO_CUSTOMER_URL,
   OPEN_METEO_FREE_URL,
+  OPEN_METEO_REQUEST_DELAY_MS,
 } from './constants';
 import { OpenMeteoMarineResponse, OpenMeteoWaveData } from './open-meteo.types';
 import { sendSlackMessage, SlackMessage } from './slack.utils';
 import { ValueWithTimestamp } from './sofar.types';
+
+const delay = (ms: number) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 /**
  * Resolve the Marine API endpoint based on env config.
@@ -107,6 +111,7 @@ async function openMeteoMarineFetch(
 
   try {
     const response = await axios.get(getOpenMeteoUrl(), {
+      timeout: 15000,
       params: {
         latitude: latitudes,
         longitude: longitudes,
@@ -154,10 +159,19 @@ export async function openMeteoMarineBatch(
 ): Promise<(OpenMeteoWaveData | undefined)[]> {
   const batches = chunk(coordinates, OPEN_METEO_BATCH_SIZE);
 
-  const limit = pLimit(OPEN_METEO_CONCURRENCY);
-  const batchResults = await Promise.all(
-    batches.map((batch) => limit(() => openMeteoMarineFetch(batch))),
+  // Dispatch batches one at a time with a fixed pause between requests,
+  // rather than using concurrency + stagger. Open-Meteo's free tier
+  // rate limit is strict enough that true sequential pacing is more
+  // reliable than any level of parallelism.
+  const results = await batches.reduce(
+    async (accPromise, batch) => {
+      const acc = await accPromise;
+      const result = await openMeteoMarineFetch(batch);
+      await delay(OPEN_METEO_REQUEST_DELAY_MS);
+      return [...acc, result];
+    },
+    Promise.resolve([] as (OpenMeteoWaveData | undefined)[][]),
   );
 
-  return batchResults.flat();
+  return results.flat();
 }

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -1,0 +1,155 @@
+/* eslint-disable no-console */
+/** Utility functions to access the Open-Meteo Marine API for wave data. */
+import { chunk, isNil } from 'lodash';
+import pLimit from 'p-limit';
+import axios from './retry-axios';
+import {
+  OPEN_METEO_BATCH_SIZE,
+  OPEN_METEO_CONCURRENCY,
+  OPEN_METEO_CUSTOMER_URL,
+  OPEN_METEO_FREE_URL,
+} from './constants';
+import { OpenMeteoMarineResponse, OpenMeteoWaveData } from './open-meteo.types';
+import { sendSlackMessage, SlackMessage } from './slack.utils';
+import { ValueWithTimestamp } from './sofar.types';
+
+/**
+ * Resolve the Marine API endpoint based on env config.
+ * Priority: OPEN_METEO_BASE_URL > customer URL (if API key set) > free URL.
+ */
+function getOpenMeteoUrl(): string {
+  if (process.env.OPEN_METEO_BASE_URL) {
+    return process.env.OPEN_METEO_BASE_URL;
+  }
+  return process.env.OPEN_METEO_API_KEY
+    ? OPEN_METEO_CUSTOMER_URL
+    : OPEN_METEO_FREE_URL;
+}
+
+async function openMeteoErrorHandler({
+  error,
+  sendToSlack = false,
+}: {
+  error: any;
+  sendToSlack?: boolean;
+}) {
+  if (error.response) {
+    const reason = error.response.data?.reason || '';
+    const message = `Open-Meteo API responded with a ${error.response.status} status. ${reason}`;
+    console.error(message);
+
+    if (!sendToSlack) return;
+
+    if ([401, 403, 429].includes(error.response.status)) {
+      const messageTemplate: SlackMessage = {
+        channel: process.env.SLACK_BOT_CHANNEL as string,
+        text: message,
+        mrkdwn: true,
+      };
+      await sendSlackMessage(
+        messageTemplate,
+        process.env.SLACK_BOT_TOKEN as string,
+      );
+    }
+  } else {
+    console.error(`An error occurred accessing the Open-Meteo API - ${error}`);
+  }
+}
+
+/**
+ * Pick the most recent non-null hourly value at or before "now".
+ *
+ * Open-Meteo returns hourly arrays that include past + forecast values.
+ * We want the latest observed/hindcast value, matching the prior Sofar
+ * behaviour (which returned the last entry of a past-only response).
+ *
+ * Implemented functionally (map + filter) rather than an imperative
+ * backwards loop, per project ESLint rules disallowing mutation/continue.
+ */
+function extractLatestValue(
+  times: string[],
+  values: (number | null)[] | undefined,
+): ValueWithTimestamp | undefined {
+  if (!values || values.length === 0) return undefined;
+
+  const now = Date.now();
+
+  const validEntries = values
+    .map((value, index) => ({ value, timestamp: times[index] }))
+    .filter(
+      (entry): entry is { value: number; timestamp: string } =>
+        !isNil(entry.value) &&
+        !Number.isNaN(entry.value) &&
+        new Date(entry.timestamp).getTime() <= now,
+    );
+
+  return validEntries.length > 0
+    ? validEntries[validEntries.length - 1]
+    : undefined;
+}
+
+/**
+ * Fetch wave data for one batch of sites in a single Marine API call.
+ * Returns one OpenMeteoWaveData per input coordinate, in the same order.
+ * On error, returns an array of undefined so callers can skip those sites.
+ */
+async function openMeteoMarineFetch(
+  coordinates: Array<[number, number]>,
+): Promise<(OpenMeteoWaveData | undefined)[]> {
+  if (coordinates.length === 0) return [];
+
+  const latitudes = coordinates.map(([lat]) => lat).join(',');
+  const longitudes = coordinates.map(([, lng]) => lng).join(',');
+
+  try {
+    const response = await axios.get(getOpenMeteoUrl(), {
+      params: {
+        latitude: latitudes,
+        longitude: longitudes,
+        hourly: 'wave_height,wave_direction,wave_period',
+        cell_selection: 'sea',
+        past_days: 1,
+        forecast_days: 1,
+        ...(process.env.OPEN_METEO_API_KEY && {
+          apikey: process.env.OPEN_METEO_API_KEY,
+        }),
+      },
+    });
+
+    const results: OpenMeteoMarineResponse[] = Array.isArray(response.data)
+      ? response.data
+      : [response.data];
+
+    return results.map((r) => {
+      const times = r.hourly?.time ?? [];
+      return {
+        waveHeight: extractLatestValue(times, r.hourly?.wave_height),
+        waveDirection: extractLatestValue(times, r.hourly?.wave_direction),
+        wavePeriod: extractLatestValue(times, r.hourly?.wave_period),
+      };
+    });
+  } catch (error) {
+    await openMeteoErrorHandler({ error, sendToSlack: true });
+    return coordinates.map(() => undefined);
+  }
+}
+
+/**
+ * Fetch wave data for an arbitrary number of sites, split into batched
+ * Marine API calls. Returns results in the same order as input.
+ *
+ * Uses lodash `chunk` rather than a manual loop + push, per project
+ * ESLint rules disallowing mutating array methods.
+ */
+export async function openMeteoMarineBatch(
+  coordinates: Array<[number, number]>,
+): Promise<(OpenMeteoWaveData | undefined)[]> {
+  const batches = chunk(coordinates, OPEN_METEO_BATCH_SIZE);
+
+  const limit = pLimit(OPEN_METEO_CONCURRENCY);
+  const batchResults = await Promise.all(
+    batches.map((batch) => limit(() => openMeteoMarineFetch(batch))),
+  );
+
+  return batchResults.flat();
+}

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -120,7 +120,10 @@ async function openMeteoMarineFetch(
       ? response.data
       : [response.data];
 
-    return results.map((r) => {
+    return coordinates.map((_, i) => {
+      const r = results[i];
+      if (!r) return undefined;
+
       const times = r.hourly?.time ?? [];
       return {
         waveHeight: extractLatestValue(times, r.hourly?.wave_height),

--- a/packages/api/src/utils/open-meteo.ts
+++ b/packages/api/src/utils/open-meteo.ts
@@ -4,18 +4,14 @@ import { chunk, isNil } from 'lodash';
 import axios from './retry-axios';
 import {
   OPEN_METEO_BATCH_SIZE,
+  OPEN_METEO_CONCURRENCY,
   OPEN_METEO_CUSTOMER_URL,
   OPEN_METEO_FREE_URL,
-  OPEN_METEO_REQUEST_DELAY_MS,
 } from './constants';
 import { OpenMeteoMarineResponse, OpenMeteoWaveData } from './open-meteo.types';
 import { sendSlackMessage, SlackMessage } from './slack.utils';
 import { ValueWithTimestamp } from './sofar.types';
-
-const delay = (ms: number) =>
-  new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
+import pLimit from 'p-limit';
 
 /**
  * Resolve the Marine API endpoint based on env config.
@@ -159,19 +155,21 @@ export async function openMeteoMarineBatch(
 ): Promise<(OpenMeteoWaveData | undefined)[]> {
   const batches = chunk(coordinates, OPEN_METEO_BATCH_SIZE);
 
-  // Dispatch batches one at a time with a fixed pause between requests,
-  // rather than using concurrency + stagger. Open-Meteo's free tier
-  // rate limit is strict enough that true sequential pacing is more
-  // reliable than any level of parallelism.
-  const results = await batches.reduce(
-    async (accPromise, batch) => {
-      const acc = await accPromise;
-      const result = await openMeteoMarineFetch(batch);
-      await delay(OPEN_METEO_REQUEST_DELAY_MS);
-      return [...acc, result];
-    },
-    Promise.resolve([] as (OpenMeteoWaveData | undefined)[][]),
+  const limit = pLimit(OPEN_METEO_CONCURRENCY);
+  const firstAttempt = await Promise.all(
+    batches.map((batch) => limit(() => openMeteoMarineFetch(batch))),
   );
 
-  return results.flat();
+  // Retry only batches that came back entirely empty (likely a transient
+  // timeout/network blip), rather than alerting.
+  const retryResults = await Promise.all(
+    firstAttempt.map((result, i) => {
+      const batchFailed = result.every((r) => r === undefined);
+      return batchFailed
+        ? limit(() => openMeteoMarineFetch(batches[i]))
+        : Promise.resolve(result);
+    }),
+  );
+
+  return retryResults.flat();
 }

--- a/packages/api/src/utils/open-meteo.types.ts
+++ b/packages/api/src/utils/open-meteo.types.ts
@@ -1,0 +1,33 @@
+import { ValueWithTimestamp } from './sofar.types';
+
+/**
+ * Response shape from Open-Meteo Marine API.
+ * Multi-coordinate requests return an array of these.
+ * https://open-meteo.com/en/docs/marine-weather-api
+ */
+export interface OpenMeteoMarineResponse {
+  latitude: number;
+  longitude: number;
+  generationtime_ms: number;
+  utc_offset_seconds: number;
+  timezone: string;
+  timezone_abbreviation: string;
+  hourly?: {
+    time: string[];
+    wave_height?: (number | null)[];
+    wave_direction?: (number | null)[];
+    wave_period?: (number | null)[];
+  };
+  hourly_units?: Record<string, string>;
+}
+
+/**
+ * Latest observed wave values for a single site, after extraction from
+ * the Open-Meteo hourly response. Mirrors the per-variable shape used
+ * throughout the existing wind/wave pipeline.
+ */
+export interface OpenMeteoWaveData {
+  waveHeight?: ValueWithTimestamp;
+  waveDirection?: ValueWithTimestamp;
+  wavePeriod?: ValueWithTimestamp;
+}

--- a/packages/api/src/workers/spotterTimeSeries.ts
+++ b/packages/api/src/workers/spotterTimeSeries.ts
@@ -5,7 +5,7 @@ import { Site } from '../sites/sites.entity';
 import { Sources } from '../sites/sources.entity';
 import { TimeSeries } from '../time-series/time-series.entity';
 import { addSpotterData } from '../utils/spotter-time-series';
-import { addWindWaveData } from '../utils/hindcast-wind-wave';
+import { addWaveData, addWindData } from '../utils/hindcast-wind-wave';
 
 // since this is hourly run we want to only take the latest data.
 const DAYS_OF_SPOTTER_DATA = 1;
@@ -27,9 +27,15 @@ export function runSpotterTimeSeriesUpdate(
   );
 }
 
-export function runWindWaveTimeSeriesUpdate(dataSource: DataSource) {
-  return addWindWaveData([], {
-    siteRepository: dataSource.getRepository(Site),
-    hindcastRepository: dataSource.getRepository(ForecastData),
-  });
+const hindcastRepos = (dataSource: DataSource) => ({
+  siteRepository: dataSource.getRepository(Site),
+  hindcastRepository: dataSource.getRepository(ForecastData),
+});
+
+export function runWaveTimeSeriesUpdate(dataSource: DataSource) {
+  return addWaveData([], hindcastRepos(dataSource));
+}
+
+export function runWindTimeSeriesUpdate(dataSource: DataSource) {
+  return addWindData([], hindcastRepos(dataSource));
 }

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -62,7 +62,7 @@
     "react-markdown": "^10.1.0",
     "react-material-ui-carousel": "3.4.2",
     "react-redux": "^9.2.0",
-    "react-router-dom": "^7.15.0",
+    "react-router-dom": "^7.18.1",
     "react-router-hash-link": "^2.4.3",
     "react-slick": "^0.30.3",
     "react-swipeable-bottom-sheet": "^1.1.2",

--- a/packages/website/package.json
+++ b/packages/website/package.json
@@ -42,7 +42,7 @@
     "date-fns-tz": "^1.3.8",
     "firebase": "^11.0.2",
     "geolib": "^3.3.4",
-    "hono": "^4.12.21",
+    "hono": "^4.12.25",
     "immutable": "^4.3.8",
     "leaflet": "^1.9.4",
     "leaflet.locatecontrol": "^0.79.0",

--- a/packages/website/src/common/Chip/index.tsx
+++ b/packages/website/src/common/Chip/index.tsx
@@ -45,6 +45,7 @@ const useStyles = makeStyles((theme: Theme) =>
     button: {
       padding: 0,
       height: '100%',
+      minWidth: 58,
     },
   }),
 );

--- a/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-12 makeStyles-withMargin-13 css-1urtxze-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-18 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-19 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -92,28 +92,27 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-            style="display: flex; justify-content: flex-end;"
+            class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-18 css-x7bhrq-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item makeStyles-chip-19 makeStyles-chip-25 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-20 makeStyles-chip-26 css-x7bhrq-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-24 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-25 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <a
-                    class="makeStyles-link-22"
+                    class="makeStyles-link-23"
                     href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography
-                      classname="makeStyles-chipText-20"
+                      classname="makeStyles-chipText-21"
                     >
                       NOAA CRW
                     </mock-typography>

--- a/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/CoralBleaching/__snapshots__/index.test.tsx.snap
@@ -47,7 +47,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-12 makeStyles-withMargin-13 css-1urtxze-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-19 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -95,24 +95,24 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-18 css-x7bhrq-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item makeStyles-chip-20 makeStyles-chip-26 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-19 makeStyles-chip-25 css-x7bhrq-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-25 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-24 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <a
-                    class="makeStyles-link-23"
+                    class="makeStyles-link-22"
                     href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography
-                      classname="makeStyles-chipText-21"
+                      classname="makeStyles-chipText-20"
                     >
                       NOAA CRW
                     </mock-typography>

--- a/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-10 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-17 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-14 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -361,30 +361,30 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-16 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-18 makeStyles-chip-24 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-17 makeStyles-chip-23 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-23 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-22 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-21"
+                  class="makeStyles-link-20"
                   href="https://coralreefwatch.noaa.gov/"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-19"
+                    classname="makeStyles-chipText-18"
                   >
                     NOAA
                   </mock-typography>
                   <img
                     alt="sensor-type"
-                    class="makeStyles-sensorImage-22"
+                    class="makeStyles-sensorImage-21"
                     src="satellite.svg"
                   />
                 </a>

--- a/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Satellite/__snapshots__/index.test.tsx.snap
@@ -313,7 +313,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-10 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-16 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-14 makeStyles-dateInfoWrapper-17 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -358,34 +358,33 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-          style="display: flex; justify-content: flex-end;"
+          class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-16 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-17 makeStyles-chip-23 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-18 makeStyles-chip-24 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-22 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-23 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-20"
+                  class="makeStyles-link-21"
                   href="https://coralreefwatch.noaa.gov/"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-18"
+                    classname="makeStyles-chipText-19"
                   >
                     NOAA
                   </mock-typography>
                   <img
                     alt="sensor-type"
-                    class="makeStyles-sensorImage-21"
+                    class="makeStyles-sensorImage-22"
                     src="satellite.svg"
                   />
                 </a>

--- a/packages/website/src/common/SiteDetails/TemperatureChange/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/TemperatureChange/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`TemperatureChange card > should render with given state from Redux stor
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-18 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-22 makeStyles-dateInfoWrapper-25 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-22 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -124,30 +124,30 @@ exports[`TemperatureChange card > should render with given state from Redux stor
           class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-24 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-26 makeStyles-chip-32 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-25 makeStyles-chip-31 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-31 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-30 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-29"
+                  class="makeStyles-link-28"
                   href="https://coralreefwatch.noaa.gov/"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-27"
+                    classname="makeStyles-chipText-26"
                   >
                     NOAA
                   </mock-typography>
                   <img
                     alt="sensor-type"
-                    class="makeStyles-sensorImage-30"
+                    class="makeStyles-sensorImage-29"
                     src="satellite.svg"
                   />
                 </a>

--- a/packages/website/src/common/SiteDetails/TemperatureChange/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/TemperatureChange/__snapshots__/index.test.tsx.snap
@@ -76,7 +76,7 @@ exports[`TemperatureChange card > should render with given state from Redux stor
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-18 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-22 makeStyles-dateInfoWrapper-24 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-22 makeStyles-dateInfoWrapper-25 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -121,34 +121,33 @@ exports[`TemperatureChange card > should render with given state from Redux stor
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-          style="display: flex; justify-content: flex-end;"
+          class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-24 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-25 makeStyles-chip-31 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-26 makeStyles-chip-32 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-30 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-31 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-28"
+                  class="makeStyles-link-29"
                   href="https://coralreefwatch.noaa.gov/"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-26"
+                    classname="makeStyles-chipText-27"
                   >
                     NOAA
                   </mock-typography>
                   <img
                     alt="sensor-type"
-                    class="makeStyles-sensorImage-29"
+                    class="makeStyles-sensorImage-30"
                     src="satellite.svg"
                   />
                 </a>

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-12 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-19 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -294,25 +294,25 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-18 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-20 makeStyles-chip-26 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-19 makeStyles-chip-25 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-25 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-24 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-23"
+                  class="makeStyles-link-22"
                   data-discover="true"
                   href="/sites/1"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-21"
+                    classname="makeStyles-chipText-20"
                   >
                     VIEW UPLOAD
                   </mock-typography>

--- a/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/WaterSampling/__snapshots__/index.test.tsx.snap
@@ -248,7 +248,7 @@ exports[`renders as expected 1`] = `
         class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-12 false css-1urtxze-MuiGrid-root"
       >
         <div
-          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-18 css-x7bhrq-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-16 makeStyles-dateInfoWrapper-19 css-x7bhrq-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -291,29 +291,28 @@ exports[`renders as expected 1`] = `
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-          style="display: flex; justify-content: flex-end;"
+          class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-18 css-x7bhrq-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-chip-19 makeStyles-chip-25 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-chip-20 makeStyles-chip-26 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
             >
               <button
-                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-24 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-25 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                 tabindex="0"
                 type="button"
               >
                 <a
-                  class="makeStyles-link-22"
+                  class="makeStyles-link-23"
                   data-discover="true"
                   href="/sites/1"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
                   <mock-typography
-                    classname="makeStyles-chipText-20"
+                    classname="makeStyles-chipText-21"
                   >
                     VIEW UPLOAD
                   </mock-typography>

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-19 false css-1urtxze-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-23 makeStyles-dateInfoWrapper-25 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-23 makeStyles-dateInfoWrapper-26 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -239,30 +239,55 @@ exports[`renders as expected 1`] = `
             </div>
           </div>
           <div
-            class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-            style="display: flex; justify-content: flex-end;"
+            class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-25 css-x7bhrq-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item makeStyles-chip-26 makeStyles-chip-32 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-27 makeStyles-chip-33 css-x7bhrq-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-31 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-32 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <a
-                    class="makeStyles-link-29"
+                    class="makeStyles-link-30"
                     href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography
-                      classname="makeStyles-chipText-27"
+                      classname="makeStyles-chipText-28"
                     >
-                      SOFAR MODEL
+                      WIND
+                    </mock-typography>
+                  </a>
+                </button>
+              </div>
+            </div>
+            <div
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-27 makeStyles-chip-34 css-x7bhrq-MuiGrid-root"
+            >
+              <div
+                class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
+              >
+                <button
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-32 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  tabindex="0"
+                  type="button"
+                >
+                  <a
+                    class="makeStyles-link-30"
+                    href="https://open-meteo.com/en/docs/marine-weather-api"
+                    rel="noopener noreferrer"
+                    target="_blank"
+                  >
+                    <mock-typography
+                      classname="makeStyles-chipText-28"
+                    >
+                      WAVE
                     </mock-typography>
                   </a>
                 </button>

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`renders as expected 1`] = `
           class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-19 false css-1urtxze-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-23 makeStyles-dateInfoWrapper-26 css-x7bhrq-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-23 css-x7bhrq-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -242,24 +242,24 @@ exports[`renders as expected 1`] = `
             class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-25 css-x7bhrq-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item makeStyles-chip-27 makeStyles-chip-33 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-26 makeStyles-chip-32 css-x7bhrq-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-32 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-31 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <a
-                    class="makeStyles-link-30"
+                    class="makeStyles-link-29"
                     href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography
-                      classname="makeStyles-chipText-28"
+                      classname="makeStyles-chipText-27"
                     >
                       WIND
                     </mock-typography>
@@ -268,24 +268,24 @@ exports[`renders as expected 1`] = `
               </div>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-item makeStyles-chip-27 makeStyles-chip-34 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item makeStyles-chip-26 makeStyles-chip-33 css-x7bhrq-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-32 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-31 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
                   <a
-                    class="makeStyles-link-30"
+                    class="makeStyles-link-29"
                     href="https://open-meteo.com/en/docs/marine-weather-api"
                     rel="noopener noreferrer"
                     target="_blank"
                   >
                     <mock-typography
-                      classname="makeStyles-chipText-28"
+                      classname="makeStyles-chipText-27"
                     >
                       WAVE
                     </mock-typography>

--- a/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/SiteDetails/Waves/__snapshots__/index.test.tsx.snap
@@ -122,14 +122,7 @@ exports[`renders as expected 1`] = `
                 color="textSecondary"
                 variant="h3"
               >
-                0.6
-              </mock-typography>
-              <mock-typography
-                classname="makeStyles-contentUnits-6"
-                color="textSecondary"
-                variant="h6"
-              >
-                m
+                - -
               </mock-typography>
             </div>
           </div>
@@ -151,14 +144,7 @@ exports[`renders as expected 1`] = `
                 color="textSecondary"
                 variant="h3"
               >
-                6
-              </mock-typography>
-              <mock-typography
-                classname="makeStyles-contentUnits-6"
-                color="textSecondary"
-                variant="h6"
-              >
-                s
+                - -
               </mock-typography>
             </div>
           </div>
@@ -175,17 +161,12 @@ exports[`renders as expected 1`] = `
             <div
               class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
             >
-              <img
-                alt="arrow"
-                class="makeStyles-arrow-14 makeStyles-wavesDirectionArrow-16 makeStyles-wavesDirectionArrow-18"
-                src="data:image/svg+xml,%3csvg%20viewBox='0%200%2024%2024'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='none'%20fill-rule='evenodd'%3e%3ccircle%20cx='12'%20cy='12'%20r='11.25'%20stroke='%23000'%20stroke-width='1.5'/%3e%3cpath%20d='M11.241%205.095L6.784%209.551c-.41.41-.41%201.095%200%201.506.41.41%201.095.41%201.506%200l2.647-2.631v9.734c0%20.593.471%201.065%201.064%201.065.593%200%201.065-.472%201.065-1.065V8.426l2.632%202.631a1.074%201.074%200%20001.825-.76%201.07%201.07%200%2000-.32-.76l-4.441-4.442a1.083%201.083%200%2000-.76-.32c-.29%200-.563.107-.761.32z'%20fill='%23000'/%3e%3c/g%3e%3c/svg%3e"
-              />
               <mock-typography
                 classname="makeStyles-contentTextValues-5"
                 color="textSecondary"
                 variant="h3"
               >
-                152°
+                - -
               </mock-typography>
             </div>
           </div>
@@ -226,7 +207,7 @@ exports[`renders as expected 1`] = `
                     classname="makeStyles-updateInfoText-22"
                     variant="caption"
                   >
-                    Valid 1 day ago
+                    No data available
                   </mock-typography>
                   <mock-typography
                     classname="makeStyles-updateInfoText-22"

--- a/packages/website/src/common/SiteDetails/Waves/index.tsx
+++ b/packages/website/src/common/SiteDetails/Waves/index.tsx
@@ -77,8 +77,9 @@ function Waves({ data, hasSpotter }: WavesProps) {
   const spotterValidityLimit = 12 * 60 * 60 * 1000; // 12 hours in milliseconds
   const now = Date.now();
 
-  // Only show as live Spotter data if site actually has a Spotter
-  // Otherwise it's model data regardless of timestamp
+  // Only show as live Spotter data if site actually has a Spotter.
+  // Wind and wave now come from different providers, so each is
+  // evaluated independently.
   const hasSpotterWindWaveData = Boolean(
     hasSpotter &&
     ((windSpeed?.timestamp &&
@@ -88,6 +89,11 @@ function Waves({ data, hasSpotter }: WavesProps) {
           spotterValidityLimit)),
   );
 
+  const windRelativeTime = hasSpotterWindWaveData
+    ? windSpeed?.timestamp && toRelativeTime(windSpeed.timestamp)
+    : significantWaveHeight?.timestamp &&
+      toRelativeTime(significantWaveHeight.timestamp);
+
   // Make sure to get the direction the wind is COMING FROM.
   // use `numberUtils.invertDirection` if needed.
   const windDirectionFrom = windDirection?.value;
@@ -96,11 +102,6 @@ function Waves({ data, hasSpotter }: WavesProps) {
     windDirection: windDirectionFrom,
     wavesDirection: waveDirectionFrom,
   });
-
-  const windRelativeTime = hasSpotterWindWaveData
-    ? windSpeed?.timestamp && toRelativeTime(windSpeed.timestamp)
-    : significantWaveHeight?.timestamp &&
-      toRelativeTime(significantWaveHeight.timestamp);
 
   return (
     <Card className={classes.root}>
@@ -289,7 +290,14 @@ function Waves({ data, hasSpotter }: WavesProps) {
             live={hasSpotterWindWaveData}
             frequency={hasSpotterWindWaveData ? 'hourly' : 'every 6 hours'}
             href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
-            imageText={hasSpotterWindWaveData ? undefined : 'SOFAR MODEL'}
+            imageText={hasSpotterWindWaveData ? undefined : 'WIND'}
+            chipWidth={hasSpotterWindWaveData ? undefined : 110}
+            secondaryHref={
+              hasSpotterWindWaveData
+                ? undefined
+                : 'https://open-meteo.com/en/docs/marine-weather-api'
+            }
+            secondaryImageText={hasSpotterWindWaveData ? undefined : 'WAVE'}
           />
         </Grid>
       </CardContent>

--- a/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders as expected 1`] = `
     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-1 false css-1urtxze-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-5 makeStyles-dateInfoWrapper-8 css-x7bhrq-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-5 css-x7bhrq-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -54,18 +54,18 @@ exports[`renders as expected 1`] = `
       class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-7 css-x7bhrq-MuiGrid-root"
     >
       <div
-        class="MuiGrid-root MuiGrid-item makeStyles-chip-9 makeStyles-chip-15 css-x7bhrq-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item makeStyles-chip-8 makeStyles-chip-14 css-x7bhrq-MuiGrid-root"
       >
         <div
           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-14 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-13 css-1ysap08-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
             <mock-typography
-              classname="makeStyles-chipText-10"
+              classname="makeStyles-chipText-9"
             >
               NOAA
             </mock-typography>

--- a/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/common/UpdateInfo/__snapshots__/index.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`renders as expected 1`] = `
     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-1 false css-1urtxze-MuiGrid-root"
   >
     <div
-      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-5 makeStyles-dateInfoWrapper-7 css-x7bhrq-MuiGrid-root"
+      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-5 makeStyles-dateInfoWrapper-8 css-x7bhrq-MuiGrid-root"
     >
       <div
         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -51,22 +51,21 @@ exports[`renders as expected 1`] = `
       </div>
     </div>
     <div
-      class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-      style="display: flex; justify-content: flex-end;"
+      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-7 css-x7bhrq-MuiGrid-root"
     >
       <div
-        class="MuiGrid-root MuiGrid-item makeStyles-chip-8 makeStyles-chip-14 css-x7bhrq-MuiGrid-root"
+        class="MuiGrid-root MuiGrid-item makeStyles-chip-9 makeStyles-chip-15 css-x7bhrq-MuiGrid-root"
       >
         <div
           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
         >
           <button
-            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-13 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-14 css-1ysap08-MuiButtonBase-root-MuiButton-root"
             tabindex="0"
             type="button"
           >
             <mock-typography
-              classname="makeStyles-chipText-9"
+              classname="makeStyles-chipText-10"
             >
               NOAA
             </mock-typography>

--- a/packages/website/src/common/UpdateInfo/index.tsx
+++ b/packages/website/src/common/UpdateInfo/index.tsx
@@ -5,8 +5,6 @@ import { grey } from '@mui/material/colors';
 import UpdateIcon from '@mui/icons-material/Update';
 import Chip from '../Chip';
 
-const CHIP_SMALL_DEFAULT_WIDTH = 48;
-const CHIP_LARGE_DEFAULT_WIDTH = 60;
 const UPDATE_ICON_SIZE = 24;
 const UPDATE_ICON_RIGHT_MARGIN = 4;
 
@@ -35,20 +33,19 @@ const useStyles = makeStyles((theme: Theme) => ({
       fontSize: 8.5,
     },
   },
-  dateInfoWrapper: ({ chipWidth }: { chipWidth?: number }) => ({
-    width: `calc(100% - ${chipWidth || CHIP_LARGE_DEFAULT_WIDTH}px)`,
-    [theme.breakpoints.only('md')]: {
-      width: `calc(100% - ${chipWidth || CHIP_SMALL_DEFAULT_WIDTH}px)`,
-    },
+  dateInfoWrapper: {
+    flex: '1 1 auto',
+    minWidth: 0,
     display: 'flex',
     justifyContent: 'flex-start',
-  }),
+  },
   dateInfo: {
     width: `calc(100% - ${UPDATE_ICON_RIGHT_MARGIN + UPDATE_ICON_SIZE}px)`,
   },
   chipsWrapper: {
     display: 'flex',
     gap: 4,
+    flexShrink: 0,
   },
 }));
 

--- a/packages/website/src/common/UpdateInfo/index.tsx
+++ b/packages/website/src/common/UpdateInfo/index.tsx
@@ -46,6 +46,10 @@ const useStyles = makeStyles((theme: Theme) => ({
   dateInfo: {
     width: `calc(100% - ${UPDATE_ICON_RIGHT_MARGIN + UPDATE_ICON_SIZE}px)`,
   },
+  chipsWrapper: {
+    display: 'flex',
+    gap: 4,
+  },
 }));
 
 function UpdateInfo({
@@ -60,8 +64,14 @@ function UpdateInfo({
   chipWidth,
   subtitle,
   onClick,
+  secondaryImage,
+  secondaryImageText,
+  secondaryLive = false,
+  secondaryHref,
+  secondaryOnClick,
 }: UpdateInfoProps) {
   const classes = useStyles({ chipWidth });
+  const hasSecondaryChip = Boolean(secondaryImageText || secondaryImage);
   return (
     <Grid
       className={`${classes.updateInfo} ${withMargin && classes.withMargin}`}
@@ -93,7 +103,7 @@ function UpdateInfo({
           </Grid>
         </Grid>
       </Grid>
-      <Grid item style={{ display: 'flex', justifyContent: 'flex-end' }}>
+      <Grid item className={classes.chipsWrapper}>
         <Chip
           live={live}
           href={live ? undefined : href}
@@ -101,6 +111,15 @@ function UpdateInfo({
           imageText={imageText}
           onClick={onClick}
         />
+        {hasSecondaryChip && (
+          <Chip
+            live={secondaryLive}
+            href={secondaryLive ? undefined : secondaryHref}
+            image={secondaryImage}
+            imageText={secondaryImageText}
+            onClick={secondaryOnClick}
+          />
+        )}
       </Grid>
     </Grid>
   );
@@ -118,6 +137,11 @@ interface UpdateInfoProps {
   withMargin?: boolean;
   chipWidth?: number;
   onClick?: () => void;
+  secondaryImage?: string;
+  secondaryImageText?: string;
+  secondaryLive?: boolean;
+  secondaryHref?: string;
+  secondaryOnClick?: () => void;
 }
 
 export default UpdateInfo;

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Site Detail Page > should render with given state from Redux store > snapshot-with-data 1`] = `
 <div>
   <mock-appbar
-    classname="NavBar-appBar-818 NavBar-appBarXs-820"
+    classname="NavBar-appBar-824 NavBar-appBarXs-826"
     color="primary"
     position="static"
   >
     <mock-toolbar
-      classname="NavBar-toolbar-821"
+      classname="NavBar-toolbar-827"
     >
       <mock-drawer
         anchor="left"
@@ -22,7 +22,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           <mock-clear />
         </mock-iconbutton>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/"
           tabindex="0"
@@ -35,7 +35,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/map"
           tabindex="0"
@@ -48,7 +48,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/register"
           tabindex="0"
@@ -61,7 +61,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://highlights.aqualink.org"
           tabindex="0"
           target="_blank"
@@ -75,7 +75,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </mock-link>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://bristlemouth.aqualink.org"
           tabindex="0"
           target="_blank"
@@ -89,7 +89,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </mock-link>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/tracker"
           tabindex="0"
@@ -102,7 +102,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/about"
           tabindex="0"
@@ -115,7 +115,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/faq"
           tabindex="0"
@@ -128,7 +128,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/buoy"
           tabindex="0"
@@ -141,7 +141,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/drones"
           tabindex="0"
@@ -154,7 +154,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-832 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://highlights.aqualink.org/contact-us"
           tabindex="0"
           target="_blank"
@@ -184,7 +184,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             role="group"
           >
             <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-831 MuiButtonGroup-firstButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-837 MuiButtonGroup-firstButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
               href="https://github.com/aqualinkorg/aqualink-app"
               tabindex="0"
               target="_blank"
@@ -197,7 +197,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               GitHub
             </a>
             <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-831 MuiButtonGroup-lastButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-837 MuiButtonGroup-lastButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
               href="https://ovio.org/project/aqualinkorg/aqualink-app"
               tabindex="0"
               target="_blank"
@@ -239,7 +239,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </svg>
             </mock-iconbutton>
             <mock-link
-              classname="NavBar-navBarLink-819"
+              classname="NavBar-navBarLink-825"
               href="/map"
               underline="hover"
             >
@@ -265,10 +265,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-3 css-x5eji4-MuiGrid-root"
           >
             <div
-              class="Search-searchBar-833"
+              class="Search-searchBar-839"
             >
               <div
-                class="Search-searchBarIcon-834"
+                class="Search-searchBarIcon-840"
               >
                 <mock-iconbutton
                   size="small"
@@ -287,10 +287,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-iconbutton>
               </div>
               <div
-                class="Search-searchBarText-835"
+                class="Search-searchBarText-841"
               >
                 <div
-                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-836 css-1tlcqt-MuiAutocomplete-root"
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-842 css-1tlcqt-MuiAutocomplete-root"
                 >
                   <div
                     class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -358,7 +358,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </div>
         </mock-hidden>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8 MuiGrid-grid-sm-4 MuiGrid-grid-md-3 NavBar-languageUserWrapper-829 css-1odkxmp-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8 MuiGrid-grid-sm-4 MuiGrid-grid-md-3 NavBar-languageUserWrapper-835 css-1odkxmp-MuiGrid-root"
         >
           <mock-tooltip
             title="Translate"
@@ -387,12 +387,12 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           >
             Mock User
             <mock-iconbutton
-              classname="NavBar-button-828"
+              classname="NavBar-button-834"
               size="large"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium NavBar-expandIcon-827 css-1umw9bq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium NavBar-expandIcon-833 css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ExpandMoreIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -403,22 +403,22 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </svg>
             </mock-iconbutton>
             <mock-menu
-              classname="NavBar-userMenu-824"
+              classname="NavBar-userMenu-830"
               keepmounted="true"
               menulistprops="[object Object]"
               open="false"
               popoverclasses="[object Object]"
             >
               <mock-divider
-                classname="NavBar-userMenuDivider-823"
+                classname="NavBar-userMenuDivider-829"
               />
               <a
-                class="NavBar-menuItemLink-826"
+                class="NavBar-menuItemLink-832"
                 data-discover="true"
                 href="/dashboard"
               >
                 <mock-menuitem
-                  classname="NavBar-menuItem-825"
+                  classname="NavBar-menuItem-831"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-iqna23-MuiGrid-root"
@@ -451,10 +451,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-menuitem>
               </a>
               <mock-divider
-                classname="NavBar-userMenuDivider-823"
+                classname="NavBar-userMenuDivider-829"
               />
               <mock-menuitem
-                classname="NavBar-menuItem-825"
+                classname="NavBar-menuItem-831"
               >
                 <div
                   class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-iqna23-MuiGrid-root"
@@ -492,10 +492,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             style="margin: 0px; padding-top: 0px;"
           >
             <div
-              class="Search-searchBar-833"
+              class="Search-searchBar-839"
             >
               <div
-                class="Search-searchBarIcon-834"
+                class="Search-searchBarIcon-840"
               >
                 <mock-iconbutton
                   size="small"
@@ -514,10 +514,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-iconbutton>
               </div>
               <div
-                class="Search-searchBarText-835"
+                class="Search-searchBarText-841"
               >
                 <div
-                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-836 css-1tlcqt-MuiAutocomplete-root"
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-842 css-1tlcqt-MuiAutocomplete-root"
                 >
                   <div
                     class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -595,7 +595,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root RegisterDialog-dialogHeader-840 css-149tc0y-MuiCardHeader-root"
+        class="MuiCardHeader-root RegisterDialog-dialogHeader-846 css-149tc0y-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -618,7 +618,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="RegisterDialog-dialogHeaderSecondPart-841"
+                    classname="RegisterDialog-dialogHeaderSecondPart-847"
                     variant="h4"
                   >
                     link
@@ -629,7 +629,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
               >
                 <mock-iconbutton
-                  classname="RegisterDialog-closeButton-839"
+                  classname="RegisterDialog-closeButton-845"
                   size="small"
                 >
                   <svg
@@ -654,7 +654,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-ldi2p4-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 RegisterDialog-dialogContentTitle-842 css-9ve18c-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 RegisterDialog-dialogContentTitle-848 css-9ve18c-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
@@ -671,10 +671,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
           >
             <form
-              class="RegisterDialog-form-843"
+              class="RegisterDialog-form-849"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-844 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -692,7 +692,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-845 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="firstName"
                       name="firstName"
                       placeholder="First Name"
@@ -715,7 +715,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-844 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -733,7 +733,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-845 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="lastName"
                       name="lastName"
                       placeholder="Last Name"
@@ -756,7 +756,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-844 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -774,7 +774,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-845 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="organization"
                       name="organization"
                       placeholder="Organization"
@@ -797,7 +797,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-844 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -815,7 +815,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-845 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="emailAddress"
                       name="emailAddress"
                       placeholder="Email Address"
@@ -838,7 +838,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-844 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -856,7 +856,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-845 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="password"
                       name="password"
                       placeholder="Password"
@@ -886,7 +886,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 >
                   <mock-checkbox
                     checked="false"
-                    classname="RegisterDialog-termsCheckbox-848"
+                    classname="RegisterDialog-termsCheckbox-854"
                     color="primary"
                   />
                 </div>
@@ -895,14 +895,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 >
                   <mock-box>
                     <mock-typography
-                      classname="RegisterDialog-formText-846"
+                      classname="RegisterDialog-formText-852"
                       color="textSecondary"
                       variant="subtitle1"
                     >
                       I have read the
                        
                       <a
-                        class="RegisterDialog-termsLink-849"
+                        class="RegisterDialog-termsLink-855"
                         data-discover="true"
                         href="/terms"
                       >
@@ -913,7 +913,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-button-847 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-button-853 css-z4k4cw-MuiGrid-root"
               >
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth css-14fik5b-MuiButtonBase-root-MuiButton-root"
@@ -928,7 +928,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <mock-typography
-                  classname="RegisterDialog-formText-846"
+                  classname="RegisterDialog-formText-852"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -958,7 +958,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
       elevation="0"
     >
       <div
-        class="MuiCardHeader-root SignInDialog-dialogHeader-851 css-149tc0y-MuiCardHeader-root"
+        class="MuiCardHeader-root SignInDialog-dialogHeader-857 css-149tc0y-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -981,7 +981,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="SignInDialog-dialogHeaderSecondPart-852"
+                    classname="SignInDialog-dialogHeaderSecondPart-858"
                     variant="h4"
                   >
                     link
@@ -992,7 +992,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
               >
                 <mock-iconbutton
-                  classname="SignInDialog-closeButton-850"
+                  classname="SignInDialog-closeButton-856"
                   size="small"
                 >
                   <svg
@@ -1077,7 +1077,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-ldi2p4-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 SignInDialog-dialogContentTitle-853 css-9ve18c-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 SignInDialog-dialogContentTitle-859 css-9ve18c-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
@@ -1094,10 +1094,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
           >
             <form
-              class="SignInDialog-form-854"
+              class="SignInDialog-form-860"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-855 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-861 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1115,7 +1115,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-856 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-862 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="emailAddress"
                       name="emailAddress"
                       placeholder="Email Address"
@@ -1138,7 +1138,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-855 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-861 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1156,7 +1156,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-856 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-862 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="password"
                       name="password"
                       placeholder="Password"
@@ -1182,7 +1182,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary SignInDialog-forgotPasswordButton-859 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary SignInDialog-forgotPasswordButton-865 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
@@ -1195,7 +1195,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </button>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-button-858 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-button-864 css-z4k4cw-MuiGrid-root"
               >
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth css-14fik5b-MuiButtonBase-root-MuiButton-root"
@@ -1209,7 +1209,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-857"
+                  classname="SignInDialog-formText-863"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -1305,7 +1305,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-174grhv-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-868 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-874 css-x7bhrq-MuiGrid-root"
             >
               <mock-iconbutton
                 aria-label="menu"
@@ -1327,7 +1327,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </mock-iconbutton>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 SiteInfo-headerWrapper-869 css-1accxqv-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 SiteInfo-headerWrapper-875 css-1accxqv-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8 css-1f6br5b-MuiGrid-root"
@@ -1339,7 +1339,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item SiteInfo-siteNameWrapper-870 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item SiteInfo-siteNameWrapper-876 css-x7bhrq-MuiGrid-root"
                     >
                       <mock-typography
                         variant="h4"
@@ -1348,7 +1348,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </mock-typography>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-868 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-874 css-x7bhrq-MuiGrid-root"
                     >
                       <mock-tooltip
                         arrow="true"
@@ -1356,7 +1356,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         title="Add to your dashboard"
                       >
                         <mock-iconbutton
-                          classname="CollectionButton-root-871"
+                          classname="CollectionButton-root-877"
                           disabled="false"
                           size="large"
                         >
@@ -1405,10 +1405,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1wocbzy-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-row-884 css-1d4pq44-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-row-890 css-1d4pq44-MuiGrid-root"
             >
               <mock-box
-                classname="Title-root-889"
+                classname="Title-root-895"
               >
                 <div
                   class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
@@ -1442,7 +1442,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
             >
               <div
-                class="makeStyles-container-885"
+                class="makeStyles-container-891"
               >
                 <mock-map
                   polygon="[object Object]"
@@ -1459,7 +1459,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
             >
               <div
-                class="makeStyles-container-885"
+                class="makeStyles-container-891"
               >
                 <mock-featuredmedia
                   featuredimage="image-url"
@@ -1471,20 +1471,20 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-metricsWrapper-882 css-m4714y-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-metricsWrapper-888 css-m4714y-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-872"
+              class="makeStyles-card-878"
             >
               <mock-card
-                classname="Satellite-root-905"
+                classname="Satellite-root-911"
                 style="background-color: rgb(8, 91, 163);"
               >
                 <div
-                  class="MuiCardHeader-root Satellite-header-900 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Satellite-header-906 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -1499,7 +1499,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Satellite-cardTitle-899"
+                            classname="Satellite-cardTitle-905"
                             variant="h6"
                           >
                             SATELLITE OBSERVATION
@@ -1510,7 +1510,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Satellite-content-906"
+                  classname="Satellite-content-912"
                 >
                   <mock-box
                     display="flex"
@@ -1524,7 +1524,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-901"
+                          classname="Satellite-contentTextTitles-907"
                           variant="subtitle2"
                         >
                           SURFACE TEMP
@@ -1533,7 +1533,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title=""
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-902"
+                            classname="Satellite-contentTextValues-908"
                             variant="h3"
                           >
                             - -°C
@@ -1544,7 +1544,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-901"
+                          classname="Satellite-contentTextTitles-907"
                           variant="subtitle2"
                         >
                           HISTORICAL MAX
@@ -1553,7 +1553,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Historical maximum monthly average over the past 20 years"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-902"
+                            classname="Satellite-contentTextValues-908"
                             variant="h3"
                           >
                             0.0°C
@@ -1564,7 +1564,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-901"
+                          classname="Satellite-contentTextTitles-907"
                           variant="subtitle2"
                         >
                           DEGREE HEATING WEEKS
@@ -1573,7 +1573,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-902"
+                            classname="Satellite-contentTextValues-908"
                             variant="h3"
                           >
                             0.0
@@ -1584,7 +1584,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-901"
+                          classname="Satellite-contentTextTitles-907"
                           variant="subtitle2"
                         >
                           SST ANOMALY
@@ -1593,7 +1593,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Difference between current SST and longterm average"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-902"
+                            classname="Satellite-contentTextValues-908"
                             variant="h3"
                           >
                             - -°C
@@ -1787,10 +1787,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-907 false css-1urtxze-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-911 makeStyles-dateInfoWrapper-913 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-920 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -1800,7 +1800,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-909 css-120dh41-MuiSvgIcon-root"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
                             data-testid="UpdateIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1811,7 +1811,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </svg>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-912 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
                         >
                           <mock-box
                             display="flex"
@@ -1819,13 +1819,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             width="100%"
                           >
                             <mock-typography
-                              classname="makeStyles-updateInfoText-910"
+                              classname="makeStyles-updateInfoText-916"
                               variant="caption"
                             >
                               No data available
                             </mock-typography>
                             <mock-typography
-                              classname="makeStyles-updateInfoText-910"
+                              classname="makeStyles-updateInfoText-916"
                               variant="caption"
                             >
                               Updated daily
@@ -1835,34 +1835,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                      style="display: flex; justify-content: flex-end;"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-914 makeStyles-chip-920 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-927 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-919 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-917"
+                              class="makeStyles-link-924"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-915"
+                                classname="makeStyles-chipText-922"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-918"
+                                class="makeStyles-sensorImage-925"
                                 src="satellite.svg"
                               />
                             </a>
@@ -1879,13 +1878,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-872"
+              class="makeStyles-card-878"
             >
               <mock-card
-                classname="TemperatureChangeComponent-root-930"
+                classname="TemperatureChangeComponent-root-937"
               >
                 <div
-                  class="MuiCardHeader-root TemperatureChangeComponent-header-925 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root TemperatureChangeComponent-header-932 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -1900,7 +1899,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="TemperatureChangeComponent-cardTitle-924"
+                            classname="TemperatureChangeComponent-cardTitle-931"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -1912,21 +1911,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="TemperatureChangeComponent-content-931"
+                  classname="TemperatureChangeComponent-content-938"
                 >
                   <mock-box
-                    classname="TemperatureChangeComponent-cardContent-932"
+                    classname="TemperatureChangeComponent-cardContent-939"
                   >
                     <mock-box
-                      classname="TemperatureChangeComponent-tempContainer-934 TemperatureChangeComponent-tempIncreased-935"
+                      classname="TemperatureChangeComponent-tempContainer-941 TemperatureChangeComponent-tempIncreased-942"
                     >
                       <svg
-                        class="TemperatureChangeComponent-icon-937"
+                        class="TemperatureChangeComponent-icon-944"
                       >
                         caret.svg
                       </svg>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperatureChange-933"
+                        classname="TemperatureChangeComponent-temperatureChange-940"
                         variant="h1"
                       >
                         +
@@ -1936,7 +1935,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                     <mock-box>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperature-939"
+                        classname="TemperatureChangeComponent-temperature-946"
                         color="textSecondary"
                         variant="h4"
                       >
@@ -1952,10 +1951,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                   </mock-box>
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-907 false css-1urtxze-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-911 makeStyles-dateInfoWrapper-940 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-947 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -1965,7 +1964,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-909 css-120dh41-MuiSvgIcon-root"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
                             data-testid="UpdateIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1976,7 +1975,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </svg>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-912 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
                         >
                           <mock-box
                             display="flex"
@@ -1984,13 +1983,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             width="100%"
                           >
                             <mock-typography
-                              classname="makeStyles-updateInfoText-910"
+                              classname="makeStyles-updateInfoText-916"
                               variant="caption"
                             >
                               Last data received 5 min. ago
                             </mock-typography>
                             <mock-typography
-                              classname="makeStyles-updateInfoText-910"
+                              classname="makeStyles-updateInfoText-916"
                               variant="caption"
                             >
                               Updated daily
@@ -2000,34 +1999,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                      style="display: flex; justify-content: flex-end;"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-914 makeStyles-chip-941 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-948 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-919 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-917"
+                              class="makeStyles-link-924"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-915"
+                                classname="makeStyles-chipText-922"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-918"
+                                class="makeStyles-sensorImage-925"
                                 src="satellite.svg"
                               />
                             </a>
@@ -2044,13 +2042,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-872"
+              class="makeStyles-card-878"
             >
               <mock-card
-                classname="Bleaching-root-951"
+                classname="Bleaching-root-958"
               >
                 <div
-                  class="MuiCardHeader-root Bleaching-header-946 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Bleaching-header-953 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -2065,7 +2063,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Bleaching-cardTitle-945"
+                            classname="Bleaching-cardTitle-952"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -2077,21 +2075,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Bleaching-contentWrapper-952"
+                  classname="Bleaching-contentWrapper-959"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-953 css-ci9zny-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-960 css-ci9zny-MuiGrid-root"
                   >
                     <img
                       alt="alert-level"
-                      class="Bleaching-alertImage-954"
+                      class="Bleaching-alertImage-961"
                       src="/src/assets/alerts/alert_nostress.svg"
                     />
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-907 makeStyles-withMargin-908 css-1urtxze-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 makeStyles-withMargin-914 css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-911 makeStyles-dateInfoWrapper-955 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-962 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -2101,7 +2099,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-909 css-120dh41-MuiSvgIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
                               data-testid="UpdateIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -2112,7 +2110,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             </svg>
                           </div>
                           <div
-                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-912 css-x7bhrq-MuiGrid-root"
+                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
                           >
                             <mock-box
                               display="flex"
@@ -2120,13 +2118,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                               width="100%"
                             >
                               <mock-typography
-                                classname="makeStyles-updateInfoText-910"
+                                classname="makeStyles-updateInfoText-916"
                                 variant="caption"
                               >
                                 No data available
                               </mock-typography>
                               <mock-typography
-                                classname="makeStyles-updateInfoText-910"
+                                classname="makeStyles-updateInfoText-916"
                                 variant="caption"
                               >
                                 Updated daily
@@ -2136,28 +2134,27 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                        style="display: flex; justify-content: flex-end;"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-914 makeStyles-chip-956 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-963 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-919 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-917"
+                                class="makeStyles-link-924"
                                 href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-915"
+                                  classname="makeStyles-chipText-922"
                                 >
                                   NOAA CRW
                                 </mock-typography>
@@ -2176,40 +2173,40 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-872"
+              class="makeStyles-card-878"
             >
               <mock-card
-                classname="makeStyles-root-966"
+                classname="makeStyles-root-973"
               >
                 <mock-cardcontent
-                  classname="makeStyles-contentWrapper-970"
+                  classname="makeStyles-contentWrapper-977"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-971 css-182mpp5-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-978 css-182mpp5-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-969 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-960 makeStyles-coloredText-967"
+                        classname="makeStyles-cardTitle-967 makeStyles-coloredText-974"
                         variant="h6"
                       >
                         WIND
                       </mock-typography>
                       <img
                         alt="wind"
-                        class="makeStyles-titleImages-968"
+                        class="makeStyles-titleImages-975"
                         src="data:image/svg+xml,%3csvg%20width='40'%20height='32'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M25.034%202.516a8.027%208.027%200%2000-2.354%205.68.766.766%200%20101.53%200%206.503%206.503%200%20116.503%206.503H1.076a.763.763%200%20100%201.529h29.637a8.03%208.03%200%20006.957-12.05%208.03%208.03%200%2000-12.636-1.662z'/%3e%3cpath%20d='M2.607%2010.109a.765.765%200%20100%201.529h14.335a4.206%204.206%200%20002.977-7.182%204.208%204.208%200%2000-7.184%202.975.764.764%200%20101.53%200%202.677%202.677%200%20112.678%202.678H2.607zM26.123%2018.906H2.607a.766.766%200%20100%201.53h23.36a4.363%204.363%200%2011-1.67%208.397%204.365%204.365%200%2001-2.695-4.032.764.764%200%2010-1.53%200%205.892%205.892%200%20005.796%205.885A5.892%205.892%200%200031.858%2025a5.891%205.891%200%2000-1.544-4.186%205.888%205.888%200%2000-4.033-1.906.711.711%200%2000-.158%200z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-969 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-962"
+                          classname="makeStyles-contentTextTitles-969"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2219,7 +2216,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-963"
+                            classname="makeStyles-contentTextValues-970"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2231,7 +2228,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-962"
+                          classname="makeStyles-contentTextTitles-969"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2241,7 +2238,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-963"
+                            classname="makeStyles-contentTextValues-970"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2251,28 +2248,28 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-969 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-960 makeStyles-coloredText-967"
+                        classname="makeStyles-cardTitle-967 makeStyles-coloredText-974"
                         variant="h6"
                       >
                         WAVES
                       </mock-typography>
                       <img
                         alt="waves"
-                        class="makeStyles-titleImages-968"
+                        class="makeStyles-titleImages-975"
                         src="data:image/svg+xml,%3csvg%20width='42'%20height='23'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M.615%2019.218c1.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.791%202.81%206.129%202.81%202.593%200%205.009-1.25%206.63-3.424a.656.656%200%2000-.119-.904.619.619%200%2000-.881.121c-1.38%201.853-3.43%202.915-5.628%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397zM3.428%2010.994c1.596%201.795%203.791%202.81%206.129%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.593%200%205.009-1.249%206.63-3.424a.656.656%200%2000-.118-.903.619.619%200%2000-.882.12c-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-1%200-1.379%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-.309.415.05.914.491%201.397zM.615%202.77c1.596%201.796%203.79%202.81%206.128%202.81s4.533-1.014%206.129-2.81c1.596%201.796%203.79%202.81%206.128%202.81%202.337%200%204.532-1.014%206.128-2.81%201.596%201.796%203.791%202.81%206.129%202.81%202.593%200%205.009-1.248%206.63-3.423a.656.656%200%2000-.119-.904.619.619%200%2000-.881.12c-1.38%201.854-3.43%202.916-5.628%202.916-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-969 css-mi7qmn-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-mi7qmn-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4 css-119abwu-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-962"
+                          classname="makeStyles-contentTextTitles-969"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2282,7 +2279,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-963"
+                            classname="makeStyles-contentTextValues-970"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2294,7 +2291,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3 css-q8d82a-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-962"
+                          classname="makeStyles-contentTextTitles-969"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2304,7 +2301,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-963"
+                            classname="makeStyles-contentTextValues-970"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2316,7 +2313,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5 css-7v7ljq-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-962"
+                          classname="makeStyles-contentTextTitles-969"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2326,7 +2323,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-963"
+                            classname="makeStyles-contentTextValues-970"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2336,10 +2333,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-907 false css-1urtxze-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-911 makeStyles-dateInfoWrapper-977 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-984 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -2349,7 +2346,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-909 css-120dh41-MuiSvgIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
                               data-testid="UpdateIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -2360,7 +2357,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             </svg>
                           </div>
                           <div
-                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-912 css-x7bhrq-MuiGrid-root"
+                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
                           >
                             <mock-box
                               display="flex"
@@ -2368,13 +2365,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                               width="100%"
                             >
                               <mock-typography
-                                classname="makeStyles-updateInfoText-910"
+                                classname="makeStyles-updateInfoText-916"
                                 variant="caption"
                               >
                                 No data available
                               </mock-typography>
                               <mock-typography
-                                classname="makeStyles-updateInfoText-910"
+                                classname="makeStyles-updateInfoText-916"
                                 variant="caption"
                               >
                                 Updated every 6 hours
@@ -2384,30 +2381,55 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                        style="display: flex; justify-content: flex-end;"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-914 makeStyles-chip-978 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-985 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-919 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-917"
+                                class="makeStyles-link-924"
                                 href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-915"
+                                  classname="makeStyles-chipText-922"
                                 >
-                                  SOFAR MODEL
+                                  WIND
+                                </mock-typography>
+                              </a>
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-986 css-x7bhrq-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <a
+                                class="makeStyles-link-924"
+                                href="https://open-meteo.com/en/docs/marine-weather-api"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                <mock-typography
+                                  classname="makeStyles-chipText-922"
+                                >
+                                  WAVE
                                 </mock-typography>
                               </a>
                             </button>
@@ -2426,17 +2448,17 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         >
           <div>
             <mock-box
-              classname="makeStyles-graphtTitleWrapper-980"
+              classname="makeStyles-graphtTitleWrapper-988"
             >
               <mock-typography
-                classname="makeStyles-graphTitle-981"
+                classname="makeStyles-graphTitle-989"
                 variant="h6"
               >
                 HEAT STRESS ANALYSIS (°C)
               </mock-typography>
             </mock-box>
             <div
-              class="makeStyles-chart-979"
+              class="makeStyles-chart-987"
             >
               <mock-line
                 data="[object Object]"
@@ -2455,7 +2477,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             open="false"
           >
             <mock-dialogtitle
-              classname="Dialog-dialogTitle-995"
+              classname="Dialog-dialogTitle-1003"
             >
               <mock-typography
                 variant="h4"
@@ -2490,7 +2512,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             </mock-dialogactions>
           </mock-dialog>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-986 css-4rolpp-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-994 css-4rolpp-MuiGrid-root"
           >
             <mock-box
               bgcolor="#f5f6f6"
@@ -2500,13 +2522,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               zindex="-1"
             />
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-987 css-wdlm1q-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-995 css-wdlm1q-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-md-12 MuiGrid-grid-lg-3 css-ku179n-MuiGrid-root"
               >
                 <mock-typography
-                  classname="makeStyles-title-988"
+                  classname="makeStyles-title-996"
                 >
                   Survey History
                 </mock-typography>
@@ -2518,14 +2540,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-997"
+                    classname="makeStyles-subTitle-1005"
                     variant="h6"
                   >
                     Survey Point:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-998 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-1006 css-x7bhrq-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container css-1rp4aer-MuiGrid-root"
@@ -2534,7 +2556,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-999 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-1007 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                       >
                         <div
                           aria-expanded="false"
@@ -2578,32 +2600,32 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-989"
+                    classname="makeStyles-subTitle-997"
                     variant="h6"
                   >
                     Observation:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-990 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-998 css-x7bhrq-MuiGrid-root"
                 >
                   <div
-                    class="MuiFormControl-root makeStyles-formControl-991 css-1iw3t7y-MuiFormControl-root"
+                    class="MuiFormControl-root makeStyles-formControl-999 css-1iw3t7y-MuiFormControl-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-992 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-1000 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                     >
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="survey-observation survey-observation"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-994 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-1002 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         id="survey-observation"
                         role="combobox"
                         tabindex="0"
                       >
                         <mock-typography
-                          classname="makeStyles-menuItem-993"
+                          classname="makeStyles-menuItem-1001"
                           variant="h6"
                         >
                           Any
@@ -2637,7 +2659,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 css-fgj1s9-MuiGrid-root"
             >
               <div
-                class="SurveyTimeline-root-1006"
+                class="SurveyTimeline-root-1014"
               >
                 <mock-hidden
                   lgdown="true"
@@ -2646,13 +2668,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiTimeline-root MuiTimeline-positionRight css-i6popu-MuiTimeline-root"
                   >
                     <li
-                      class="MuiTimelineItem-root MuiTimelineItem-positionRight makeStyles-timelineItem-1015 css-ny8qih-MuiTimelineItem-root"
+                      class="MuiTimelineItem-root MuiTimelineItem-positionRight makeStyles-timelineItem-1023 css-ny8qih-MuiTimelineItem-root"
                     >
                       <div
-                        class="MuiTypography-root MuiTypography-body1 MuiTimelineOppositeContent-root MuiTimelineOppositeContent-positionRight makeStyles-timelineOppositeContent-1016 css-193a741-MuiTypography-root-MuiTimelineOppositeContent-root"
+                        class="MuiTypography-root MuiTypography-body1 MuiTimelineOppositeContent-root MuiTimelineOppositeContent-positionRight makeStyles-timelineOppositeContent-1024 css-193a741-MuiTypography-root-MuiTimelineOppositeContent-root"
                       >
                         <mock-typography
-                          classname="makeStyles-dates-1008"
+                          classname="makeStyles-dates-1016"
                           variant="h6"
                         >
                           09/10/2020
@@ -2662,20 +2684,20 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiTimelineSeparator-root css-1muvgbz-MuiTimelineSeparator-root"
                       >
                         <hr
-                          class="makeStyles-connector-1019"
+                          class="makeStyles-connector-1027"
                         />
                         <span
-                          class="MuiTimelineDot-root MuiTimelineDot-outlined MuiTimelineDot-outlinedGrey makeStyles-dot-1020 css-6xp33q-MuiTimelineDot-root"
+                          class="MuiTimelineDot-root MuiTimelineDot-outlined MuiTimelineDot-outlinedGrey makeStyles-dot-1028 css-6xp33q-MuiTimelineDot-root"
                         />
                         <hr
-                          class="makeStyles-connector-1019"
+                          class="makeStyles-connector-1027"
                         />
                       </div>
                       <div
-                        class="MuiTypography-root MuiTypography-body1 MuiTimelineContent-root MuiTimelineContent-positionRight makeStyles-surveyCardWrapper-1010 css-1qq9j0n-MuiTypography-root-MuiTimelineContent-root"
+                        class="MuiTypography-root MuiTypography-body1 MuiTimelineContent-root MuiTimelineContent-positionRight makeStyles-surveyCardWrapper-1018 css-1qq9j0n-MuiTypography-root-MuiTimelineContent-root"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1028 css-14gemme-MuiPaper-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1036 css-14gemme-MuiPaper-root"
                           style="--Paper-shadow: none;"
                         >
                           <div
@@ -2683,56 +2705,56 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             style="height: 100%;"
                           >
                             <div
-                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1032 css-1ej0ikx-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1040 css-1ej0ikx-MuiGrid-root"
                             >
                               <a
                                 data-discover="true"
                                 href="/sites/1/survey_details/46"
                               >
                                 <div
-                                  class="MuiCardMedia-root makeStyles-cardImage-1029 css-utntyq-MuiCardMedia-root"
+                                  class="MuiCardMedia-root makeStyles-cardImage-1037 css-utntyq-MuiCardMedia-root"
                                   role="img"
                                   style="background-image: url("image-url");"
                                 />
                               </a>
                             </div>
                             <div
-                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1033 css-14c8q5g-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1041 css-14c8q5g-MuiGrid-root"
                             >
                               <div
-                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1038 css-aksm9b-MuiGrid-root"
+                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1046 css-aksm9b-MuiGrid-root"
                               >
                                 <div
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1030"
+                                    classname="makeStyles-cardFields-1038"
                                     variant="h6"
                                   >
                                     User:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1031 makeStyles-valuesWithMargin-1036"
+                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
                                     variant="h6"
                                   >
                                     Joe Doe
                                   </mock-typography>
                                 </div>
                                 <div
-                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1034 css-otecwo-MuiGrid-root"
+                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1042 css-otecwo-MuiGrid-root"
                                 >
                                   <div
                                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                                     style="height: 80%;"
                                   >
                                     <mock-typography
-                                      classname="makeStyles-cardFields-1030"
+                                      classname="makeStyles-cardFields-1038"
                                       variant="h6"
                                     >
                                       Comments:
                                     </mock-typography>
                                     <mock-typography
-                                      classname="makeStyles-cardValues-1031 makeStyles-comments-1035"
+                                      classname="makeStyles-cardValues-1039 makeStyles-comments-1043"
                                       variant="h6"
                                     >
                                       No comments
@@ -2743,13 +2765,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1030"
+                                    classname="makeStyles-cardFields-1038"
                                     variant="h6"
                                   >
                                     Temp:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1031 makeStyles-valuesWithMargin-1036"
+                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
                                     variant="h6"
                                   >
                                     10.0 °C
@@ -2791,23 +2813,23 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyWrapper-1052 css-ldi2p4-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyWrapper-1060 css-ldi2p4-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11 makeStyles-dateWrapper-1043 css-tideur-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11 makeStyles-dateWrapper-1051 css-tideur-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-dates-1044"
+                          classname="makeStyles-dates-1052"
                           variant="h6"
                         >
                           09/10/2020
                         </mock-typography>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyCardWrapper-1046 css-wcmnoq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyCardWrapper-1054 css-wcmnoq-MuiGrid-root"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1028 css-14gemme-MuiPaper-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1036 css-14gemme-MuiPaper-root"
                           style="--Paper-shadow: none;"
                         >
                           <div
@@ -2815,56 +2837,56 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             style="height: 100%;"
                           >
                             <div
-                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1032 css-1ej0ikx-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1040 css-1ej0ikx-MuiGrid-root"
                             >
                               <a
                                 data-discover="true"
                                 href="/sites/1/survey_details/46"
                               >
                                 <div
-                                  class="MuiCardMedia-root makeStyles-cardImage-1029 css-utntyq-MuiCardMedia-root"
+                                  class="MuiCardMedia-root makeStyles-cardImage-1037 css-utntyq-MuiCardMedia-root"
                                   role="img"
                                   style="background-image: url("image-url");"
                                 />
                               </a>
                             </div>
                             <div
-                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1033 css-14c8q5g-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1041 css-14c8q5g-MuiGrid-root"
                             >
                               <div
-                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1038 css-aksm9b-MuiGrid-root"
+                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1046 css-aksm9b-MuiGrid-root"
                               >
                                 <div
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1030"
+                                    classname="makeStyles-cardFields-1038"
                                     variant="h6"
                                   >
                                     User:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1031 makeStyles-valuesWithMargin-1036"
+                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
                                     variant="h6"
                                   >
                                     Joe Doe
                                   </mock-typography>
                                 </div>
                                 <div
-                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1034 css-otecwo-MuiGrid-root"
+                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1042 css-otecwo-MuiGrid-root"
                                 >
                                   <div
                                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                                     style="height: 80%;"
                                   >
                                     <mock-typography
-                                      classname="makeStyles-cardFields-1030"
+                                      classname="makeStyles-cardFields-1038"
                                       variant="h6"
                                     >
                                       Comments:
                                     </mock-typography>
                                     <mock-typography
-                                      classname="makeStyles-cardValues-1031 makeStyles-comments-1035"
+                                      classname="makeStyles-cardValues-1039 makeStyles-comments-1043"
                                       variant="h6"
                                     >
                                       No comments
@@ -2875,13 +2897,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1030"
+                                    classname="makeStyles-cardFields-1038"
                                     variant="h6"
                                   >
                                     Temp:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1031 makeStyles-valuesWithMargin-1036"
+                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
                                     variant="h6"
                                   >
                                     10.0 °C
@@ -2925,7 +2947,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           title="Ask AI about coral bleaching and heat stress"
         >
           <button
-            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-1082 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
+            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-1090 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
             style="background-image: url("/src/assets/aiChat.png"); background-size: cover; background-position: center; background-color: rgb(40, 115, 197);"
             tabindex="0"
             type="button"
@@ -2935,7 +2957,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
     </div>
   </div>
   <mock-appbar
-    classname="Footer-appBar-1105"
+    classname="Footer-appBar-1113"
     position="static"
   >
     <mock-toolbar>
@@ -2946,7 +2968,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
         >
           <mock-link
-            classname="Footer-navBarLink-1106"
+            classname="Footer-navBarLink-1114"
             href="/map"
             underline="hover"
           >
@@ -4781,7 +4803,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-96 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-97 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -4826,34 +4848,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                      style="display: flex; justify-content: flex-end;"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-103 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-104 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-100"
+                              class="makeStyles-link-101"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-98"
+                                classname="makeStyles-chipText-99"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-101"
+                                class="makeStyles-sensorImage-102"
                                 src="satellite.svg"
                               />
                             </a>
@@ -4873,10 +4894,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="TemperatureChangeComponent-root-113"
+                classname="TemperatureChangeComponent-root-114"
               >
                 <div
-                  class="MuiCardHeader-root TemperatureChangeComponent-header-108 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root TemperatureChangeComponent-header-109 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -4891,7 +4912,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="TemperatureChangeComponent-cardTitle-107"
+                            classname="TemperatureChangeComponent-cardTitle-108"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -4903,21 +4924,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="TemperatureChangeComponent-content-114"
+                  classname="TemperatureChangeComponent-content-115"
                 >
                   <mock-box
-                    classname="TemperatureChangeComponent-cardContent-115"
+                    classname="TemperatureChangeComponent-cardContent-116"
                   >
                     <mock-box
-                      classname="TemperatureChangeComponent-tempContainer-117 TemperatureChangeComponent-tempIncreased-118"
+                      classname="TemperatureChangeComponent-tempContainer-118 TemperatureChangeComponent-tempIncreased-119"
                     >
                       <svg
-                        class="TemperatureChangeComponent-icon-120"
+                        class="TemperatureChangeComponent-icon-121"
                       >
                         caret.svg
                       </svg>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperatureChange-116"
+                        classname="TemperatureChangeComponent-temperatureChange-117"
                         variant="h1"
                       >
                         +
@@ -4927,7 +4948,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                     <mock-box>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperature-122"
+                        classname="TemperatureChangeComponent-temperature-123"
                         color="textSecondary"
                         variant="h4"
                       >
@@ -4946,7 +4967,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-123 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-124 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -4991,34 +5012,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                      style="display: flex; justify-content: flex-end;"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-124 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-125 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-100"
+                              class="makeStyles-link-101"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-98"
+                                classname="makeStyles-chipText-99"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-101"
+                                class="makeStyles-sensorImage-102"
                                 src="satellite.svg"
                               />
                             </a>
@@ -5038,10 +5058,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="Bleaching-root-134"
+                classname="Bleaching-root-135"
               >
                 <div
-                  class="MuiCardHeader-root Bleaching-header-129 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Bleaching-header-130 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -5056,7 +5076,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Bleaching-cardTitle-128"
+                            classname="Bleaching-cardTitle-129"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -5068,21 +5088,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Bleaching-contentWrapper-135"
+                  classname="Bleaching-contentWrapper-136"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-136 css-ci9zny-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-137 css-ci9zny-MuiGrid-root"
                   >
                     <img
                       alt="alert-level"
-                      class="Bleaching-alertImage-137"
+                      class="Bleaching-alertImage-138"
                       src="/src/assets/alerts/alert_nostress.svg"
                     />
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 makeStyles-withMargin-91 css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-138 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-139 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -5127,28 +5147,27 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                        style="display: flex; justify-content: flex-end;"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-139 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-140 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-100"
+                                class="makeStyles-link-101"
                                 href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-98"
+                                  classname="makeStyles-chipText-99"
                                 >
                                   NOAA CRW
                                 </mock-typography>
@@ -5170,37 +5189,37 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="makeStyles-root-149"
+                classname="makeStyles-root-150"
               >
                 <mock-cardcontent
-                  classname="makeStyles-contentWrapper-153"
+                  classname="makeStyles-contentWrapper-154"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-154 css-182mpp5-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-155 css-182mpp5-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-152 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-143 makeStyles-coloredText-150"
+                        classname="makeStyles-cardTitle-144 makeStyles-coloredText-151"
                         variant="h6"
                       >
                         WIND
                       </mock-typography>
                       <img
                         alt="wind"
-                        class="makeStyles-titleImages-151"
+                        class="makeStyles-titleImages-152"
                         src="data:image/svg+xml,%3csvg%20width='40'%20height='32'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M25.034%202.516a8.027%208.027%200%2000-2.354%205.68.766.766%200%20101.53%200%206.503%206.503%200%20116.503%206.503H1.076a.763.763%200%20100%201.529h29.637a8.03%208.03%200%20006.957-12.05%208.03%208.03%200%2000-12.636-1.662z'/%3e%3cpath%20d='M2.607%2010.109a.765.765%200%20100%201.529h14.335a4.206%204.206%200%20002.977-7.182%204.208%204.208%200%2000-7.184%202.975.764.764%200%20101.53%200%202.677%202.677%200%20112.678%202.678H2.607zM26.123%2018.906H2.607a.766.766%200%20100%201.53h23.36a4.363%204.363%200%2011-1.67%208.397%204.365%204.365%200%2001-2.695-4.032.764.764%200%2010-1.53%200%205.892%205.892%200%20005.796%205.885A5.892%205.892%200%200031.858%2025a5.891%205.891%200%2000-1.544-4.186%205.888%205.888%200%2000-4.033-1.906.711.711%200%2000-.158%200z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-152 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-145"
+                          classname="makeStyles-contentTextTitles-146"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5210,7 +5229,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-146"
+                            classname="makeStyles-contentTextValues-147"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5222,7 +5241,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-145"
+                          classname="makeStyles-contentTextTitles-146"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5232,7 +5251,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-146"
+                            classname="makeStyles-contentTextValues-147"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5242,28 +5261,28 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-152 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-143 makeStyles-coloredText-150"
+                        classname="makeStyles-cardTitle-144 makeStyles-coloredText-151"
                         variant="h6"
                       >
                         WAVES
                       </mock-typography>
                       <img
                         alt="waves"
-                        class="makeStyles-titleImages-151"
+                        class="makeStyles-titleImages-152"
                         src="data:image/svg+xml,%3csvg%20width='42'%20height='23'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M.615%2019.218c1.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.791%202.81%206.129%202.81%202.593%200%205.009-1.25%206.63-3.424a.656.656%200%2000-.119-.904.619.619%200%2000-.881.121c-1.38%201.853-3.43%202.915-5.628%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397zM3.428%2010.994c1.596%201.795%203.791%202.81%206.129%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.593%200%205.009-1.249%206.63-3.424a.656.656%200%2000-.118-.903.619.619%200%2000-.882.12c-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-1%200-1.379%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-.309.415.05.914.491%201.397zM.615%202.77c1.596%201.796%203.79%202.81%206.128%202.81s4.533-1.014%206.129-2.81c1.596%201.796%203.79%202.81%206.128%202.81%202.337%200%204.532-1.014%206.128-2.81%201.596%201.796%203.791%202.81%206.129%202.81%202.593%200%205.009-1.248%206.63-3.423a.656.656%200%2000-.119-.904.619.619%200%2000-.881.12c-1.38%201.854-3.43%202.916-5.628%202.916-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-152 css-mi7qmn-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-mi7qmn-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4 css-119abwu-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-145"
+                          classname="makeStyles-contentTextTitles-146"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5273,7 +5292,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-146"
+                            classname="makeStyles-contentTextValues-147"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5285,7 +5304,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3 css-q8d82a-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-145"
+                          classname="makeStyles-contentTextTitles-146"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5295,7 +5314,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-146"
+                            classname="makeStyles-contentTextValues-147"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5307,7 +5326,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5 css-7v7ljq-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-145"
+                          classname="makeStyles-contentTextTitles-146"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5317,7 +5336,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-146"
+                            classname="makeStyles-contentTextValues-147"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5330,7 +5349,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-160 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-161 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -5375,30 +5394,55 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
-                        style="display: flex; justify-content: flex-end;"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-161 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-162 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-100"
+                                class="makeStyles-link-101"
                                 href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-98"
+                                  classname="makeStyles-chipText-99"
                                 >
-                                  SOFAR MODEL
+                                  WIND
+                                </mock-typography>
+                              </a>
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-163 css-x7bhrq-MuiGrid-root"
+                        >
+                          <div
+                            class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
+                          >
+                            <button
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              tabindex="0"
+                              type="button"
+                            >
+                              <a
+                                class="makeStyles-link-101"
+                                href="https://open-meteo.com/en/docs/marine-weather-api"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                              >
+                                <mock-typography
+                                  classname="makeStyles-chipText-99"
+                                >
+                                  WAVE
                                 </mock-typography>
                               </a>
                             </button>
@@ -5417,17 +5461,17 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         >
           <div>
             <mock-box
-              classname="makeStyles-graphtTitleWrapper-163"
+              classname="makeStyles-graphtTitleWrapper-165"
             >
               <mock-typography
-                classname="makeStyles-graphTitle-164"
+                classname="makeStyles-graphTitle-166"
                 variant="h6"
               >
                 HEAT STRESS ANALYSIS (°C)
               </mock-typography>
             </mock-box>
             <div
-              class="makeStyles-chart-162"
+              class="makeStyles-chart-164"
             >
               <mock-line
                 data="[object Object]"
@@ -5446,7 +5490,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             open="false"
           >
             <mock-dialogtitle
-              classname="Dialog-dialogTitle-178"
+              classname="Dialog-dialogTitle-180"
             >
               <mock-typography
                 variant="h4"
@@ -5481,7 +5525,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             </mock-dialogactions>
           </mock-dialog>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-169 css-4rolpp-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-171 css-4rolpp-MuiGrid-root"
           >
             <mock-box
               bgcolor="#f5f6f6"
@@ -5491,13 +5535,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               zindex="-1"
             />
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-170 css-wdlm1q-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-172 css-wdlm1q-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-md-12 MuiGrid-grid-lg-3 css-ku179n-MuiGrid-root"
               >
                 <mock-typography
-                  classname="makeStyles-title-171"
+                  classname="makeStyles-title-173"
                 >
                   Survey History
                 </mock-typography>
@@ -5509,14 +5553,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-180"
+                    classname="makeStyles-subTitle-182"
                     variant="h6"
                   >
                     Survey Point:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-181 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-183 css-x7bhrq-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container css-1rp4aer-MuiGrid-root"
@@ -5525,7 +5569,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-182 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-184 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                       >
                         <div
                           aria-expanded="false"
@@ -5569,32 +5613,32 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-172"
+                    classname="makeStyles-subTitle-174"
                     variant="h6"
                   >
                     Observation:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-173 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-175 css-x7bhrq-MuiGrid-root"
                 >
                   <div
-                    class="MuiFormControl-root makeStyles-formControl-174 css-1iw3t7y-MuiFormControl-root"
+                    class="MuiFormControl-root makeStyles-formControl-176 css-1iw3t7y-MuiFormControl-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-175 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-177 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                     >
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="survey-observation survey-observation"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-177 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-179 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         id="survey-observation"
                         role="combobox"
                         tabindex="0"
                       >
                         <mock-typography
-                          classname="makeStyles-menuItem-176"
+                          classname="makeStyles-menuItem-178"
                           variant="h6"
                         >
                           Any
@@ -5628,7 +5672,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 css-fgj1s9-MuiGrid-root"
             >
               <div
-                class="SurveyTimeline-root-189"
+                class="SurveyTimeline-root-191"
               >
                 <mock-hidden
                   lgdown="true"
@@ -5653,7 +5697,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           title="Ask AI about coral bleaching and heat stress"
         >
           <button
-            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-238 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
+            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-240 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
             style="background-image: url("/src/assets/aiChat.png"); background-size: cover; background-position: center; background-color: rgb(40, 115, 197);"
             tabindex="0"
             type="button"
@@ -5663,7 +5707,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
     </div>
   </div>
   <mock-appbar
-    classname="Footer-appBar-261"
+    classname="Footer-appBar-263"
     position="static"
   >
     <mock-toolbar>
@@ -5674,7 +5718,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
         >
           <mock-link
-            classname="Footer-navBarLink-262"
+            classname="Footer-navBarLink-264"
             href="/map"
             underline="hover"
           >

--- a/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
+++ b/packages/website/src/routes/SiteRoutes/Site/__snapshots__/index.test.tsx.snap
@@ -3,12 +3,12 @@
 exports[`Site Detail Page > should render with given state from Redux store > snapshot-with-data 1`] = `
 <div>
   <mock-appbar
-    classname="NavBar-appBar-824 NavBar-appBarXs-826"
+    classname="NavBar-appBar-812 NavBar-appBarXs-814"
     color="primary"
     position="static"
   >
     <mock-toolbar
-      classname="NavBar-toolbar-827"
+      classname="NavBar-toolbar-815"
     >
       <mock-drawer
         anchor="left"
@@ -22,7 +22,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           <mock-clear />
         </mock-iconbutton>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/"
           tabindex="0"
@@ -35,7 +35,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/map"
           tabindex="0"
@@ -48,7 +48,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/register"
           tabindex="0"
@@ -61,7 +61,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://highlights.aqualink.org"
           tabindex="0"
           target="_blank"
@@ -75,7 +75,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </mock-link>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://bristlemouth.aqualink.org"
           tabindex="0"
           target="_blank"
@@ -89,7 +89,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </mock-link>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/tracker"
           tabindex="0"
@@ -102,7 +102,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/about"
           tabindex="0"
@@ -115,7 +115,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/faq"
           tabindex="0"
@@ -128,7 +128,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/buoy"
           tabindex="0"
@@ -141,7 +141,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <a
-          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           data-discover="true"
           href="/drones"
           tabindex="0"
@@ -154,7 +154,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </mock-typography>
         </a>
         <mock-link
-          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-838 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
+          classname="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MuiButton-root MuiButton-text MuiButton-textInherit MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorInherit MenuDrawer-menuDrawerButton-826 css-gw5l4k-MuiButtonBase-root-MuiButton-root"
           href="https://highlights.aqualink.org/contact-us"
           tabindex="0"
           target="_blank"
@@ -184,7 +184,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             role="group"
           >
             <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-837 MuiButtonGroup-firstButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-825 MuiButtonGroup-firstButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
               href="https://github.com/aqualinkorg/aqualink-app"
               tabindex="0"
               target="_blank"
@@ -197,7 +197,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               GitHub
             </a>
             <a
-              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-837 MuiButtonGroup-lastButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
+              class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MuiButtonGroup-grouped MuiButtonGroup-groupedHorizontal MuiButtonGroup-groupedContained MuiButtonGroup-groupedContainedHorizontal MuiButtonGroup-groupedContainedPrimary MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeMedium MuiButton-containedSizeMedium MuiButton-colorPrimary MenuDrawer-contributeButton-825 MuiButtonGroup-lastButton css-z31nbn-MuiButtonBase-root-MuiButton-root"
               href="https://ovio.org/project/aqualinkorg/aqualink-app"
               tabindex="0"
               target="_blank"
@@ -239,7 +239,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </svg>
             </mock-iconbutton>
             <mock-link
-              classname="NavBar-navBarLink-825"
+              classname="NavBar-navBarLink-813"
               href="/map"
               underline="hover"
             >
@@ -265,10 +265,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-sm-4 MuiGrid-grid-md-3 css-x5eji4-MuiGrid-root"
           >
             <div
-              class="Search-searchBar-839"
+              class="Search-searchBar-827"
             >
               <div
-                class="Search-searchBarIcon-840"
+                class="Search-searchBarIcon-828"
               >
                 <mock-iconbutton
                   size="small"
@@ -287,10 +287,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-iconbutton>
               </div>
               <div
-                class="Search-searchBarText-841"
+                class="Search-searchBarText-829"
               >
                 <div
-                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-842 css-1tlcqt-MuiAutocomplete-root"
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-830 css-1tlcqt-MuiAutocomplete-root"
                 >
                   <div
                     class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -358,7 +358,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </div>
         </mock-hidden>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8 MuiGrid-grid-sm-4 MuiGrid-grid-md-3 NavBar-languageUserWrapper-835 css-1odkxmp-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-8 MuiGrid-grid-sm-4 MuiGrid-grid-md-3 NavBar-languageUserWrapper-823 css-1odkxmp-MuiGrid-root"
         >
           <mock-tooltip
             title="Translate"
@@ -387,12 +387,12 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           >
             Mock User
             <mock-iconbutton
-              classname="NavBar-button-834"
+              classname="NavBar-button-822"
               size="large"
             >
               <svg
                 aria-hidden="true"
-                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium NavBar-expandIcon-833 css-1umw9bq-MuiSvgIcon-root"
+                class="MuiSvgIcon-root MuiSvgIcon-fontSizeMedium NavBar-expandIcon-821 css-1umw9bq-MuiSvgIcon-root"
                 data-testid="ExpandMoreIcon"
                 focusable="false"
                 viewBox="0 0 24 24"
@@ -403,22 +403,22 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </svg>
             </mock-iconbutton>
             <mock-menu
-              classname="NavBar-userMenu-830"
+              classname="NavBar-userMenu-818"
               keepmounted="true"
               menulistprops="[object Object]"
               open="false"
               popoverclasses="[object Object]"
             >
               <mock-divider
-                classname="NavBar-userMenuDivider-829"
+                classname="NavBar-userMenuDivider-817"
               />
               <a
-                class="NavBar-menuItemLink-832"
+                class="NavBar-menuItemLink-820"
                 data-discover="true"
                 href="/dashboard"
               >
                 <mock-menuitem
-                  classname="NavBar-menuItem-831"
+                  classname="NavBar-menuItem-819"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-iqna23-MuiGrid-root"
@@ -451,10 +451,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-menuitem>
               </a>
               <mock-divider
-                classname="NavBar-userMenuDivider-829"
+                classname="NavBar-userMenuDivider-817"
               />
               <mock-menuitem
-                classname="NavBar-menuItem-831"
+                classname="NavBar-menuItem-819"
               >
                 <div
                   class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-iqna23-MuiGrid-root"
@@ -492,10 +492,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             style="margin: 0px; padding-top: 0px;"
           >
             <div
-              class="Search-searchBar-839"
+              class="Search-searchBar-827"
             >
               <div
-                class="Search-searchBarIcon-840"
+                class="Search-searchBarIcon-828"
               >
                 <mock-iconbutton
                   size="small"
@@ -514,10 +514,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </mock-iconbutton>
               </div>
               <div
-                class="Search-searchBarText-841"
+                class="Search-searchBarText-829"
               >
                 <div
-                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-842 css-1tlcqt-MuiAutocomplete-root"
+                  class="MuiAutocomplete-root MuiAutocomplete-hasPopupIcon Search-searchBarInput-830 css-1tlcqt-MuiAutocomplete-root"
                 >
                   <div
                     class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -595,7 +595,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
   >
     <mock-card>
       <div
-        class="MuiCardHeader-root RegisterDialog-dialogHeader-846 css-149tc0y-MuiCardHeader-root"
+        class="MuiCardHeader-root RegisterDialog-dialogHeader-834 css-149tc0y-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -618,7 +618,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="RegisterDialog-dialogHeaderSecondPart-847"
+                    classname="RegisterDialog-dialogHeaderSecondPart-835"
                     variant="h4"
                   >
                     link
@@ -629,7 +629,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
               >
                 <mock-iconbutton
-                  classname="RegisterDialog-closeButton-845"
+                  classname="RegisterDialog-closeButton-833"
                   size="small"
                 >
                   <svg
@@ -654,7 +654,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-ldi2p4-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 RegisterDialog-dialogContentTitle-848 css-9ve18c-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 RegisterDialog-dialogContentTitle-836 css-9ve18c-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
@@ -671,10 +671,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
           >
             <form
-              class="RegisterDialog-form-849"
+              class="RegisterDialog-form-837"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-838 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -692,7 +692,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-839 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="firstName"
                       name="firstName"
                       placeholder="First Name"
@@ -715,7 +715,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-838 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -733,7 +733,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-839 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="lastName"
                       name="lastName"
                       placeholder="Last Name"
@@ -756,7 +756,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-838 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -774,7 +774,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-839 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="organization"
                       name="organization"
                       placeholder="Organization"
@@ -797,7 +797,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-838 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -815,7 +815,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-839 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="emailAddress"
                       name="emailAddress"
                       placeholder="Email Address"
@@ -838,7 +838,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-850 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-textFieldWrapper-838 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -856,7 +856,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-851 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input RegisterDialog-textField-839 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="password"
                       name="password"
                       placeholder="Password"
@@ -886,7 +886,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 >
                   <mock-checkbox
                     checked="false"
-                    classname="RegisterDialog-termsCheckbox-854"
+                    classname="RegisterDialog-termsCheckbox-842"
                     color="primary"
                   />
                 </div>
@@ -895,14 +895,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 >
                   <mock-box>
                     <mock-typography
-                      classname="RegisterDialog-formText-852"
+                      classname="RegisterDialog-formText-840"
                       color="textSecondary"
                       variant="subtitle1"
                     >
                       I have read the
                        
                       <a
-                        class="RegisterDialog-termsLink-855"
+                        class="RegisterDialog-termsLink-843"
                         data-discover="true"
                         href="/terms"
                       >
@@ -913,7 +913,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-button-853 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 RegisterDialog-button-841 css-z4k4cw-MuiGrid-root"
               >
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth Mui-disabled MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth css-14fik5b-MuiButtonBase-root-MuiButton-root"
@@ -928,7 +928,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <mock-typography
-                  classname="RegisterDialog-formText-852"
+                  classname="RegisterDialog-formText-840"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -958,7 +958,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
       elevation="0"
     >
       <div
-        class="MuiCardHeader-root SignInDialog-dialogHeader-857 css-149tc0y-MuiCardHeader-root"
+        class="MuiCardHeader-root SignInDialog-dialogHeader-845 css-149tc0y-MuiCardHeader-root"
       >
         <div
           class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -981,7 +981,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     Aqua
                   </mock-typography>
                   <mock-typography
-                    classname="SignInDialog-dialogHeaderSecondPart-858"
+                    classname="SignInDialog-dialogHeaderSecondPart-846"
                     variant="h4"
                   >
                     link
@@ -992,7 +992,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
               >
                 <mock-iconbutton
-                  classname="SignInDialog-closeButton-856"
+                  classname="SignInDialog-closeButton-844"
                   size="small"
                 >
                   <svg
@@ -1077,7 +1077,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-ldi2p4-MuiGrid-root"
         >
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 SignInDialog-dialogContentTitle-859 css-9ve18c-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 SignInDialog-dialogContentTitle-847 css-9ve18c-MuiGrid-root"
           >
             <div
               class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
@@ -1094,10 +1094,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
           >
             <form
-              class="SignInDialog-form-860"
+              class="SignInDialog-form-848"
             >
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-861 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-849 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1115,7 +1115,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-862 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-850 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="emailAddress"
                       name="emailAddress"
                       placeholder="Email Address"
@@ -1138,7 +1138,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </div>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-861 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-textFieldWrapper-849 css-z4k4cw-MuiGrid-root"
               >
                 <div
                   class="MuiFormControl-root MuiFormControl-fullWidth MuiTextField-root css-cmpglg-MuiFormControl-root-MuiTextField-root"
@@ -1156,7 +1156,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   >
                     <input
                       aria-invalid="false"
-                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-862 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
+                      class="MuiInputBase-input MuiOutlinedInput-input SignInDialog-textField-850 css-p1pyuz-MuiInputBase-input-MuiOutlinedInput-input"
                       id="password"
                       name="password"
                       placeholder="Password"
@@ -1182,7 +1182,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <button
-                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary SignInDialog-forgotPasswordButton-865 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                  class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary SignInDialog-forgotPasswordButton-853 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                   tabindex="0"
                   type="button"
                 >
@@ -1195,7 +1195,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 </button>
               </div>
               <div
-                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-button-864 css-z4k4cw-MuiGrid-root"
+                class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 SignInDialog-button-852 css-z4k4cw-MuiGrid-root"
               >
                 <button
                   class="MuiButtonBase-root MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth MuiButton-root MuiButton-contained MuiButton-containedPrimary MuiButton-sizeLarge MuiButton-containedSizeLarge MuiButton-colorPrimary MuiButton-fullWidth css-14fik5b-MuiButtonBase-root-MuiButton-root"
@@ -1209,7 +1209,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
               >
                 <mock-typography
-                  classname="SignInDialog-formText-863"
+                  classname="SignInDialog-formText-851"
                   color="textSecondary"
                   variant="subtitle1"
                 >
@@ -1305,7 +1305,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-1 css-174grhv-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-874 css-x7bhrq-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-862 css-x7bhrq-MuiGrid-root"
             >
               <mock-iconbutton
                 aria-label="menu"
@@ -1327,7 +1327,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               </mock-iconbutton>
             </div>
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 SiteInfo-headerWrapper-875 css-1accxqv-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 SiteInfo-headerWrapper-863 css-1accxqv-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8 css-1f6br5b-MuiGrid-root"
@@ -1339,7 +1339,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item SiteInfo-siteNameWrapper-876 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item SiteInfo-siteNameWrapper-864 css-x7bhrq-MuiGrid-root"
                     >
                       <mock-typography
                         variant="h4"
@@ -1348,7 +1348,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </mock-typography>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-874 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item SiteInfo-headerButtonWrapper-862 css-x7bhrq-MuiGrid-root"
                     >
                       <mock-tooltip
                         arrow="true"
@@ -1356,7 +1356,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         title="Add to your dashboard"
                       >
                         <mock-iconbutton
-                          classname="CollectionButton-root-877"
+                          classname="CollectionButton-root-865"
                           disabled="false"
                           size="large"
                         >
@@ -1405,10 +1405,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-6 css-1wocbzy-MuiGrid-root"
           >
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-row-890 css-1d4pq44-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-row-878 css-1d4pq44-MuiGrid-root"
             >
               <mock-box
-                classname="Title-root-895"
+                classname="Title-root-883"
               >
                 <div
                   class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
@@ -1442,7 +1442,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
             >
               <div
-                class="makeStyles-container-891"
+                class="makeStyles-container-879"
               >
                 <mock-map
                   polygon="[object Object]"
@@ -1459,7 +1459,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
             >
               <div
-                class="makeStyles-container-891"
+                class="makeStyles-container-879"
               >
                 <mock-featuredmedia
                   featuredimage="image-url"
@@ -1471,20 +1471,20 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           </div>
         </div>
         <div
-          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-metricsWrapper-888 css-m4714y-MuiGrid-root"
+          class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-metricsWrapper-876 css-m4714y-MuiGrid-root"
         >
           <div
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-878"
+              class="makeStyles-card-866"
             >
               <mock-card
-                classname="Satellite-root-911"
+                classname="Satellite-root-899"
                 style="background-color: rgb(8, 91, 163);"
               >
                 <div
-                  class="MuiCardHeader-root Satellite-header-906 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Satellite-header-894 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -1499,7 +1499,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Satellite-cardTitle-905"
+                            classname="Satellite-cardTitle-893"
                             variant="h6"
                           >
                             SATELLITE OBSERVATION
@@ -1510,7 +1510,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Satellite-content-912"
+                  classname="Satellite-content-900"
                 >
                   <mock-box
                     display="flex"
@@ -1524,7 +1524,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-907"
+                          classname="Satellite-contentTextTitles-895"
                           variant="subtitle2"
                         >
                           SURFACE TEMP
@@ -1533,7 +1533,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title=""
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-908"
+                            classname="Satellite-contentTextValues-896"
                             variant="h3"
                           >
                             - -°C
@@ -1544,7 +1544,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-907"
+                          classname="Satellite-contentTextTitles-895"
                           variant="subtitle2"
                         >
                           HISTORICAL MAX
@@ -1553,7 +1553,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Historical maximum monthly average over the past 20 years"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-908"
+                            classname="Satellite-contentTextValues-896"
                             variant="h3"
                           >
                             0.0°C
@@ -1564,7 +1564,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-907"
+                          classname="Satellite-contentTextTitles-895"
                           variant="subtitle2"
                         >
                           DEGREE HEATING WEEKS
@@ -1573,7 +1573,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Degree Heating Weeks - a measure of the amount of time above the 20 year historical maximum temperatures"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-908"
+                            classname="Satellite-contentTextValues-896"
                             variant="h3"
                           >
                             0.0
@@ -1584,7 +1584,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="Satellite-contentTextTitles-907"
+                          classname="Satellite-contentTextTitles-895"
                           variant="subtitle2"
                         >
                           SST ANOMALY
@@ -1593,7 +1593,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           title="Difference between current SST and longterm average"
                         >
                           <mock-typography
-                            classname="Satellite-contentTextValues-908"
+                            classname="Satellite-contentTextValues-896"
                             variant="h3"
                           >
                             - -°C
@@ -1787,10 +1787,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </div>
                   </div>
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-901 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-920 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-905 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -1800,7 +1800,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-903 css-120dh41-MuiSvgIcon-root"
                             data-testid="UpdateIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1811,7 +1811,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </svg>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-906 css-x7bhrq-MuiGrid-root"
                         >
                           <mock-box
                             display="flex"
@@ -1819,13 +1819,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             width="100%"
                           >
                             <mock-typography
-                              classname="makeStyles-updateInfoText-916"
+                              classname="makeStyles-updateInfoText-904"
                               variant="caption"
                             >
                               No data available
                             </mock-typography>
                             <mock-typography
-                              classname="makeStyles-updateInfoText-916"
+                              classname="makeStyles-updateInfoText-904"
                               variant="caption"
                             >
                               Updated daily
@@ -1835,33 +1835,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-907 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-927 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-908 makeStyles-chip-914 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-913 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-924"
+                              class="makeStyles-link-911"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-922"
+                                classname="makeStyles-chipText-909"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-925"
+                                class="makeStyles-sensorImage-912"
                                 src="satellite.svg"
                               />
                             </a>
@@ -1878,13 +1878,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-878"
+              class="makeStyles-card-866"
             >
               <mock-card
-                classname="TemperatureChangeComponent-root-937"
+                classname="TemperatureChangeComponent-root-924"
               >
                 <div
-                  class="MuiCardHeader-root TemperatureChangeComponent-header-932 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root TemperatureChangeComponent-header-919 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -1899,7 +1899,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="TemperatureChangeComponent-cardTitle-931"
+                            classname="TemperatureChangeComponent-cardTitle-918"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -1911,21 +1911,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="TemperatureChangeComponent-content-938"
+                  classname="TemperatureChangeComponent-content-925"
                 >
                   <mock-box
-                    classname="TemperatureChangeComponent-cardContent-939"
+                    classname="TemperatureChangeComponent-cardContent-926"
                   >
                     <mock-box
-                      classname="TemperatureChangeComponent-tempContainer-941 TemperatureChangeComponent-tempIncreased-942"
+                      classname="TemperatureChangeComponent-tempContainer-928 TemperatureChangeComponent-tempIncreased-929"
                     >
                       <svg
-                        class="TemperatureChangeComponent-icon-944"
+                        class="TemperatureChangeComponent-icon-931"
                       >
                         caret.svg
                       </svg>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperatureChange-940"
+                        classname="TemperatureChangeComponent-temperatureChange-927"
                         variant="h1"
                       >
                         +
@@ -1935,7 +1935,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                     <mock-box>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperature-946"
+                        classname="TemperatureChangeComponent-temperature-933"
                         color="textSecondary"
                         variant="h4"
                       >
@@ -1951,10 +1951,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                   </mock-box>
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-901 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-947 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-905 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -1964,7 +1964,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         >
                           <svg
                             aria-hidden="true"
-                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
+                            class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-903 css-120dh41-MuiSvgIcon-root"
                             data-testid="UpdateIcon"
                             focusable="false"
                             viewBox="0 0 24 24"
@@ -1975,7 +1975,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </svg>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-906 css-x7bhrq-MuiGrid-root"
                         >
                           <mock-box
                             display="flex"
@@ -1983,13 +1983,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             width="100%"
                           >
                             <mock-typography
-                              classname="makeStyles-updateInfoText-916"
+                              classname="makeStyles-updateInfoText-904"
                               variant="caption"
                             >
                               Last data received 5 min. ago
                             </mock-typography>
                             <mock-typography
-                              classname="makeStyles-updateInfoText-916"
+                              classname="makeStyles-updateInfoText-904"
                               variant="caption"
                             >
                               Updated daily
@@ -1999,33 +1999,33 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-907 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-948 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-908 makeStyles-chip-934 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-913 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-924"
+                              class="makeStyles-link-911"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-922"
+                                classname="makeStyles-chipText-909"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-925"
+                                class="makeStyles-sensorImage-912"
                                 src="satellite.svg"
                               />
                             </a>
@@ -2042,13 +2042,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-878"
+              class="makeStyles-card-866"
             >
               <mock-card
-                classname="Bleaching-root-958"
+                classname="Bleaching-root-944"
               >
                 <div
-                  class="MuiCardHeader-root Bleaching-header-953 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Bleaching-header-939 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -2063,7 +2063,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Bleaching-cardTitle-952"
+                            classname="Bleaching-cardTitle-938"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -2075,21 +2075,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Bleaching-contentWrapper-959"
+                  classname="Bleaching-contentWrapper-945"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-960 css-ci9zny-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-946 css-ci9zny-MuiGrid-root"
                   >
                     <img
                       alt="alert-level"
-                      class="Bleaching-alertImage-961"
+                      class="Bleaching-alertImage-947"
                       src="/src/assets/alerts/alert_nostress.svg"
                     />
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 makeStyles-withMargin-914 css-1urtxze-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-901 makeStyles-withMargin-902 css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-962 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-905 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -2099,7 +2099,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-903 css-120dh41-MuiSvgIcon-root"
                               data-testid="UpdateIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -2110,7 +2110,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             </svg>
                           </div>
                           <div
-                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
+                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-906 css-x7bhrq-MuiGrid-root"
                           >
                             <mock-box
                               display="flex"
@@ -2118,13 +2118,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                               width="100%"
                             >
                               <mock-typography
-                                classname="makeStyles-updateInfoText-916"
+                                classname="makeStyles-updateInfoText-904"
                                 variant="caption"
                               >
                                 No data available
                               </mock-typography>
                               <mock-typography
-                                classname="makeStyles-updateInfoText-916"
+                                classname="makeStyles-updateInfoText-904"
                                 variant="caption"
                               >
                                 Updated daily
@@ -2134,27 +2134,27 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-907 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-963 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-908 makeStyles-chip-948 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-913 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-924"
+                                class="makeStyles-link-911"
                                 href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-922"
+                                  classname="makeStyles-chipText-909"
                                 >
                                   NOAA CRW
                                 </mock-typography>
@@ -2173,40 +2173,40 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-6 MuiGrid-grid-md-3 css-1bmkibp-MuiGrid-root"
           >
             <div
-              class="makeStyles-card-878"
+              class="makeStyles-card-866"
             >
               <mock-card
-                classname="makeStyles-root-973"
+                classname="makeStyles-root-958"
               >
                 <mock-cardcontent
-                  classname="makeStyles-contentWrapper-977"
+                  classname="makeStyles-contentWrapper-962"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-978 css-182mpp5-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-963 css-182mpp5-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-961 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-967 makeStyles-coloredText-974"
+                        classname="makeStyles-cardTitle-952 makeStyles-coloredText-959"
                         variant="h6"
                       >
                         WIND
                       </mock-typography>
                       <img
                         alt="wind"
-                        class="makeStyles-titleImages-975"
+                        class="makeStyles-titleImages-960"
                         src="data:image/svg+xml,%3csvg%20width='40'%20height='32'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M25.034%202.516a8.027%208.027%200%2000-2.354%205.68.766.766%200%20101.53%200%206.503%206.503%200%20116.503%206.503H1.076a.763.763%200%20100%201.529h29.637a8.03%208.03%200%20006.957-12.05%208.03%208.03%200%2000-12.636-1.662z'/%3e%3cpath%20d='M2.607%2010.109a.765.765%200%20100%201.529h14.335a4.206%204.206%200%20002.977-7.182%204.208%204.208%200%2000-7.184%202.975.764.764%200%20101.53%200%202.677%202.677%200%20112.678%202.678H2.607zM26.123%2018.906H2.607a.766.766%200%20100%201.53h23.36a4.363%204.363%200%2011-1.67%208.397%204.365%204.365%200%2001-2.695-4.032.764.764%200%2010-1.53%200%205.892%205.892%200%20005.796%205.885A5.892%205.892%200%200031.858%2025a5.891%205.891%200%2000-1.544-4.186%205.888%205.888%200%2000-4.033-1.906.711.711%200%2000-.158%200z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-961 css-wcmnoq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-969"
+                          classname="makeStyles-contentTextTitles-954"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2216,7 +2216,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-970"
+                            classname="makeStyles-contentTextValues-955"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2228,7 +2228,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-969"
+                          classname="makeStyles-contentTextTitles-954"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2238,7 +2238,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-970"
+                            classname="makeStyles-contentTextValues-955"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2248,28 +2248,28 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-961 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-967 makeStyles-coloredText-974"
+                        classname="makeStyles-cardTitle-952 makeStyles-coloredText-959"
                         variant="h6"
                       >
                         WAVES
                       </mock-typography>
                       <img
                         alt="waves"
-                        class="makeStyles-titleImages-975"
+                        class="makeStyles-titleImages-960"
                         src="data:image/svg+xml,%3csvg%20width='42'%20height='23'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M.615%2019.218c1.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.791%202.81%206.129%202.81%202.593%200%205.009-1.25%206.63-3.424a.656.656%200%2000-.119-.904.619.619%200%2000-.881.121c-1.38%201.853-3.43%202.915-5.628%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397zM3.428%2010.994c1.596%201.795%203.791%202.81%206.129%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.593%200%205.009-1.249%206.63-3.424a.656.656%200%2000-.118-.903.619.619%200%2000-.882.12c-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-1%200-1.379%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-.309.415.05.914.491%201.397zM.615%202.77c1.596%201.796%203.79%202.81%206.128%202.81s4.533-1.014%206.129-2.81c1.596%201.796%203.79%202.81%206.128%202.81%202.337%200%204.532-1.014%206.128-2.81%201.596%201.796%203.791%202.81%206.129%202.81%202.593%200%205.009-1.248%206.63-3.423a.656.656%200%2000-.119-.904.619.619%200%2000-.881.12c-1.38%201.854-3.43%202.916-5.628%202.916-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-976 css-mi7qmn-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-961 css-mi7qmn-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4 css-119abwu-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-969"
+                          classname="makeStyles-contentTextTitles-954"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2279,7 +2279,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-970"
+                            classname="makeStyles-contentTextValues-955"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2291,7 +2291,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3 css-q8d82a-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-969"
+                          classname="makeStyles-contentTextTitles-954"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2301,7 +2301,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-970"
+                            classname="makeStyles-contentTextValues-955"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2313,7 +2313,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5 css-7v7ljq-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-969"
+                          classname="makeStyles-contentTextTitles-954"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -2323,7 +2323,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-970"
+                            classname="makeStyles-contentTextValues-955"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -2333,10 +2333,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-913 false css-1urtxze-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-901 false css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-917 makeStyles-dateInfoWrapper-984 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-905 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -2346,7 +2346,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           >
                             <svg
                               aria-hidden="true"
-                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-915 css-120dh41-MuiSvgIcon-root"
+                              class="MuiSvgIcon-root MuiSvgIcon-fontSizeSmall makeStyles-updateIcon-903 css-120dh41-MuiSvgIcon-root"
                               data-testid="UpdateIcon"
                               focusable="false"
                               viewBox="0 0 24 24"
@@ -2357,7 +2357,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             </svg>
                           </div>
                           <div
-                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-918 css-x7bhrq-MuiGrid-root"
+                            class="MuiGrid-root MuiGrid-item makeStyles-dateInfo-906 css-x7bhrq-MuiGrid-root"
                           >
                             <mock-box
                               display="flex"
@@ -2365,13 +2365,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                               width="100%"
                             >
                               <mock-typography
-                                classname="makeStyles-updateInfoText-916"
+                                classname="makeStyles-updateInfoText-904"
                                 variant="caption"
                               >
                                 No data available
                               </mock-typography>
                               <mock-typography
-                                classname="makeStyles-updateInfoText-916"
+                                classname="makeStyles-updateInfoText-904"
                                 variant="caption"
                               >
                                 Updated every 6 hours
@@ -2381,27 +2381,27 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         </div>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-919 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-907 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-985 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-908 makeStyles-chip-969 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-913 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-924"
+                                class="makeStyles-link-911"
                                 href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-922"
+                                  classname="makeStyles-chipText-909"
                                 >
                                   WIND
                                 </mock-typography>
@@ -2410,24 +2410,24 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </div>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-921 makeStyles-chip-986 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-908 makeStyles-chip-970 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-926 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-913 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-924"
+                                class="makeStyles-link-911"
                                 href="https://open-meteo.com/en/docs/marine-weather-api"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-922"
+                                  classname="makeStyles-chipText-909"
                                 >
                                   WAVE
                                 </mock-typography>
@@ -2448,17 +2448,17 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         >
           <div>
             <mock-box
-              classname="makeStyles-graphtTitleWrapper-988"
+              classname="makeStyles-graphtTitleWrapper-972"
             >
               <mock-typography
-                classname="makeStyles-graphTitle-989"
+                classname="makeStyles-graphTitle-973"
                 variant="h6"
               >
                 HEAT STRESS ANALYSIS (°C)
               </mock-typography>
             </mock-box>
             <div
-              class="makeStyles-chart-987"
+              class="makeStyles-chart-971"
             >
               <mock-line
                 data="[object Object]"
@@ -2477,7 +2477,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             open="false"
           >
             <mock-dialogtitle
-              classname="Dialog-dialogTitle-1003"
+              classname="Dialog-dialogTitle-987"
             >
               <mock-typography
                 variant="h4"
@@ -2512,7 +2512,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             </mock-dialogactions>
           </mock-dialog>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-994 css-4rolpp-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-978 css-4rolpp-MuiGrid-root"
           >
             <mock-box
               bgcolor="#f5f6f6"
@@ -2522,13 +2522,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               zindex="-1"
             />
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-995 css-wdlm1q-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-979 css-wdlm1q-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-md-12 MuiGrid-grid-lg-3 css-ku179n-MuiGrid-root"
               >
                 <mock-typography
-                  classname="makeStyles-title-996"
+                  classname="makeStyles-title-980"
                 >
                   Survey History
                 </mock-typography>
@@ -2540,14 +2540,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-1005"
+                    classname="makeStyles-subTitle-989"
                     variant="h6"
                   >
                     Survey Point:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-1006 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-990 css-x7bhrq-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container css-1rp4aer-MuiGrid-root"
@@ -2556,7 +2556,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-1007 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-991 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                       >
                         <div
                           aria-expanded="false"
@@ -2600,32 +2600,32 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-997"
+                    classname="makeStyles-subTitle-981"
                     variant="h6"
                   >
                     Observation:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-998 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-982 css-x7bhrq-MuiGrid-root"
                 >
                   <div
-                    class="MuiFormControl-root makeStyles-formControl-999 css-1iw3t7y-MuiFormControl-root"
+                    class="MuiFormControl-root makeStyles-formControl-983 css-1iw3t7y-MuiFormControl-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-1000 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-984 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                     >
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="survey-observation survey-observation"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-1002 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-986 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         id="survey-observation"
                         role="combobox"
                         tabindex="0"
                       >
                         <mock-typography
-                          classname="makeStyles-menuItem-1001"
+                          classname="makeStyles-menuItem-985"
                           variant="h6"
                         >
                           Any
@@ -2659,7 +2659,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 css-fgj1s9-MuiGrid-root"
             >
               <div
-                class="SurveyTimeline-root-1014"
+                class="SurveyTimeline-root-998"
               >
                 <mock-hidden
                   lgdown="true"
@@ -2668,13 +2668,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiTimeline-root MuiTimeline-positionRight css-i6popu-MuiTimeline-root"
                   >
                     <li
-                      class="MuiTimelineItem-root MuiTimelineItem-positionRight makeStyles-timelineItem-1023 css-ny8qih-MuiTimelineItem-root"
+                      class="MuiTimelineItem-root MuiTimelineItem-positionRight makeStyles-timelineItem-1007 css-ny8qih-MuiTimelineItem-root"
                     >
                       <div
-                        class="MuiTypography-root MuiTypography-body1 MuiTimelineOppositeContent-root MuiTimelineOppositeContent-positionRight makeStyles-timelineOppositeContent-1024 css-193a741-MuiTypography-root-MuiTimelineOppositeContent-root"
+                        class="MuiTypography-root MuiTypography-body1 MuiTimelineOppositeContent-root MuiTimelineOppositeContent-positionRight makeStyles-timelineOppositeContent-1008 css-193a741-MuiTypography-root-MuiTimelineOppositeContent-root"
                       >
                         <mock-typography
-                          classname="makeStyles-dates-1016"
+                          classname="makeStyles-dates-1000"
                           variant="h6"
                         >
                           09/10/2020
@@ -2684,20 +2684,20 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiTimelineSeparator-root css-1muvgbz-MuiTimelineSeparator-root"
                       >
                         <hr
-                          class="makeStyles-connector-1027"
+                          class="makeStyles-connector-1011"
                         />
                         <span
-                          class="MuiTimelineDot-root MuiTimelineDot-outlined MuiTimelineDot-outlinedGrey makeStyles-dot-1028 css-6xp33q-MuiTimelineDot-root"
+                          class="MuiTimelineDot-root MuiTimelineDot-outlined MuiTimelineDot-outlinedGrey makeStyles-dot-1012 css-6xp33q-MuiTimelineDot-root"
                         />
                         <hr
-                          class="makeStyles-connector-1027"
+                          class="makeStyles-connector-1011"
                         />
                       </div>
                       <div
-                        class="MuiTypography-root MuiTypography-body1 MuiTimelineContent-root MuiTimelineContent-positionRight makeStyles-surveyCardWrapper-1018 css-1qq9j0n-MuiTypography-root-MuiTimelineContent-root"
+                        class="MuiTypography-root MuiTypography-body1 MuiTimelineContent-root MuiTimelineContent-positionRight makeStyles-surveyCardWrapper-1002 css-1qq9j0n-MuiTypography-root-MuiTimelineContent-root"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1036 css-14gemme-MuiPaper-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1020 css-14gemme-MuiPaper-root"
                           style="--Paper-shadow: none;"
                         >
                           <div
@@ -2705,56 +2705,56 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             style="height: 100%;"
                           >
                             <div
-                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1040 css-1ej0ikx-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1024 css-1ej0ikx-MuiGrid-root"
                             >
                               <a
                                 data-discover="true"
                                 href="/sites/1/survey_details/46"
                               >
                                 <div
-                                  class="MuiCardMedia-root makeStyles-cardImage-1037 css-utntyq-MuiCardMedia-root"
+                                  class="MuiCardMedia-root makeStyles-cardImage-1021 css-utntyq-MuiCardMedia-root"
                                   role="img"
                                   style="background-image: url("image-url");"
                                 />
                               </a>
                             </div>
                             <div
-                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1041 css-14c8q5g-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1025 css-14c8q5g-MuiGrid-root"
                             >
                               <div
-                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1046 css-aksm9b-MuiGrid-root"
+                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1030 css-aksm9b-MuiGrid-root"
                               >
                                 <div
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1038"
+                                    classname="makeStyles-cardFields-1022"
                                     variant="h6"
                                   >
                                     User:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
+                                    classname="makeStyles-cardValues-1023 makeStyles-valuesWithMargin-1028"
                                     variant="h6"
                                   >
                                     Joe Doe
                                   </mock-typography>
                                 </div>
                                 <div
-                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1042 css-otecwo-MuiGrid-root"
+                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1026 css-otecwo-MuiGrid-root"
                                 >
                                   <div
                                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                                     style="height: 80%;"
                                   >
                                     <mock-typography
-                                      classname="makeStyles-cardFields-1038"
+                                      classname="makeStyles-cardFields-1022"
                                       variant="h6"
                                     >
                                       Comments:
                                     </mock-typography>
                                     <mock-typography
-                                      classname="makeStyles-cardValues-1039 makeStyles-comments-1043"
+                                      classname="makeStyles-cardValues-1023 makeStyles-comments-1027"
                                       variant="h6"
                                     >
                                       No comments
@@ -2765,13 +2765,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1038"
+                                    classname="makeStyles-cardFields-1022"
                                     variant="h6"
                                   >
                                     Temp:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
+                                    classname="makeStyles-cardValues-1023 makeStyles-valuesWithMargin-1028"
                                     variant="h6"
                                   >
                                     10.0 °C
@@ -2813,23 +2813,23 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-wcmnoq-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyWrapper-1060 css-ldi2p4-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyWrapper-1044 css-ldi2p4-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11 makeStyles-dateWrapper-1051 css-tideur-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-11 makeStyles-dateWrapper-1035 css-tideur-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-dates-1052"
+                          classname="makeStyles-dates-1036"
                           variant="h6"
                         >
                           09/10/2020
                         </mock-typography>
                       </div>
                       <div
-                        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyCardWrapper-1054 css-wcmnoq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-surveyCardWrapper-1038 css-wcmnoq-MuiGrid-root"
                       >
                         <div
-                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1036 css-14gemme-MuiPaper-root"
+                          class="MuiPaper-root MuiPaper-elevation MuiPaper-rounded MuiPaper-elevation0 makeStyles-surveyCard-1020 css-14gemme-MuiPaper-root"
                           style="--Paper-shadow: none;"
                         >
                           <div
@@ -2837,56 +2837,56 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                             style="height: 100%;"
                           >
                             <div
-                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1040 css-1ej0ikx-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-5 makeStyles-cardImageWrapper-1024 css-1ej0ikx-MuiGrid-root"
                             >
                               <a
                                 data-discover="true"
                                 href="/sites/1/survey_details/46"
                               >
                                 <div
-                                  class="MuiCardMedia-root makeStyles-cardImage-1037 css-utntyq-MuiCardMedia-root"
+                                  class="MuiCardMedia-root makeStyles-cardImage-1021 css-utntyq-MuiCardMedia-root"
                                   role="img"
                                   style="background-image: url("image-url");"
                                 />
                               </a>
                             </div>
                             <div
-                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1041 css-14c8q5g-MuiGrid-root"
+                              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-7 makeStyles-infoWrapper-1025 css-14c8q5g-MuiGrid-root"
                             >
                               <div
-                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1046 css-aksm9b-MuiGrid-root"
+                                class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-info-1030 css-aksm9b-MuiGrid-root"
                               >
                                 <div
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1038"
+                                    classname="makeStyles-cardFields-1022"
                                     variant="h6"
                                   >
                                     User:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
+                                    classname="makeStyles-cardValues-1023 makeStyles-valuesWithMargin-1028"
                                     variant="h6"
                                   >
                                     Joe Doe
                                   </mock-typography>
                                 </div>
                                 <div
-                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1042 css-otecwo-MuiGrid-root"
+                                  class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-commentsWrapper-1026 css-otecwo-MuiGrid-root"
                                 >
                                   <div
                                     class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                                     style="height: 80%;"
                                   >
                                     <mock-typography
-                                      classname="makeStyles-cardFields-1038"
+                                      classname="makeStyles-cardFields-1022"
                                       variant="h6"
                                     >
                                       Comments:
                                     </mock-typography>
                                     <mock-typography
-                                      classname="makeStyles-cardValues-1039 makeStyles-comments-1043"
+                                      classname="makeStyles-cardValues-1023 makeStyles-comments-1027"
                                       variant="h6"
                                     >
                                       No comments
@@ -2897,13 +2897,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                                   class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 css-1rc1zen-MuiGrid-root"
                                 >
                                   <mock-typography
-                                    classname="makeStyles-cardFields-1038"
+                                    classname="makeStyles-cardFields-1022"
                                     variant="h6"
                                   >
                                     Temp:
                                   </mock-typography>
                                   <mock-typography
-                                    classname="makeStyles-cardValues-1039 makeStyles-valuesWithMargin-1044"
+                                    classname="makeStyles-cardValues-1023 makeStyles-valuesWithMargin-1028"
                                     variant="h6"
                                   >
                                     10.0 °C
@@ -2947,7 +2947,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           title="Ask AI about coral bleaching and heat stress"
         >
           <button
-            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-1090 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
+            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-1074 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
             style="background-image: url("/src/assets/aiChat.png"); background-size: cover; background-position: center; background-color: rgb(40, 115, 197);"
             tabindex="0"
             type="button"
@@ -2957,7 +2957,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
     </div>
   </div>
   <mock-appbar
-    classname="Footer-appBar-1113"
+    classname="Footer-appBar-1097"
     position="static"
   >
     <mock-toolbar>
@@ -2968,7 +2968,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
         >
           <mock-link
-            classname="Footer-navBarLink-1114"
+            classname="Footer-navBarLink-1098"
             href="/map"
             underline="hover"
           >
@@ -4803,7 +4803,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-97 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -4851,30 +4851,30 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-104 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-103 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-101"
+                              class="makeStyles-link-100"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-99"
+                                classname="makeStyles-chipText-98"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-102"
+                                class="makeStyles-sensorImage-101"
                                 src="satellite.svg"
                               />
                             </a>
@@ -4894,10 +4894,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="TemperatureChangeComponent-root-114"
+                classname="TemperatureChangeComponent-root-113"
               >
                 <div
-                  class="MuiCardHeader-root TemperatureChangeComponent-header-109 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root TemperatureChangeComponent-header-108 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -4912,7 +4912,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="TemperatureChangeComponent-cardTitle-108"
+                            classname="TemperatureChangeComponent-cardTitle-107"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -4924,21 +4924,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="TemperatureChangeComponent-content-115"
+                  classname="TemperatureChangeComponent-content-114"
                 >
                   <mock-box
-                    classname="TemperatureChangeComponent-cardContent-116"
+                    classname="TemperatureChangeComponent-cardContent-115"
                   >
                     <mock-box
-                      classname="TemperatureChangeComponent-tempContainer-118 TemperatureChangeComponent-tempIncreased-119"
+                      classname="TemperatureChangeComponent-tempContainer-117 TemperatureChangeComponent-tempIncreased-118"
                     >
                       <svg
-                        class="TemperatureChangeComponent-icon-121"
+                        class="TemperatureChangeComponent-icon-120"
                       >
                         caret.svg
                       </svg>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperatureChange-117"
+                        classname="TemperatureChangeComponent-temperatureChange-116"
                         variant="h1"
                       >
                         +
@@ -4948,7 +4948,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     </mock-box>
                     <mock-box>
                       <mock-typography
-                        classname="TemperatureChangeComponent-temperature-123"
+                        classname="TemperatureChangeComponent-temperature-122"
                         color="textSecondary"
                         variant="h4"
                       >
@@ -4967,7 +4967,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                     class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-124 css-x7bhrq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 css-x7bhrq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -5015,30 +5015,30 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-125 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-123 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                         >
                           <button
-                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                            class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                             tabindex="0"
                             type="button"
                           >
                             <a
-                              class="makeStyles-link-101"
+                              class="makeStyles-link-100"
                               href="https://coralreefwatch.noaa.gov/"
                               rel="noopener noreferrer"
                               target="_blank"
                             >
                               <mock-typography
-                                classname="makeStyles-chipText-99"
+                                classname="makeStyles-chipText-98"
                               >
                                 NOAA
                               </mock-typography>
                               <img
                                 alt="sensor-type"
-                                class="makeStyles-sensorImage-102"
+                                class="makeStyles-sensorImage-101"
                                 src="satellite.svg"
                               />
                             </a>
@@ -5058,10 +5058,10 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="Bleaching-root-135"
+                classname="Bleaching-root-133"
               >
                 <div
-                  class="MuiCardHeader-root Bleaching-header-130 css-149tc0y-MuiCardHeader-root"
+                  class="MuiCardHeader-root Bleaching-header-128 css-149tc0y-MuiCardHeader-root"
                 >
                   <div
                     class="MuiCardHeader-content css-1jkp9bu-MuiCardHeader-content"
@@ -5076,7 +5076,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 css-z4k4cw-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="Bleaching-cardTitle-129"
+                            classname="Bleaching-cardTitle-127"
                             color="textSecondary"
                             variant="h6"
                           >
@@ -5088,21 +5088,21 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   </div>
                 </div>
                 <mock-cardcontent
-                  classname="Bleaching-contentWrapper-136"
+                  classname="Bleaching-contentWrapper-134"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-137 css-ci9zny-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 Bleaching-content-135 css-ci9zny-MuiGrid-root"
                   >
                     <img
                       alt="alert-level"
-                      class="Bleaching-alertImage-138"
+                      class="Bleaching-alertImage-136"
                       src="/src/assets/alerts/alert_nostress.svg"
                     />
                     <div
                       class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 makeStyles-withMargin-91 css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-139 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -5150,24 +5150,24 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-140 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-137 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-101"
+                                class="makeStyles-link-100"
                                 href="https://coralreefwatch.noaa.gov/product/5km/index_5km_baa-max-7d.php"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-99"
+                                  classname="makeStyles-chipText-98"
                                 >
                                   NOAA CRW
                                 </mock-typography>
@@ -5189,37 +5189,37 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="makeStyles-card-57"
             >
               <mock-card
-                classname="makeStyles-root-150"
+                classname="makeStyles-root-147"
               >
                 <mock-cardcontent
-                  classname="makeStyles-contentWrapper-154"
+                  classname="makeStyles-contentWrapper-151"
                 >
                   <div
-                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-155 css-182mpp5-MuiGrid-root"
+                    class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-content-152 css-182mpp5-MuiGrid-root"
                   >
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-150 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-144 makeStyles-coloredText-151"
+                        classname="makeStyles-cardTitle-141 makeStyles-coloredText-148"
                         variant="h6"
                       >
                         WIND
                       </mock-typography>
                       <img
                         alt="wind"
-                        class="makeStyles-titleImages-152"
+                        class="makeStyles-titleImages-149"
                         src="data:image/svg+xml,%3csvg%20width='40'%20height='32'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M25.034%202.516a8.027%208.027%200%2000-2.354%205.68.766.766%200%20101.53%200%206.503%206.503%200%20116.503%206.503H1.076a.763.763%200%20100%201.529h29.637a8.03%208.03%200%20006.957-12.05%208.03%208.03%200%2000-12.636-1.662z'/%3e%3cpath%20d='M2.607%2010.109a.765.765%200%20100%201.529h14.335a4.206%204.206%200%20002.977-7.182%204.208%204.208%200%2000-7.184%202.975.764.764%200%20101.53%200%202.677%202.677%200%20112.678%202.678H2.607zM26.123%2018.906H2.607a.766.766%200%20100%201.53h23.36a4.363%204.363%200%2011-1.67%208.397%204.365%204.365%200%2001-2.695-4.032.764.764%200%2010-1.53%200%205.892%205.892%200%20005.796%205.885A5.892%205.892%200%200031.858%2025a5.891%205.891%200%2000-1.544-4.186%205.888%205.888%200%2000-4.033-1.906.711.711%200%2000-.158%200z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-150 css-wcmnoq-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-146"
+                          classname="makeStyles-contentTextTitles-143"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5229,7 +5229,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-147"
+                            classname="makeStyles-contentTextValues-144"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5241,7 +5241,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 css-13kechv-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-146"
+                          classname="makeStyles-contentTextTitles-143"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5251,7 +5251,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-147"
+                            classname="makeStyles-contentTextValues-144"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5261,28 +5261,28 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       </div>
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-wcmnoq-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-150 css-wcmnoq-MuiGrid-root"
                     >
                       <mock-typography
-                        classname="makeStyles-cardTitle-144 makeStyles-coloredText-151"
+                        classname="makeStyles-cardTitle-141 makeStyles-coloredText-148"
                         variant="h6"
                       >
                         WAVES
                       </mock-typography>
                       <img
                         alt="waves"
-                        class="makeStyles-titleImages-152"
+                        class="makeStyles-titleImages-149"
                         src="data:image/svg+xml,%3csvg%20width='42'%20height='23'%20xmlns='http://www.w3.org/2000/svg'%3e%3cg%20fill='%236BC1E1'%20fill-rule='evenodd'%20opacity='.5'%3e%3cpath%20d='M.615%2019.218c1.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.791%202.81%206.129%202.81%202.593%200%205.009-1.25%206.63-3.424a.656.656%200%2000-.119-.904.619.619%200%2000-.881.121c-1.38%201.853-3.43%202.915-5.628%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397zM3.428%2010.994c1.596%201.795%203.791%202.81%206.129%202.81%202.337%200%204.532-1.015%206.128-2.81%201.596%201.795%203.79%202.81%206.128%202.81s4.533-1.015%206.129-2.81c1.596%201.795%203.79%202.81%206.128%202.81%202.593%200%205.009-1.249%206.63-3.424a.656.656%200%2000-.118-.903.619.619%200%2000-.882.12c-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-1%200-1.379%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-.309.415.05.914.491%201.397zM.615%202.77c1.596%201.796%203.79%202.81%206.128%202.81s4.533-1.014%206.129-2.81c1.596%201.796%203.79%202.81%206.128%202.81%202.337%200%204.532-1.014%206.128-2.81%201.596%201.796%203.791%202.81%206.129%202.81%202.593%200%205.009-1.248%206.63-3.423a.656.656%200%2000-.119-.904.619.619%200%2000-.881.12c-1.38%201.854-3.43%202.916-5.628%202.916-2.197%200-4.25-1.062-5.627-2.915-.238-.32-.761-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.197%200-4.25-1.062-5.627-2.915-.239-.32-.762-.32-1%200-1.38%201.853-3.43%202.915-5.627%202.915-2.198%200-4.25-1.062-5.628-2.915-.238-.32-.76-.32-.999%200-.309.415.05.914.49%201.397z'/%3e%3c/g%3e%3c/svg%3e"
                       />
                     </div>
                     <div
-                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-153 css-mi7qmn-MuiGrid-root"
+                      class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 makeStyles-paddingContainer-150 css-mi7qmn-MuiGrid-root"
                     >
                       <div
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-4 css-119abwu-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-146"
+                          classname="makeStyles-contentTextTitles-143"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5292,7 +5292,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-147"
+                            classname="makeStyles-contentTextValues-144"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5304,7 +5304,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-3 css-q8d82a-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-146"
+                          classname="makeStyles-contentTextTitles-143"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5314,7 +5314,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-147"
+                            classname="makeStyles-contentTextValues-144"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5326,7 +5326,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item MuiGrid-grid-lg-5 css-7v7ljq-MuiGrid-root"
                       >
                         <mock-typography
-                          classname="makeStyles-contentTextTitles-146"
+                          classname="makeStyles-contentTextTitles-143"
                           color="textSecondary"
                           variant="subtitle2"
                         >
@@ -5336,7 +5336,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           class="MuiGrid-root MuiGrid-container css-eiox0h-MuiGrid-root"
                         >
                           <mock-typography
-                            classname="makeStyles-contentTextValues-147"
+                            classname="makeStyles-contentTextValues-144"
                             color="textSecondary"
                             variant="h3"
                           >
@@ -5349,7 +5349,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-container MuiGrid-item makeStyles-updateInfo-90 false css-1urtxze-MuiGrid-root"
                     >
                       <div
-                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 makeStyles-dateInfoWrapper-161 css-x7bhrq-MuiGrid-root"
+                        class="MuiGrid-root MuiGrid-item makeStyles-dateInfoWrapper-94 css-x7bhrq-MuiGrid-root"
                       >
                         <div
                           class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
@@ -5397,24 +5397,24 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                         class="MuiGrid-root MuiGrid-item makeStyles-chipsWrapper-96 css-x7bhrq-MuiGrid-root"
                       >
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-162 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-158 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-101"
+                                class="makeStyles-link-100"
                                 href="https://www.ncdc.noaa.gov/data-access/model-data/model-datasets/global-forcast-system-gfs"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-99"
+                                  classname="makeStyles-chipText-98"
                                 >
                                   WIND
                                 </mock-typography>
@@ -5423,24 +5423,24 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                           </div>
                         </div>
                         <div
-                          class="MuiGrid-root MuiGrid-item makeStyles-chip-98 makeStyles-chip-163 css-x7bhrq-MuiGrid-root"
+                          class="MuiGrid-root MuiGrid-item makeStyles-chip-97 makeStyles-chip-159 css-x7bhrq-MuiGrid-root"
                         >
                           <div
                             class="MuiGrid-root MuiGrid-container css-6zo1m7-MuiGrid-root"
                           >
                             <button
-                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-103 css-1ysap08-MuiButtonBase-root-MuiButton-root"
+                              class="MuiButtonBase-root MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary MuiButton-root MuiButton-text MuiButton-textPrimary MuiButton-sizeMedium MuiButton-textSizeMedium MuiButton-colorPrimary makeStyles-button-102 css-1ysap08-MuiButtonBase-root-MuiButton-root"
                               tabindex="0"
                               type="button"
                             >
                               <a
-                                class="makeStyles-link-101"
+                                class="makeStyles-link-100"
                                 href="https://open-meteo.com/en/docs/marine-weather-api"
                                 rel="noopener noreferrer"
                                 target="_blank"
                               >
                                 <mock-typography
-                                  classname="makeStyles-chipText-99"
+                                  classname="makeStyles-chipText-98"
                                 >
                                   WAVE
                                 </mock-typography>
@@ -5461,17 +5461,17 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
         >
           <div>
             <mock-box
-              classname="makeStyles-graphtTitleWrapper-165"
+              classname="makeStyles-graphtTitleWrapper-161"
             >
               <mock-typography
-                classname="makeStyles-graphTitle-166"
+                classname="makeStyles-graphTitle-162"
                 variant="h6"
               >
                 HEAT STRESS ANALYSIS (°C)
               </mock-typography>
             </mock-box>
             <div
-              class="makeStyles-chart-164"
+              class="makeStyles-chart-160"
             >
               <mock-line
                 data="[object Object]"
@@ -5490,7 +5490,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             open="false"
           >
             <mock-dialogtitle
-              classname="Dialog-dialogTitle-180"
+              classname="Dialog-dialogTitle-176"
             >
               <mock-typography
                 variant="h4"
@@ -5525,7 +5525,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
             </mock-dialogactions>
           </mock-dialog>
           <div
-            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-171 css-4rolpp-MuiGrid-root"
+            class="MuiGrid-root MuiGrid-container MuiGrid-spacing-xs-2 makeStyles-root-167 css-4rolpp-MuiGrid-root"
           >
             <mock-box
               bgcolor="#f5f6f6"
@@ -5535,13 +5535,13 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               zindex="-1"
             />
             <div
-              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-172 css-wdlm1q-MuiGrid-root"
+              class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-spacing-xs-1 MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 makeStyles-surveyWrapper-168 css-wdlm1q-MuiGrid-root"
             >
               <div
                 class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-md-12 MuiGrid-grid-lg-3 css-ku179n-MuiGrid-root"
               >
                 <mock-typography
-                  classname="makeStyles-title-173"
+                  classname="makeStyles-title-169"
                 >
                   Survey History
                 </mock-typography>
@@ -5553,14 +5553,14 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-182"
+                    classname="makeStyles-subTitle-178"
                     variant="h6"
                   >
                     Survey Point:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-183 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-179 css-x7bhrq-MuiGrid-root"
                 >
                   <div
                     class="MuiGrid-root MuiGrid-container css-1rp4aer-MuiGrid-root"
@@ -5569,7 +5569,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                       class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                     >
                       <div
-                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-184 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                        class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary makeStyles-selector-180 MuiSelect-root css-r2nq11-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                       >
                         <div
                           aria-expanded="false"
@@ -5613,32 +5613,32 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
                   class="MuiGrid-root MuiGrid-item css-x7bhrq-MuiGrid-root"
                 >
                   <mock-typography
-                    classname="makeStyles-subTitle-174"
+                    classname="makeStyles-subTitle-170"
                     variant="h6"
                   >
                     Observation:
                   </mock-typography>
                 </div>
                 <div
-                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-175 css-x7bhrq-MuiGrid-root"
+                  class="MuiGrid-root MuiGrid-item makeStyles-selectorWrapper-171 css-x7bhrq-MuiGrid-root"
                 >
                   <div
-                    class="MuiFormControl-root makeStyles-formControl-176 css-1iw3t7y-MuiFormControl-root"
+                    class="MuiFormControl-root makeStyles-formControl-172 css-1iw3t7y-MuiFormControl-root"
                   >
                     <div
-                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-177 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
+                      class="MuiInputBase-root MuiInput-root MuiInput-underline MuiInputBase-colorPrimary MuiInputBase-formControl makeStyles-selectedItem-173 MuiSelect-root css-qzew0s-MuiInputBase-root-MuiInput-root-MuiSelect-root"
                     >
                       <div
                         aria-expanded="false"
                         aria-haspopup="listbox"
                         aria-labelledby="survey-observation survey-observation"
-                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-179 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
+                        class="MuiSelect-select MuiSelect-standard MuiInputBase-input MuiInput-input makeStyles-textField-175 css-1f2i9o-MuiNativeSelect-root-MuiSelect-select-MuiInputBase-input-MuiInput-input"
                         id="survey-observation"
                         role="combobox"
                         tabindex="0"
                       >
                         <mock-typography
-                          classname="makeStyles-menuItem-178"
+                          classname="makeStyles-menuItem-174"
                           variant="h6"
                         >
                           Any
@@ -5672,7 +5672,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
               class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-lg-12 css-fgj1s9-MuiGrid-root"
             >
               <div
-                class="SurveyTimeline-root-191"
+                class="SurveyTimeline-root-187"
               >
                 <mock-hidden
                   lgdown="true"
@@ -5697,7 +5697,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           title="Ask AI about coral bleaching and heat stress"
         >
           <button
-            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-240 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
+            class="MuiButtonBase-root MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default MuiFab-root MuiFab-circular MuiFab-sizeLarge MuiFab-default ChatButton-chatButton-236 css-1qwkc5n-MuiButtonBase-root-MuiFab-root"
             style="background-image: url("/src/assets/aiChat.png"); background-size: cover; background-position: center; background-color: rgb(40, 115, 197);"
             tabindex="0"
             type="button"
@@ -5707,7 +5707,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
     </div>
   </div>
   <mock-appbar
-    classname="Footer-appBar-263"
+    classname="Footer-appBar-259"
     position="static"
   >
     <mock-toolbar>
@@ -5718,7 +5718,7 @@ exports[`Site Detail Page > should render with given state from Redux store > sn
           class="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-10 css-9ve18c-MuiGrid-root"
         >
           <mock-link
-            classname="Footer-navBarLink-264"
+            classname="Footer-navBarLink-260"
             href="/map"
             underline="hover"
           >

--- a/packages/website/src/store/Sites/helpers.ts
+++ b/packages/website/src/store/Sites/helpers.ts
@@ -335,7 +335,15 @@ export const parseLatestData = (
   const spotterValidityLimit = 12 * 60 * 60 * 1000; // 12 hours
   const validityDate = Date.now() - spotterValidityLimit;
 
-  // only keep spotter top/bottom temp for now and check for validity date
+  // Wave metrics are now sourced exclusively from Open-Meteo. Any
+  // sofar_model rows for these metrics are legacy leftovers from before
+  // the Open-Meteo migration and should never be displayed.
+  const waveMetrics = new Set([
+    'significant_wave_height',
+    'wave_mean_period',
+    'wave_mean_direction',
+  ]);
+
   const spotterTempWhitelist = new Set([
     'bottom_temperature',
     'top_temperature',
@@ -348,28 +356,24 @@ export const parseLatestData = (
     'dissolved_oxygen',
   ]);
 
-  const filtered = copy.filter(
-    (value) =>
-      // Allow spotter data if within validity window
+  const filtered = copy.filter((value) => {
+    if (waveMetrics.has(value.metric)) {
+      return value.source === 'open_meteo';
+    }
+
+    return (
       (value.source === 'spotter' &&
         new Date(value.timestamp).getTime() > validityDate) ||
-      // Allow seaphox data (no time restriction since it's sensor data)
       value.source === 'seaphox' ||
-      // Allow any data with metrics not in the whitelist
-      !spotterTempWhitelist.has(value.metric),
-  );
+      !spotterTempWhitelist.has(value.metric)
+    );
+  });
 
   // sort data by timestamp ASCENDING but prioritize spotter data
   // eslint-disable-next-line fp/no-mutating-methods
   const sorted = filtered.sort((x, y) => {
-    // if spotter data is available and, use it.
-    if (x.source === 'spotter' && y.source !== 'spotter') {
-      return +1;
-    }
-
-    if (y.source === 'spotter' && x.source !== 'spotter') {
-      return -1;
-    }
+    if (x.source === 'spotter' && y.source !== 'spotter') return +1;
+    if (y.source === 'spotter' && x.source !== 'spotter') return -1;
 
     const xTime = new Date(x.timestamp).getTime();
     const yTime = new Date(y.timestamp).getTime();
@@ -378,7 +382,6 @@ export const parseLatestData = (
     return 0;
   });
 
-  // reduce the array, into a mapping, keeping only the latest data for each metric
   return sorted.reduce(
     (a, c) => ({
       ...a,

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -131,7 +131,8 @@ export type Sources =
   | 'metlog'
   | 'hui'
   | 'sheet_data'
-  | 'seaphox';
+  | 'seaphox'
+  | 'open_meteo';
 
 export type LatestDataASSofarValue = {
   [keys in Metrics]?: ValueWithTimestamp;

--- a/scripts/yarn-audit-summary.js
+++ b/scripts/yarn-audit-summary.js
@@ -3,6 +3,27 @@
 
 const { spawnSync } = require('node:child_process');
 
+// Advisories that cannot be fixed without a major framework upgrade and whose
+// impact does not apply to this codebase. Each entry must document why.
+const IGNORED_ADVISORY_IDS = [
+  // GHSA-qwww-vcr4-c8h2: react-router RSC CSRF bypass.
+  // The advisory explicitly states this only affects the *unstable* RSC APIs,
+  // which this project does not use.  The patched version (react-router >=8.3.0)
+  // requires upgrading to React 19 and react-router v8 — a separate major
+  // undertaking tracked in its own future PR.
+  'GHSA-qwww-vcr4-c8h2',
+
+  // GHSA-mh99-v99m-4gvg / CVE-2026-14257: brace-expansion OOM via unbounded expansion.
+  // Path: api > typeorm > glob > minimatch > brace-expansion.
+  // The glob patterns in that chain (entity/migration file discovery) are
+  // server-controlled constants defined in ormconfig.ts — not user-supplied
+  // input — so this DoS vector is not reachable in practice.
+  // The patched version (brace-expansion >=5.0.8) requires upgrading TypeORM to
+  // v1.x (which replaces glob with tinyglobby) — a separate migration tracked in
+  // its own future PR.
+  'GHSA-mh99-v99m-4gvg',
+];
+
 function getAuditOptions() {
   return {
     level: 'moderate',
@@ -22,7 +43,11 @@ function parseAuditLines(lines) {
     })
     .filter(Boolean)
     .filter((entry) => entry.type === 'auditAdvisory')
-    .map((entry) => entry.data);
+    .map((entry) => entry.data)
+    .filter((data) => {
+      const ghsaId = data?.advisory?.github_advisory_id;
+      return !ghsaId || !IGNORED_ADVISORY_IDS.includes(ghsaId);
+    });
 }
 
 function formatAuditFailureReport(lines) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -527,7 +527,14 @@
     "@emnapi/wasi-threads" "1.1.0"
     tslib "^2.4.0"
 
-"@emnapi/runtime@^1.2.0", "@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.5.0":
+"@emnapi/runtime@^1.11.1":
+  version "1.11.3"
+  resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.11.3.tgz#84257ae3b0531eb2aec1ffa23d70700da007ba95"
+  integrity sha512-Xz4Tpyki7XyrpbUK1jR1AhdAdaXyhhY4lZ3neLodmhpuWfy2PAQN5B46sAiU4liOXGLkHypn/qU+jvfWSCYYLA==
+  dependencies:
+    tslib "^2.4.0"
+
+"@emnapi/runtime@^1.4.3", "@emnapi/runtime@^1.5.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@emnapi/runtime/-/runtime-1.7.1.tgz#a73784e23f5d57287369c808197288b52276b791"
   integrity sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==
@@ -1664,13 +1671,6 @@
   resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz"
   integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
-"@img/sharp-darwin-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz#ef5b5a07862805f1e8145a377c8ba6e98813ca08"
-  integrity sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==
-  optionalDependencies:
-    "@img/sharp-libvips-darwin-arm64" "1.0.4"
-
 "@img/sharp-darwin-arm64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz#6e0732dcade126b6670af7aa17060b926835ea86"
@@ -1678,12 +1678,12 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-arm64" "1.2.4"
 
-"@img/sharp-darwin-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz#e03d3451cd9e664faa72948cc70a403ea4063d61"
-  integrity sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==
+"@img/sharp-darwin-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.35.3.tgz#8b2740884bc58b127fc3020479a01294fa1095cb"
+  integrity sha512-RMnFX7YQsMoh7lWfcM4NEHHymBX/rLuKNPVM84XE9ONPcaSCDgE7CHIHpSgPcO2xcRthgBy1HfNO319mwhIAkg==
   optionalDependencies:
-    "@img/sharp-libvips-darwin-x64" "1.0.4"
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
 
 "@img/sharp-darwin-x64@0.34.5":
   version "0.34.5"
@@ -1692,102 +1692,119 @@
   optionalDependencies:
     "@img/sharp-libvips-darwin-x64" "1.2.4"
 
-"@img/sharp-libvips-darwin-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz#447c5026700c01a993c7804eb8af5f6e9868c07f"
-  integrity sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==
+"@img/sharp-darwin-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.35.3.tgz#92df91320faf57cc54b331185770d5a93d510049"
+  integrity sha512-Xo+5uFBtLN0BKqieTxiFzFPQAUlBbbH5iBKyRX/z1JrbnYsHTfKJnUfL8+p2TPXr1pXqao4eeL4Rl144uDpK9w==
+  optionalDependencies:
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+
+"@img/sharp-freebsd-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-freebsd-wasm32/-/sharp-freebsd-wasm32-0.35.3.tgz#48018c1379a8f507d681d6cd8dbe43d9795dc809"
+  integrity sha512-lUxcqWIj2wMQ9BrwNjngcr1gWUr5xgaGThBRqPPalIC2n67Cqj1uPh8NnA/ZhAg8hUbKl+kVHKwgUIwe6ZYPrg==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
 
 "@img/sharp-libvips-darwin-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz#2894c0cb87d42276c3889942e8e2db517a492c43"
   integrity sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==
 
-"@img/sharp-libvips-darwin-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz#e0456f8f7c623f9dbfbdc77383caa72281d86062"
-  integrity sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==
+"@img/sharp-libvips-darwin-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.3.2.tgz#227b41ffc6c99612bceaba56f994a1933d779573"
+  integrity sha512-9J6ypZFpQBj4YnePGoq/S38w6nz+vqg5WZLrLGY4YuSemdMq47GMLBPO42MzwdGwpg/agZ7xzZcFHa48xlywfg==
 
 "@img/sharp-libvips-darwin-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz#e63681f4539a94af9cd17246ed8881734386f8cc"
   integrity sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==
 
-"@img/sharp-libvips-linux-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz#979b1c66c9a91f7ff2893556ef267f90ebe51704"
-  integrity sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==
+"@img/sharp-libvips-darwin-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.3.2.tgz#694903ec410c00945ce5b0c26dac83d7184c8b86"
+  integrity sha512-m2pW1n6cns9VaubNwsZ+c3CRYjxNQWgJ5gPlnL1nbBcpkBvFm6SCFN5o0psFHI8w9n11NKhFkeEDns98tiqbEw==
 
 "@img/sharp-libvips-linux-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz#b1b288b36864b3bce545ad91fa6dadcf1a4ad318"
   integrity sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==
 
-"@img/sharp-libvips-linux-arm@1.0.5":
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz#99f922d4e15216ec205dcb6891b721bfd2884197"
-  integrity sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==
+"@img/sharp-libvips-linux-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.3.2.tgz#49ddf156728666a21deed0716f3bb72bb351179e"
+  integrity sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==
 
 "@img/sharp-libvips-linux-arm@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz#b9260dd1ebe6f9e3bdbcbdcac9d2ac125f35852d"
   integrity sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==
 
+"@img/sharp-libvips-linux-arm@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.3.2.tgz#e60e088c806bde1ac28be648b60c3465f41c18a7"
+  integrity sha512-1eMLzy92I4J6rmi4mAT8yC3HxOtniyGELlzGbNMLLeqe052ahFQ0h6LFq+lh5DsDIdYViIDst08abvSbcEdLXQ==
+
 "@img/sharp-libvips-linux-ppc64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz#4b83ecf2a829057222b38848c7b022e7b4d07aa7"
   integrity sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==
+
+"@img/sharp-libvips-linux-ppc64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.3.2.tgz#be3161aafd659417b3e26374dfbbcd2da2bfb62c"
+  integrity sha512-3z0NHDxD6n5I9gc05U1eW1AyRm+Gznzq3naMrthPNqE6oYykcogW0l/jfpJdjYnuNl8R7yI9pNbE1XiUeyq0Aw==
 
 "@img/sharp-libvips-linux-riscv64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz#880b4678009e5a2080af192332b00b0aaf8a48de"
   integrity sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==
 
-"@img/sharp-libvips-linux-s390x@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz#f8a5eb1f374a082f72b3f45e2fb25b8118a8a5ce"
-  integrity sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==
+"@img/sharp-libvips-linux-riscv64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.3.2.tgz#bf008a6779d9be2b56a4df67b753941f767c957d"
+  integrity sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==
 
 "@img/sharp-libvips-linux-s390x@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz#74f343c8e10fad821b38f75ced30488939dc59ec"
   integrity sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==
 
-"@img/sharp-libvips-linux-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz#d4c4619cdd157774906e15770ee119931c7ef5e0"
-  integrity sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==
+"@img/sharp-libvips-linux-s390x@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.3.2.tgz#9583814b8db58889c85bad9e5e0b7825257ff394"
+  integrity sha512-/ABshyj8gCpyIrNXnHn4LorDJ0HHm1VhXPBlxZ8zAtfVPAaSafXPGn+sUSIRiwaSBy0mmFjSjiXI5mkcwdChKQ==
 
 "@img/sharp-libvips-linux-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz#df4183e8bd8410f7d61b66859a35edeab0a531ce"
   integrity sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==
 
-"@img/sharp-libvips-linuxmusl-arm64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz#166778da0f48dd2bded1fa3033cee6b588f0d5d5"
-  integrity sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==
+"@img/sharp-libvips-linux-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.3.2.tgz#abc9a3114495b705ba20b7c1568b9eecd62aebbb"
+  integrity sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==
 
 "@img/sharp-libvips-linuxmusl-arm64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz#c8d6b48211df67137541007ee8d1b7b1f8ca8e06"
   integrity sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==
 
-"@img/sharp-libvips-linuxmusl-x64@1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz#93794e4d7720b077fcad3e02982f2f1c246751ff"
-  integrity sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==
+"@img/sharp-libvips-linuxmusl-arm64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.3.2.tgz#e58fb14a7879f15d9e70a982870f384f39a832a2"
+  integrity sha512-zE9EdiUzUmg5mDT5a1rk5fYJ6GWPloTwWBYDS14naqHsL+EaMpDj1AWnpLgh3u0YCORv2Tt50wrcrpYqkP97Kw==
 
 "@img/sharp-libvips-linuxmusl-x64@1.2.4":
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz#be11c75bee5b080cbee31a153a8779448f919f75"
   integrity sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==
 
-"@img/sharp-linux-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz#edb0697e7a8279c9fc829a60fc35644c4839bb22"
-  integrity sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==
-  optionalDependencies:
-    "@img/sharp-libvips-linux-arm64" "1.0.4"
+"@img/sharp-libvips-linuxmusl-x64@1.3.2":
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.3.2.tgz#5611480fcb7465dd5316044db53ad7a843ed4af8"
+  integrity sha512-m0lrLiUt+lBYnCFr8qV/65yMR4E/c7/wf78I5eKTdkEakFAlZ9QlzEM3QIhhAwVeUhLAHLcCq7a7Vszq/oFNZQ==
 
 "@img/sharp-linux-arm64@0.34.5":
   version "0.34.5"
@@ -1796,12 +1813,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-arm64" "1.2.4"
 
-"@img/sharp-linux-arm@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz#422c1a352e7b5832842577dc51602bcd5b6f5eff"
-  integrity sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==
+"@img/sharp-linux-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.35.3.tgz#44b65823ecc977d4585b308070fff3947256de04"
+  integrity sha512-QgKDspHPnrU+GQ55XPhGwyhC8acLVOOSyAvo1oVfFmrIXLkDNmGWzAfDZ4xK8oSA1qBQrALcHX0G5UZni/SuFQ==
   optionalDependencies:
-    "@img/sharp-libvips-linux-arm" "1.0.5"
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
 
 "@img/sharp-linux-arm@0.34.5":
   version "0.34.5"
@@ -1810,12 +1827,26 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-arm" "1.2.4"
 
+"@img/sharp-linux-arm@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-arm/-/sharp-linux-arm-0.35.3.tgz#c8da500c4016893a89d46e9832d08a06eef77f27"
+  integrity sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+
 "@img/sharp-linux-ppc64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz#9c213a81520a20caf66978f3d4c07456ff2e0813"
   integrity sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==
   optionalDependencies:
     "@img/sharp-libvips-linux-ppc64" "1.2.4"
+
+"@img/sharp-linux-ppc64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.35.3.tgz#ea1d7db818f52af1e1e057e82d55f23b2de3864c"
+  integrity sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==
+  optionalDependencies:
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
 
 "@img/sharp-linux-riscv64@0.34.5":
   version "0.34.5"
@@ -1824,12 +1855,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-riscv64" "1.2.4"
 
-"@img/sharp-linux-s390x@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz#f5c077926b48e97e4a04d004dfaf175972059667"
-  integrity sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==
+"@img/sharp-linux-riscv64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.35.3.tgz#722bd7994658791b02d1037ea09ca5cb78030d8d"
+  integrity sha512-0Eob78yjlYPfL5vMNWAW55l3R9Y6BQS/gOfe0ZcP9mEz9ohhKSt4im1hayiknXgf8AWrFqMvJcKIdmLmEe7yeQ==
   optionalDependencies:
-    "@img/sharp-libvips-linux-s390x" "1.0.4"
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
 
 "@img/sharp-linux-s390x@0.34.5":
   version "0.34.5"
@@ -1838,12 +1869,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-s390x" "1.2.4"
 
-"@img/sharp-linux-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz#d806e0afd71ae6775cc87f0da8f2d03a7c2209cb"
-  integrity sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==
+"@img/sharp-linux-s390x@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.35.3.tgz#e8294817d7da495541a4a870f56e6b5d0f8643cd"
+  integrity sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==
   optionalDependencies:
-    "@img/sharp-libvips-linux-x64" "1.0.4"
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
 
 "@img/sharp-linux-x64@0.34.5":
   version "0.34.5"
@@ -1852,12 +1883,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linux-x64" "1.2.4"
 
-"@img/sharp-linuxmusl-arm64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz#252975b915894fb315af5deea174651e208d3d6b"
-  integrity sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==
+"@img/sharp-linux-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linux-x64/-/sharp-linux-x64-0.35.3.tgz#9843c32f39aeac4b60dd60f9e3416520a4e4de46"
+  integrity sha512-8pqvxubL2PGdhlPy6GLqzDYMUjyRmKAwKHYKixpdJYBUK7PJ0C029XdsnpFIdgRZG68fZiGdHVWcKPvtiPB4cA==
   optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.4"
+    "@img/sharp-libvips-linux-x64" "1.3.2"
 
 "@img/sharp-linuxmusl-arm64@0.34.5":
   version "0.34.5"
@@ -1866,12 +1897,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
 
-"@img/sharp-linuxmusl-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz#3f4609ac5d8ef8ec7dadee80b560961a60fd4f48"
-  integrity sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==
+"@img/sharp-linuxmusl-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.35.3.tgz#9cfee4ecc3d41ab9a274e019dfe7b4062840510c"
+  integrity sha512-Vz0iQjzzcSX3HCbfwFfCSG/9SCIqyO0mH2sXyiHaAYfBk0cRsCWXRyQYX0ovCK/PAQBbTzQ0dsPQHh5MAFL59w==
   optionalDependencies:
-    "@img/sharp-libvips-linuxmusl-x64" "1.0.4"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
 
 "@img/sharp-linuxmusl-x64@0.34.5":
   version "0.34.5"
@@ -1880,12 +1911,12 @@
   optionalDependencies:
     "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
 
-"@img/sharp-wasm32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz#6f44f3283069d935bb5ca5813153572f3e6f61a1"
-  integrity sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==
-  dependencies:
-    "@emnapi/runtime" "^1.2.0"
+"@img/sharp-linuxmusl-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.35.3.tgz#204d0678c8c3b15300d9a26ecb9c0dcda11ca5de"
+  integrity sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==
+  optionalDependencies:
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
 
 "@img/sharp-wasm32@0.34.5":
   version "0.34.5"
@@ -1894,30 +1925,49 @@
   dependencies:
     "@emnapi/runtime" "^1.7.0"
 
+"@img/sharp-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-wasm32/-/sharp-wasm32-0.35.3.tgz#42f8979bdbe1a541a2e9b99d3b5be07e6b71c7c0"
+  integrity sha512-cZ0XkcYGpHZkqW6iCkqTcmUC0CD9DhD5d/qeZlZkfRBn6GnHniZXLUo5+9xw8Iv76YE6LQFN9YNBlKREcCG76w==
+  dependencies:
+    "@emnapi/runtime" "^1.11.1"
+
+"@img/sharp-webcontainers-wasm32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-webcontainers-wasm32/-/sharp-webcontainers-wasm32-0.35.3.tgz#823aaa93d14db84999d5b5dc967ff56cf1966d9f"
+  integrity sha512-2rnq7bX3NzeR2T4YWgz8qiG4h3TSdMe+vN1iQXpJleSJ3SM5zQ8Fy2SyyXAWlbxpEZ2Y+Z4u1BePgJEYbSy80Q==
+  dependencies:
+    "@img/sharp-wasm32" "0.35.3"
+
 "@img/sharp-win32-arm64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz#3706e9e3ac35fddfc1c87f94e849f1b75307ce0a"
   integrity sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==
 
-"@img/sharp-win32-ia32@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz#1a0c839a40c5351e9885628c85f2e5dfd02b52a9"
-  integrity sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==
+"@img/sharp-win32-arm64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.35.3.tgz#f3554d45cbe24532a0adea736ec57658f74a2911"
+  integrity sha512-4bPwFdMbeC4JQ8L8LOyWp6nsHcboP5fxkp6iPOXz2Vg49R42TuMs2whkJ5OAP4/Ul035qOzy0AecOF9VOscn4w==
 
 "@img/sharp-win32-ia32@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz#0b71166599b049e032f085fb9263e02f4e4788de"
   integrity sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==
 
-"@img/sharp-win32-x64@0.33.5":
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz#56f00962ff0c4e0eb93d34a047d29fa995e3e342"
-  integrity sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==
+"@img/sharp-win32-ia32@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.35.3.tgz#0942b2643bcb57e48419fe4119de84078ae0ac74"
+  integrity sha512-r53mXsBN6lFUDiST764SvgwUdHAqM4rPAiDzAmf4fLoB6X/rkfyTrLCg6+g17wJJiCmB3JYgHuUldCWUIRFSXw==
 
 "@img/sharp-win32-x64@0.34.5":
   version "0.34.5"
   resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz#a81ffb00e69267cd0a1d626eaedb8a8430b2b2f8"
   integrity sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==
+
+"@img/sharp-win32-x64@0.35.3":
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/@img/sharp-win32-x64/-/sharp-win32-x64-0.35.3.tgz#8a25cacdc75a8c26077c07fba51e8056aae474f1"
+  integrity sha512-D4y1vNeZrIIJCN+uHaWVtH86B+aCrdMYYjicy9pXHvbGZeGYLLSd3wdVuC37FxVXlU1ARsk84eKWfWMXGYEqvA==
 
 "@inquirer/ansi@^1.0.2":
   version "1.0.2"
@@ -2827,11 +2877,6 @@
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@noble/hashes/-/hashes-1.8.0.tgz#cee43d801fcef9644b11b8194857695acd5f815a"
   integrity sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==
-
-"@nodable/entities@^2.2.0":
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
-  integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
 
 "@nodable/entities@^3.0.0":
   version "3.0.0"
@@ -6244,7 +6289,7 @@ ansis@4.2.0:
   resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.2.0.tgz#2e6e61c46b11726ac67f78785385618b9e658780"
   integrity sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==
 
-ansis@^4.2.0:
+ansis@^4.3.1:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.3.1.tgz#2815c1ef490adaf0d612ae3a699e90cbcf70a917"
   integrity sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==
@@ -6657,6 +6702,11 @@ balanced-match@^1.0.0:
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
+
 bare-events@^2.7.0:
   version "2.8.2"
   resolved "https://registry.yarnpkg.com/bare-events/-/bare-events-2.8.2.tgz#7b3e10bd8e1fc80daf38bb516921678f566ab89f"
@@ -6791,13 +6841,27 @@ boxen@^5.0.0:
     widest-line "^3.1.0"
     wrap-ansi "^7.0.0"
 
-brace-expansion@^1.1.13, brace-expansion@^1.1.7, brace-expansion@^2.0.1, brace-expansion@^2.0.2, brace-expansion@^5.0.5:
+brace-expansion@^1.1.7:
   version "1.1.16"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.16.tgz#723d3a30c0558c225abc9fc479a73e14e26c3c2f"
   integrity sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==
   dependencies:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
+
+brace-expansion@^2.0.1, brace-expansion@^2.0.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.1.3.tgz#1bf69aacdf6a4380ca17c284d9f928d4aa6401bc"
+  integrity sha512-DRdx5neNsG/QXbniLFWi2YmC/68oeOOmKz6zOjVk6ZS1ZLXgLIKqVEc6hWsmkjBbgii0SwaBTcJ5XKj5gzY/4A==
+  dependencies:
+    balanced-match "^1.0.0"
+
+brace-expansion@^5.0.5:
+  version "5.0.8"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.8.tgz#135ad0d8d808eb18eb5e0ec9a21f3a0b92ef18cf"
+  integrity sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==
+  dependencies:
+    balanced-match "^4.0.2"
 
 braces@^3.0.3, braces@~3.0.2:
   version "3.0.3"
@@ -7308,23 +7372,15 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@~1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
-  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
-
 color-name@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-2.1.0.tgz#0b677385c1c4b4edfdeaf77e38fa338e3a40b693"
   integrity sha512-1bPaDNFm0axzE4MEAzKPuqKWeRaT43U/hyxKPBdqTfmPF+d6n7FSoTFxLVULUJOmiLp01KjhIPPH+HrXZJN4Rg==
 
-color-string@^1.9.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/color-string/-/color-string-1.9.1.tgz#4467f9146f036f855b764dfb5bf8582bf342c7a4"
-  integrity sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==
-  dependencies:
-    color-name "^1.0.0"
-    simple-swizzle "^0.2.2"
+color-name@~1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
+  integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
 color-string@^2.1.3:
   version "2.1.4"
@@ -7332,14 +7388,6 @@ color-string@^2.1.3:
   integrity sha512-Bb6Cq8oq0IjDOe8wJmi4JeNn763Xs9cfrBcaylK1tPypWzyoy2G3l90v9k64kjphl/ZJjPIShFztenRomi8WTg==
   dependencies:
     color-name "^2.0.0"
-
-color@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/color/-/color-4.2.3.tgz#d781ecb5e57224ee43ea9627560107c0e0c6463a"
-  integrity sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==
-  dependencies:
-    color-convert "^2.0.1"
-    color-string "^1.9.0"
 
 color@^5.0.2:
   version "5.0.3"
@@ -7882,7 +7930,7 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-dayjs@^1.11.20:
+dayjs@^1.11.21:
   version "1.11.21"
   resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
   integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
@@ -8034,7 +8082,7 @@ destroy@1.2.0, destroy@^1.0.4, destroy@~1.2.0:
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
   integrity sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==
 
-detect-libc@^2.0.3, detect-libc@^2.1.2:
+detect-libc@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/detect-libc/-/detect-libc-2.1.2.tgz#689c5dcdc1900ef5583a4cb9f6d7b473742074ad"
   integrity sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==
@@ -10655,11 +10703,6 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==
 
-is-arrayish@^0.3.1:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.3.4.tgz#1ee5553818511915685d33bb13d31bf854e5059d"
-  integrity sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==
-
 is-async-function@^2.0.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-async-function/-/is-async-function-2.1.1.tgz#3e69018c8e04e73b738793d020bfe884b9fd3523"
@@ -10959,11 +11002,6 @@ is-unicode-supported@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
-
-is-unsafe@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-1.0.1.tgz#ce89b55dec0034364f5beda41e10481efa8fa317"
-  integrity sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==
 
 is-unsafe@^2.0.0:
   version "2.0.0"
@@ -14981,10 +15019,15 @@ semver@^6.0.0, semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.6.3, semver@^7.7.1, semver@^7.7.3:
+semver@^7.0.0, semver@^7.1.1, semver@^7.3.5, semver@^7.3.7, semver@^7.3.8, semver@^7.5.2, semver@^7.5.3, semver@^7.5.4, semver@^7.6.0, semver@^7.7.1, semver@^7.7.3:
   version "7.7.3"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.3.tgz#4b5f4143d007633a8dc671cd0a6ef9147b8bb946"
   integrity sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==
+
+semver@^7.8.5:
+  version "7.8.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.8.5.tgz#39b646037dd50c14fb451e7e4cac58ed8b863f69"
+  integrity sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==
 
 send@0.19.0:
   version "0.19.0"
@@ -15133,42 +15176,41 @@ shapefile@~0.6.6:
     stream-source "0.3"
     text-encoding "^0.6.4"
 
-sharp@^0.35.0:
-  version "0.35.3"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz"
-  integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
-  dependencies:
-    "@img/colour" "^1.1.0"
-    detect-libc "^2.1.2"
-    semver "^7.8.5"
-  optionalDependencies:
-    "@img/sharp-darwin-arm64" "0.35.3"
-    "@img/sharp-darwin-x64" "0.35.3"
-    "@img/sharp-freebsd-wasm32" "0.35.3"
-    "@img/sharp-libvips-darwin-arm64" "1.3.2"
-    "@img/sharp-libvips-darwin-x64" "1.3.2"
-    "@img/sharp-libvips-linux-arm" "1.3.2"
-    "@img/sharp-libvips-linux-arm64" "1.3.2"
-    "@img/sharp-libvips-linux-ppc64" "1.3.2"
-    "@img/sharp-libvips-linux-riscv64" "1.3.2"
-    "@img/sharp-libvips-linux-s390x" "1.3.2"
-    "@img/sharp-libvips-linux-x64" "1.3.2"
-    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
-    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
-    "@img/sharp-linux-arm" "0.35.3"
-    "@img/sharp-linux-arm64" "0.35.3"
-    "@img/sharp-linux-ppc64" "0.35.3"
-    "@img/sharp-linux-riscv64" "0.35.3"
-    "@img/sharp-linux-s390x" "0.35.3"
-    "@img/sharp-linux-x64" "0.35.3"
-    "@img/sharp-linuxmusl-arm64" "0.35.3"
-    "@img/sharp-linuxmusl-x64" "0.35.3"
-    "@img/sharp-webcontainers-wasm32" "0.35.3"
-    "@img/sharp-win32-arm64" "0.35.3"
-    "@img/sharp-win32-ia32" "0.35.3"
-    "@img/sharp-win32-x64" "0.35.3"
-
 sharp@^0.34.5:
+  version "0.34.5"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.34.5.tgz#b6f148e4b8c61f1797bde11a9d1cfebbae2c57b0"
+  integrity sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==
+  dependencies:
+    "@img/colour" "^1.0.0"
+    detect-libc "^2.1.2"
+    semver "^7.7.3"
+  optionalDependencies:
+    "@img/sharp-darwin-arm64" "0.34.5"
+    "@img/sharp-darwin-x64" "0.34.5"
+    "@img/sharp-libvips-darwin-arm64" "1.2.4"
+    "@img/sharp-libvips-darwin-x64" "1.2.4"
+    "@img/sharp-libvips-linux-arm" "1.2.4"
+    "@img/sharp-libvips-linux-arm64" "1.2.4"
+    "@img/sharp-libvips-linux-ppc64" "1.2.4"
+    "@img/sharp-libvips-linux-riscv64" "1.2.4"
+    "@img/sharp-libvips-linux-s390x" "1.2.4"
+    "@img/sharp-libvips-linux-x64" "1.2.4"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
+    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
+    "@img/sharp-linux-arm" "0.34.5"
+    "@img/sharp-linux-arm64" "0.34.5"
+    "@img/sharp-linux-ppc64" "0.34.5"
+    "@img/sharp-linux-riscv64" "0.34.5"
+    "@img/sharp-linux-s390x" "0.34.5"
+    "@img/sharp-linux-x64" "0.34.5"
+    "@img/sharp-linuxmusl-arm64" "0.34.5"
+    "@img/sharp-linuxmusl-x64" "0.34.5"
+    "@img/sharp-wasm32" "0.34.5"
+    "@img/sharp-win32-arm64" "0.34.5"
+    "@img/sharp-win32-ia32" "0.34.5"
+    "@img/sharp-win32-x64" "0.34.5"
+
+sharp@^0.35.0:
   version "0.35.3"
   resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz"
   integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
@@ -15288,13 +15330,6 @@ signal-exit@^4.0.1, signal-exit@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-4.1.0.tgz#952188c1cbd546070e2dd20d0f41c0ae0530cb04"
   integrity sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==
-
-simple-swizzle@^0.2.2:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/simple-swizzle/-/simple-swizzle-0.2.4.tgz#a8d11a45a11600d6a1ecdff6363329e3648c3667"
-  integrity sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==
-  dependencies:
-    is-arrayish "^0.3.1"
 
 simple-update-notifier@^2.0.0:
   version "2.0.0"
@@ -17500,6 +17535,19 @@ yargs@^17.3.1, yargs@^17.7.2:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
+  dependencies:
+    cliui "^8.0.1"
+    escalade "^3.1.1"
+    get-caller-file "^2.0.5"
+    require-directory "^2.1.1"
+    string-width "^4.2.3"
+    y18n "^5.0.5"
+    yargs-parser "^21.1.1"
+
+yargs@^17.7.3:
+  version "17.7.3"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.3.tgz#779dffe6bcafec596a7172e983289a588647faaa"
+  integrity sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==
   dependencies:
     cliui "^8.0.1"
     escalade "^3.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1599,29 +1599,13 @@
   dependencies:
     crypto-js "^4.2.0"
 
-"@grpc/grpc-js@^1.10.9":
+"@grpc/grpc-js@^1.10.9", "@grpc/grpc-js@^1.12.6", "@grpc/grpc-js@^1.14.4", "@grpc/grpc-js@~1.9.0":
   version "1.14.4"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#56ec0eb4354228e174c3bc4eec31c0439bd1828e"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#e73ff57d97802f063999545f43ebb2b1eca65d9d"
   integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
   dependencies:
     "@grpc/proto-loader" "^0.8.0"
     "@js-sdsl/ordered-map" "^4.4.2"
-
-"@grpc/grpc-js@^1.12.6":
-  version "1.14.4"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#56ec0eb4354228e174c3bc4eec31c0439bd1828e"
-  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
-  dependencies:
-    "@grpc/proto-loader" "^0.8.0"
-    "@js-sdsl/ordered-map" "^4.4.2"
-
-"@grpc/grpc-js@~1.9.0":
-  version "1.9.16"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.16.tgz#43f68f7f1667ce28fcae1e3b712d8755c1a9e4f6"
-  integrity sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.8"
-    "@types/node" ">=12.12.47"
 
 "@grpc/proto-loader@^0.7.13", "@grpc/proto-loader@^0.7.8":
   version "0.7.15"
@@ -5515,7 +5499,7 @@
   dependencies:
     "@types/express" "*"
 
-"@types/node@*", "@types/node@>=12.12.47", "@types/node@>=13.7.0":
+"@types/node@*", "@types/node@>=13.7.0":
   version "24.10.1"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.10.1.tgz#91e92182c93db8bd6224fca031e2370cef9a8f01"
   integrity sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==
@@ -6377,10 +6361,10 @@ ansis@4.2.0:
   resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.2.0.tgz#2e6e61c46b11726ac67f78785385618b9e658780"
   integrity sha512-HqZ5rWlFjGiV0tDm3UxxgNRqsOTniqoKZu0pIAfh7TZQMGuZK+hH0drySty0si0QXj1ieop4+SkSfPZBPPkHig==
 
-ansis@^3.17.0:
-  version "3.17.0"
-  resolved "https://registry.yarnpkg.com/ansis/-/ansis-3.17.0.tgz#fa8d9c2a93fe7d1177e0c17f9eeb562a58a832d7"
-  integrity sha512-0qWUglt9JEqLFr3w1I1pbrChn1grhaiAR2ocX1PP/flRmxgtwTzPFFFnfIlD6aMOLQZgSuCRlidD70lvx8yhzg==
+ansis@^4.2.0:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/ansis/-/ansis-4.3.1.tgz#2815c1ef490adaf0d612ae3a699e90cbcf70a917"
+  integrity sha512-BJ8/l4R5LRE7hW9WdSuGYrLSHi2ynxeFpDFbH0K/CgNeY/tyhk+vO6TYxXC5r5CpUhNVX310xzPsN/H9lCdfOA==
 
 any-promise@^1.0.0:
   version "1.3.0"
@@ -7487,7 +7471,7 @@ colors@1.4.0, colors@^1.1.2:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.4.0.tgz#c50491479d4c1bdaed2c9ced32cf7c7dc2360f78"
   integrity sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
 
-combined-stream@^1.0.6, combined-stream@^1.0.8, combined-stream@~1.0.6:
+combined-stream@^1.0.8, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
   integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
@@ -8010,10 +7994,10 @@ date-fns@^2.30.0:
   dependencies:
     "@babel/runtime" "^7.21.0"
 
-dayjs@^1.11.13:
-  version "1.11.19"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.19.tgz#15dc98e854bb43917f12021806af897c58ae2938"
-  integrity sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==
+dayjs@^1.11.20:
+  version "1.11.21"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.11.21.tgz#57f87562e62de76f3c704bd2b8d522fc33068eb2"
+  integrity sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA==
 
 debug@2.6.9:
   version "2.6.9"
@@ -8065,10 +8049,15 @@ decode-uri-component@^0.2.2:
   resolved "https://registry.yarnpkg.com/decode-uri-component/-/decode-uri-component-0.2.2.tgz#e69dbe25d37941171dd540e024c444cd5188e1e9"
   integrity sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==
 
-dedent@^1.0.0, dedent@^1.6.0:
+dedent@^1.0.0:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.0.tgz#c1f9445335f0175a96587be245a282ff451446ca"
   integrity sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==
+
+dedent@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.7.2.tgz#34e2264ab538301e27cf7b07bf2369c19baa8dd9"
+  integrity sha512-WzMx3mW98SN+zn3hgemf4OzdmyNhhhKz5Ay0pUfQiMQ3e1g+xmTJWp/pKdwKVXhdSkAEGIIzqeuWrL3mV/AXbA==
 
 deep-eql@^5.0.1:
   version "5.0.2"
@@ -8289,7 +8278,7 @@ dotenv-expand@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv-expand/-/dotenv-expand-10.0.0.tgz#12605d00fb0af6d0a592e6558585784032e4ef37"
   integrity sha512-GopVGCpVS1UKH75VKHGuQFqS1Gusej0z4FyQkPdwjil2gNIv+LNsqBlboOzpJFZKVT95GkCyWJbBSdFEFUWI2A==
 
-dotenv@^16.3.0, dotenv@^16.4.7:
+dotenv@^16.3.0, dotenv@^16.6.1:
   version "16.6.1"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.6.1.tgz#773f0e69527a8315c7285d5ee73c4459d20a8020"
   integrity sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==
@@ -9697,37 +9686,16 @@ fork-ts-checker-webpack-plugin@9.1.0:
     semver "^7.3.5"
     tapable "^2.2.1"
 
-form-data@^2.5.5:
-  version "2.5.6"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#7497ef5d7f151ace7f4a3af9151751a8f69a1088"
-  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    hasown "^2.0.4"
-    mime-types "^2.1.35"
-    safe-buffer "^5.2.1"
-
-form-data@^4.0.0, form-data@^4.0.1, form-data@^4.0.5:
+form-data@^2.5.5, form-data@^4.0.0, form-data@^4.0.1, form-data@^4.0.5, form-data@^4.0.6, form-data@~2.3.2:
   version "4.0.6"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#8ec9ec662255ea3f41de044c918d845af8b118e6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#28e864e1b786dbebb68db1f452f9635278665827"
   integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
     hasown "^2.0.4"
-    mime-types "^2.1.12"
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
+    mime-types "^2.1.35"
 
 formdata-polyfill@^4.0.10:
   version "4.0.10"
@@ -10112,7 +10080,7 @@ glob@7.1.6:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.7, glob@^10.4.5, glob@^10.5.0:
+glob@^10.0.0, glob@^10.2.2, glob@^10.3.10, glob@^10.3.7, glob@^10.5.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -10394,6 +10362,13 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
+hasown@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.4.tgz#8c62d8cb90beb2aad5d0a5b67581ad9854c3f003"
+  integrity sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==
+  dependencies:
+    function-bind "^1.1.2"
+
 hast-util-to-jsx-runtime@^2.0.0:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz#ff31897aae59f62232e21594eac7ef6b63333e98"
@@ -10449,10 +10424,10 @@ hono@^4.11.4:
   resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
   integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
 
-hono@^4.12.21, hono@^4.12.25:
+hono@^4.12.25:
   version "4.12.25"
   resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.25.tgz#d03e3ca93fb18bece23ff9292978295adf8f0bf2"
-  integrity sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==
+  integrity "sha1-8tmZalToycDF9d4cjzqWLkOpjE4= sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="
 
 hosted-git-info@^7.0.0:
   version "7.0.2"
@@ -12814,7 +12789,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.0.8, mime-types@^2.1.12, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.0.8, mime-types@^2.1.27, mime-types@^2.1.35, mime-types@~2.1.19, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -13049,10 +13024,10 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multer@2.1.1, multer@^2.1.1, multer@^2.2.0:
+multer@2.1.1, multer@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/multer/-/multer-2.2.0.tgz#eecbf76977ef08f876cb6cc9690d13c9c49d8319"
-  integrity sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==
+  integrity "sha1-8AUmjKgWMkunM147SBZolqP6XXk= sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ=="
   dependencies:
     append-field "^1.0.0"
     busboy "^1.6.0"
@@ -14136,10 +14111,10 @@ proto3-json-serializer@^3.0.0:
   dependencies:
     protobufjs "^7.4.0"
 
-protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.5.5, protobufjs@^7.6.3:
+protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.6.3:
   version "7.6.3"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.3.tgz#f72fd9ec707e2c53f4f5d3f5f26e327f450e6704"
-  integrity sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==
+  integrity "sha1-ksyIBtthOT5o9qLrdCwdnAyv1nI= sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw=="
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -15598,7 +15573,7 @@ sql-formatter@^15.3.0:
     argparse "^2.0.1"
     nearley "^2.20.1"
 
-sql-highlight@^6.0.0:
+sql-highlight@^6.1.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/sql-highlight/-/sql-highlight-6.1.0.tgz#e34024b4c6eac2744648771edfe3c1f894153743"
   integrity sha512-ed7OK4e9ywpE7pgRMkMQmZDPKSVdm0oX5IEtZiKnFucSF0zu6c80GZBe38UqHuVhTWJ9xsKgSMjCG2bml86KvA==
@@ -16750,10 +16725,10 @@ typeorm-seeding@^1.6.1:
     reflect-metadata "0.1.13"
     yargs "15.3.1"
 
-typeorm@^0.3.20, typeorm@^0.3.29:
+typeorm@^0.3.29:
   version "0.3.29"
   resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.29.tgz#ecf913d7dc031c0bf34ec7f191e59eafabc16543"
-  integrity sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==
+  integrity "sha1-gR4n7i50vCaYZtV92rKHQL+oXI8= sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ=="
   dependencies:
     "@sqltools/formatter" "^1.2.5"
     ansis "^4.2.0"
@@ -16764,6 +16739,7 @@ typeorm@^0.3.20, typeorm@^0.3.29:
     dedent "^1.7.2"
     dotenv "^16.6.1"
     glob "^10.5.0"
+    reflect-metadata "^0.2.2"
     sha.js "^2.4.12"
     sql-highlight "^6.1.0"
     tslib "^2.8.1"
@@ -17026,7 +17002,7 @@ utils-merge@1.0.1, utils-merge@^1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
 
-uuid@^11.0.2, uuid@^11.1.0, uuid@^11.1.1, uuid@^3.3.2, uuid@^8.0.0, uuid@^8.3.2, uuid@^9.0.0, uuid@^9.0.1:
+uuid@^11.0.2, uuid@^11.1.1, uuid@^3.3.2, uuid@^8.0.0, uuid@^8.3.2, uuid@^9.0.0, uuid@^9.0.1:
   version "11.1.1"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.1.1.tgz#f6d81d2e1c65d00762e5e29b16c5d2d995e208ad"
   integrity sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -3006,11 +3006,6 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
   integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
-"@protobufjs/inquire@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.2.tgz#ae64fbc014ff44c8bfad03dd4c93cd2d6a4c82db"
-  integrity sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==
-
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
@@ -10425,9 +10420,9 @@ hono@^4.11.4:
   integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
 
 hono@^4.12.25:
-  version "4.12.25"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.25.tgz#d03e3ca93fb18bece23ff9292978295adf8f0bf2"
-  integrity "sha1-8tmZalToycDF9d4cjzqWLkOpjE4= sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ=="
+  version "4.12.28"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.28.tgz#c2e12c32027f0e9fb8b0cef2ecfb73050c2ca62e"
+  integrity sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==
 
 hosted-git-info@^7.0.0:
   version "7.0.2"
@@ -13026,8 +13021,8 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
 
 multer@2.1.1, multer@^2.2.0:
   version "2.2.0"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-2.2.0.tgz#eecbf76977ef08f876cb6cc9690d13c9c49d8319"
-  integrity "sha1-8AUmjKgWMkunM147SBZolqP6XXk= sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ=="
+  resolved "https://registry.yarnpkg.com/multer/-/multer-2.2.0.tgz#f005268ca816324ba7335e3b48166896a3fa5d79"
+  integrity sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==
   dependencies:
     append-field "^1.0.0"
     busboy "^1.6.0"
@@ -14112,9 +14107,9 @@ proto3-json-serializer@^3.0.0:
     protobufjs "^7.4.0"
 
 protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.6.3:
-  version "7.6.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.3.tgz#f72fd9ec707e2c53f4f5d3f5f26e327f450e6704"
-  integrity "sha1-ksyIBtthOT5o9qLrdCwdnAyv1nI= sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw=="
+  version "7.6.5"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.5.tgz#7b9250cdaf4a06139a9f0fe468a40d7d4febca71"
+  integrity sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -14122,7 +14117,6 @@ protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, prot
     "@protobufjs/eventemitter" "^1.1.1"
     "@protobufjs/fetch" "^1.1.1"
     "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.2"
     "@protobufjs/path" "^1.1.2"
     "@protobufjs/pool" "^1.1.0"
     "@protobufjs/utf8" "^1.1.1"
@@ -16726,9 +16720,9 @@ typeorm-seeding@^1.6.1:
     yargs "15.3.1"
 
 typeorm@^0.3.29:
-  version "0.3.29"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.29.tgz#ecf913d7dc031c0bf34ec7f191e59eafabc16543"
-  integrity "sha1-gR4n7i50vCaYZtV92rKHQL+oXI8= sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ=="
+  version "0.3.30"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.30.tgz#79721a6de089b187b93b2dcd5c542847f07ac8b2"
+  integrity sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==
   dependencies:
     "@sqltools/formatter" "^1.2.5"
     ansis "^4.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -15602,7 +15602,7 @@ string-natural-compare@^3.0.1:
   resolved "https://registry.yarnpkg.com/string-natural-compare/-/string-natural-compare-3.0.1.tgz#7a42d58474454963759e8e8b7ae63d71c1e7fdf4"
   integrity sha512-n3sPwynL1nwKi3WJ6AIsClwBMa0zTi54fn2oLU6ndfTSIO05xaznjSf15PcBZU6FNWbmN5Q6cxT4V5hGvB4taw==
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -15618,15 +15618,6 @@ string-width@^2.1.0, string-width@^2.1.1:
   dependencies:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
-
-string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -15736,7 +15727,7 @@ stringify-entities@^4.0.0:
     character-entities-html4 "^2.0.0"
     character-entities-legacy "^3.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -15756,13 +15747,6 @@ strip-ansi@^5.1.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.2"
@@ -17107,10 +17091,10 @@ webpack@5.106.0:
     watchpack "^2.5.1"
     webpack-sources "^3.3.4"
 
-websocket-driver@>=0.5.1:
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
-  integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==
+websocket-driver@>=0.5.1, websocket-driver@^0.7.5:
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.5.tgz#569d22764ab21f2de20af0e74b411e8ae5a0fa46"
+  integrity sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==
   dependencies:
     http-parser-js ">=0.5.1"
     safe-buffer ">=5.1.0"
@@ -17304,7 +17288,7 @@ wrangler@^4.59.1:
   optionalDependencies:
     fsevents "~2.3.2"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -17317,15 +17301,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1659,10 +1659,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz#4a2868d75d6d6963e423bcf90b7fd1be343409d3"
   integrity sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==
 
-"@img/colour@^1.0.0":
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.0.0.tgz#d2fabb223455a793bf3bf9c70de3d28526aa8311"
-  integrity sha512-A5P/LfWGFSl6nsckYtjw9da+19jB8hkJ6ACTGcDfEJ0aE+l2n2El7dsVM7UVHZQ9s2lmYMWlrS21YLy2IR1LUw==
+"@img/colour@^1.0.0", "@img/colour@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@img/colour/-/colour-1.1.0.tgz"
+  integrity sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==
 
 "@img/sharp-darwin-arm64@0.33.5":
   version "0.33.5"
@@ -2832,6 +2832,11 @@
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-2.2.0.tgz#a1d45a992b022591b1c2b03a77935c939375b642"
   integrity sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==
+
+"@nodable/entities@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@nodable/entities/-/entities-3.0.0.tgz"
+  integrity sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -9196,17 +9201,17 @@ fast-xml-builder@^1.2.0:
     path-expression-matcher "^1.5.0"
     xml-naming "^0.1.0"
 
-fast-xml-parser@^4.2.2, fast-xml-parser@^4.4.1, fast-xml-parser@^5.7.0:
-  version "5.9.3"
-  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz#9db7a6dba7ac6f8dc1ee924d69547b2d4750d60c"
-  integrity sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==
+fast-xml-parser@^4.2.2, fast-xml-parser@^4.4.1, fast-xml-parser@^5.10.1:
+  version "5.10.1"
+  resolved "https://registry.yarnpkg.com/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz"
+  integrity sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==
   dependencies:
-    "@nodable/entities" "^2.2.0"
+    "@nodable/entities" "^3.0.0"
     fast-xml-builder "^1.2.0"
-    is-unsafe "^1.0.1"
-    path-expression-matcher "^1.5.0"
+    is-unsafe "^2.0.0"
+    path-expression-matcher "^1.6.2"
     strnum "^2.4.1"
-    xml-naming "^0.1.0"
+    xml-naming "^0.3.0"
 
 fastq@^1.6.0:
   version "1.19.1"
@@ -10959,6 +10964,11 @@ is-unsafe@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-1.0.1.tgz#ce89b55dec0034364f5beda41e10481efa8fa317"
   integrity sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==
+
+is-unsafe@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/is-unsafe/-/is-unsafe-2.0.0.tgz"
+  integrity sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==
 
 is-url@^1.2.2, is-url@^1.2.4:
   version "1.2.4"
@@ -13595,7 +13605,7 @@ path-exists@^4.0.0:
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-4.0.0.tgz#513bdbe2d3b95d7762e8c1137efa195c6c61b5b3"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
 
-path-expression-matcher@^1.5.0:
+path-expression-matcher@^1.5.0, path-expression-matcher@^1.6.2:
   version "1.6.2"
   resolved "https://registry.yarnpkg.com/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz#567c73c07197e9dcef24e90edcdc571056599168"
   integrity sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==
@@ -14316,12 +14326,12 @@ react-refresh@^0.18.0:
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.18.0.tgz#2dce97f4fe932a4d8142fa1630e475c1729c8062"
   integrity sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==
 
-react-router-dom@^7.15.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.17.0.tgz#e77527b4b7862f7b47ff26dd5b9315fb897b82a7"
-  integrity sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==
+react-router-dom@^7.18.1:
+  version "7.18.1"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-7.18.1.tgz"
+  integrity sha512-KaZh+X/6UtEp28x51AUYZDMg9NGoz2ja3dNHa+ta/tk40vCzKhQ/RypCWBMLbmDr6//E24Vv5uPsrqXFozdkAg==
   dependencies:
-    react-router "7.17.0"
+    react-router "7.18.1"
 
 react-router-hash-link@^2.4.3:
   version "2.4.3"
@@ -14330,10 +14340,10 @@ react-router-hash-link@^2.4.3:
   dependencies:
     prop-types "^15.7.2"
 
-react-router@7.17.0:
-  version "7.17.0"
-  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.17.0.tgz#88bbe817c6e37ab36faf140623b5d4678bf81e41"
-  integrity sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==
+react-router@7.18.1:
+  version "7.18.1"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-7.18.1.tgz"
+  integrity sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==
   dependencies:
     cookie "^1.0.1"
     set-cookie-parser "^2.6.0"
@@ -15123,68 +15133,75 @@ shapefile@~0.6.6:
     stream-source "0.3"
     text-encoding "^0.6.4"
 
-sharp@^0.33.5:
-  version "0.33.5"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.33.5.tgz#13e0e4130cc309d6a9497596715240b2ec0c594e"
-  integrity sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==
+sharp@^0.35.0:
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz"
+  integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
   dependencies:
-    color "^4.2.3"
-    detect-libc "^2.0.3"
-    semver "^7.6.3"
+    "@img/colour" "^1.1.0"
+    detect-libc "^2.1.2"
+    semver "^7.8.5"
   optionalDependencies:
-    "@img/sharp-darwin-arm64" "0.33.5"
-    "@img/sharp-darwin-x64" "0.33.5"
-    "@img/sharp-libvips-darwin-arm64" "1.0.4"
-    "@img/sharp-libvips-darwin-x64" "1.0.4"
-    "@img/sharp-libvips-linux-arm" "1.0.5"
-    "@img/sharp-libvips-linux-arm64" "1.0.4"
-    "@img/sharp-libvips-linux-s390x" "1.0.4"
-    "@img/sharp-libvips-linux-x64" "1.0.4"
-    "@img/sharp-libvips-linuxmusl-arm64" "1.0.4"
-    "@img/sharp-libvips-linuxmusl-x64" "1.0.4"
-    "@img/sharp-linux-arm" "0.33.5"
-    "@img/sharp-linux-arm64" "0.33.5"
-    "@img/sharp-linux-s390x" "0.33.5"
-    "@img/sharp-linux-x64" "0.33.5"
-    "@img/sharp-linuxmusl-arm64" "0.33.5"
-    "@img/sharp-linuxmusl-x64" "0.33.5"
-    "@img/sharp-wasm32" "0.33.5"
-    "@img/sharp-win32-ia32" "0.33.5"
-    "@img/sharp-win32-x64" "0.33.5"
+    "@img/sharp-darwin-arm64" "0.35.3"
+    "@img/sharp-darwin-x64" "0.35.3"
+    "@img/sharp-freebsd-wasm32" "0.35.3"
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+    "@img/sharp-libvips-linux-x64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
+    "@img/sharp-linux-arm" "0.35.3"
+    "@img/sharp-linux-arm64" "0.35.3"
+    "@img/sharp-linux-ppc64" "0.35.3"
+    "@img/sharp-linux-riscv64" "0.35.3"
+    "@img/sharp-linux-s390x" "0.35.3"
+    "@img/sharp-linux-x64" "0.35.3"
+    "@img/sharp-linuxmusl-arm64" "0.35.3"
+    "@img/sharp-linuxmusl-x64" "0.35.3"
+    "@img/sharp-webcontainers-wasm32" "0.35.3"
+    "@img/sharp-win32-arm64" "0.35.3"
+    "@img/sharp-win32-ia32" "0.35.3"
+    "@img/sharp-win32-x64" "0.35.3"
 
 sharp@^0.34.5:
-  version "0.34.5"
-  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.34.5.tgz#b6f148e4b8c61f1797bde11a9d1cfebbae2c57b0"
-  integrity sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==
+  version "0.35.3"
+  resolved "https://registry.yarnpkg.com/sharp/-/sharp-0.35.3.tgz"
+  integrity sha512-ej0zVHuZGHCiABXcNxeYhpRnPNPAcvbG8RMdBAhDAxLKkCRVSpK3Iyu7qbqw3JMzoj0REeM6f3tJLtVwl0023Q==
   dependencies:
-    "@img/colour" "^1.0.0"
+    "@img/colour" "^1.1.0"
     detect-libc "^2.1.2"
-    semver "^7.7.3"
+    semver "^7.8.5"
   optionalDependencies:
-    "@img/sharp-darwin-arm64" "0.34.5"
-    "@img/sharp-darwin-x64" "0.34.5"
-    "@img/sharp-libvips-darwin-arm64" "1.2.4"
-    "@img/sharp-libvips-darwin-x64" "1.2.4"
-    "@img/sharp-libvips-linux-arm" "1.2.4"
-    "@img/sharp-libvips-linux-arm64" "1.2.4"
-    "@img/sharp-libvips-linux-ppc64" "1.2.4"
-    "@img/sharp-libvips-linux-riscv64" "1.2.4"
-    "@img/sharp-libvips-linux-s390x" "1.2.4"
-    "@img/sharp-libvips-linux-x64" "1.2.4"
-    "@img/sharp-libvips-linuxmusl-arm64" "1.2.4"
-    "@img/sharp-libvips-linuxmusl-x64" "1.2.4"
-    "@img/sharp-linux-arm" "0.34.5"
-    "@img/sharp-linux-arm64" "0.34.5"
-    "@img/sharp-linux-ppc64" "0.34.5"
-    "@img/sharp-linux-riscv64" "0.34.5"
-    "@img/sharp-linux-s390x" "0.34.5"
-    "@img/sharp-linux-x64" "0.34.5"
-    "@img/sharp-linuxmusl-arm64" "0.34.5"
-    "@img/sharp-linuxmusl-x64" "0.34.5"
-    "@img/sharp-wasm32" "0.34.5"
-    "@img/sharp-win32-arm64" "0.34.5"
-    "@img/sharp-win32-ia32" "0.34.5"
-    "@img/sharp-win32-x64" "0.34.5"
+    "@img/sharp-darwin-arm64" "0.35.3"
+    "@img/sharp-darwin-x64" "0.35.3"
+    "@img/sharp-freebsd-wasm32" "0.35.3"
+    "@img/sharp-libvips-darwin-arm64" "1.3.2"
+    "@img/sharp-libvips-darwin-x64" "1.3.2"
+    "@img/sharp-libvips-linux-arm" "1.3.2"
+    "@img/sharp-libvips-linux-arm64" "1.3.2"
+    "@img/sharp-libvips-linux-ppc64" "1.3.2"
+    "@img/sharp-libvips-linux-riscv64" "1.3.2"
+    "@img/sharp-libvips-linux-s390x" "1.3.2"
+    "@img/sharp-libvips-linux-x64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-arm64" "1.3.2"
+    "@img/sharp-libvips-linuxmusl-x64" "1.3.2"
+    "@img/sharp-linux-arm" "0.35.3"
+    "@img/sharp-linux-arm64" "0.35.3"
+    "@img/sharp-linux-ppc64" "0.35.3"
+    "@img/sharp-linux-riscv64" "0.35.3"
+    "@img/sharp-linux-s390x" "0.35.3"
+    "@img/sharp-linux-x64" "0.35.3"
+    "@img/sharp-linuxmusl-arm64" "0.35.3"
+    "@img/sharp-linuxmusl-x64" "0.35.3"
+    "@img/sharp-webcontainers-wasm32" "0.35.3"
+    "@img/sharp-win32-arm64" "0.35.3"
+    "@img/sharp-win32-ia32" "0.35.3"
+    "@img/sharp-win32-x64" "0.35.3"
 
 shebang-command@^2.0.0:
   version "2.0.0"
@@ -16585,16 +16602,16 @@ typeorm-seeding@^1.6.1:
     reflect-metadata "0.1.13"
     yargs "15.3.1"
 
-typeorm@^0.3.29:
-  version "0.3.30"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.30.tgz#79721a6de089b187b93b2dcd5c542847f07ac8b2"
-  integrity sha512-8T35PzjefOdqc2ZR9mwLQj0pUGp6lQhMbK2EvVMwJVJWlaoHm0v/Q6dThNOZkFchD+0yMg8gwjKM28ePiLSXSQ==
+typeorm@^0.3.31:
+  version "0.3.31"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.31.tgz"
+  integrity sha512-6u9EFtdLBgHjnPm78NStVeM+I/1MolTzKykDDcydzKUkh6E++YS6XViU/fePJbvDvEGU4Xq34KOM/CLeer9I2A==
   dependencies:
     "@sqltools/formatter" "^1.2.5"
-    ansis "^4.2.0"
+    ansis "^4.3.1"
     app-root-path "^3.1.0"
     buffer "^6.0.3"
-    dayjs "^1.11.20"
+    dayjs "^1.11.21"
     debug "^4.4.3"
     dedent "^1.7.2"
     dotenv "^16.6.1"
@@ -16604,7 +16621,7 @@ typeorm@^0.3.29:
     sql-highlight "^6.1.0"
     tslib "^2.8.1"
     uuid "^11.1.1"
-    yargs "^17.7.2"
+    yargs "^17.7.3"
 
 typescript@5.9.3, typescript@^5.7.3:
   version "5.9.3"
@@ -17380,6 +17397,11 @@ xml-naming@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.1.0.tgz#8ab7106c5b8d23caa2fabac1cadf17136379fbd8"
   integrity sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==
+
+xml-naming@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/xml-naming/-/xml-naming-0.3.0.tgz"
+  integrity sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==
 
 xml-utils@^1.0.2:
   version "1.10.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1600,25 +1600,25 @@
     crypto-js "^4.2.0"
 
 "@grpc/grpc-js@^1.10.9":
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.1.tgz#b2d1c83e6dbd0dfbfacc01c7b7009dec2526318d"
-  integrity sha512-sPxgEWtPUR3EnRJCEtbGZG2iX8LQDUls2wUS3o27jg07KqJFMq6YDeWvMo1wfpmy3rqRdS0rivpLwhqQtEyCuQ==
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#56ec0eb4354228e174c3bc4eec31c0439bd1828e"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
   dependencies:
     "@grpc/proto-loader" "^0.8.0"
     "@js-sdsl/ordered-map" "^4.4.2"
 
 "@grpc/grpc-js@^1.12.6":
-  version "1.14.3"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.3.tgz#4c9b817a900ae4020ddc28515ae4b52c78cfb8da"
-  integrity sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==
+  version "1.14.4"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.4.tgz#56ec0eb4354228e174c3bc4eec31c0439bd1828e"
+  integrity sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==
   dependencies:
     "@grpc/proto-loader" "^0.8.0"
     "@js-sdsl/ordered-map" "^4.4.2"
 
 "@grpc/grpc-js@~1.9.0":
-  version "1.9.15"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.15.tgz#433d7ac19b1754af690ea650ab72190bd700739b"
-  integrity sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==
+  version "1.9.16"
+  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.9.16.tgz#43f68f7f1667ce28fcae1e3b712d8755c1a9e4f6"
+  integrity sha512-wE4Ut/olIzfKqp631XrG+wbF0v1vWFN4YL9FyXC2LJiG33DsV7PLzURjrCvY/6je2ntdRkeLpPDluzSRGaVltQ==
   dependencies:
     "@grpc/proto-loader" "^0.7.8"
     "@types/node" ">=12.12.47"
@@ -9698,26 +9698,26 @@ fork-ts-checker-webpack-plugin@9.1.0:
     tapable "^2.2.1"
 
 form-data@^2.5.5:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.5.tgz#a5f6364ad7e4e67e95b4a07e2d8c6f711c74f624"
-  integrity sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==
+  version "2.5.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.6.tgz#7497ef5d7f151ace7f4a3af9151751a8f69a1088"
+  integrity sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.35"
     safe-buffer "^5.2.1"
 
 form-data@^4.0.0, form-data@^4.0.1, form-data@^4.0.5:
-  version "4.0.5"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.5.tgz#b49e48858045ff4cbf6b03e1805cebcad3679053"
-  integrity sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==
+  version "4.0.6"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.6.tgz#8ec9ec662255ea3f41de044c918d845af8b118e6"
+  integrity sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     es-set-tostringtag "^2.1.0"
-    hasown "^2.0.2"
+    hasown "^2.0.4"
     mime-types "^2.1.12"
 
 form-data@~2.3.2:
@@ -10449,10 +10449,10 @@ hono@^4.11.4:
   resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.14.tgz#4777c9512b7c84138e4f09e61e3d2fa305eb1414"
   integrity sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==
 
-hono@^4.12.21:
-  version "4.12.23"
-  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.23.tgz#998b91651686149f0e6edbb8564d604da04f3cf8"
-  integrity sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==
+hono@^4.12.21, hono@^4.12.25:
+  version "4.12.25"
+  resolved "https://registry.yarnpkg.com/hono/-/hono-4.12.25.tgz#d03e3ca93fb18bece23ff9292978295adf8f0bf2"
+  integrity sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==
 
 hosted-git-info@^7.0.0:
   version "7.0.2"
@@ -13049,10 +13049,10 @@ ms@2.1.3, ms@^2.0.0, ms@^2.1.1, ms@^2.1.3:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.3.tgz#574c8138ce1d2b5861f0b44579dbadd60c6615b2"
   integrity sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
 
-multer@2.1.1, multer@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/multer/-/multer-2.1.1.tgz#122d819244fbdfee1efddd9147426691014385b7"
-  integrity sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==
+multer@2.1.1, multer@^2.1.1, multer@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/multer/-/multer-2.2.0.tgz#eecbf76977ef08f876cb6cc9690d13c9c49d8319"
+  integrity sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==
   dependencies:
     append-field "^1.0.0"
     busboy "^1.6.0"
@@ -14136,10 +14136,10 @@ proto3-json-serializer@^3.0.0:
   dependencies:
     protobufjs "^7.4.0"
 
-protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.5.5:
-  version "7.6.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.2.tgz#2659f77bd8d54778814c274dc0df808f54c88918"
-  integrity sha512-N9EiLovGEQOJSPF26Ij7qUGvahfEnq0eeYZ02aigIedkmz1qZSwjnP9SBITHJuF/6MYbIW4HDN8zdYjsjqJKXQ==
+protobufjs@^7.2.2, protobufjs@^7.2.5, protobufjs@^7.2.6, protobufjs@^7.3.2, protobufjs@^7.4.0, protobufjs@^7.5.3, protobufjs@^7.5.5, protobufjs@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.6.3.tgz#f72fd9ec707e2c53f4f5d3f5f26e327f450e6704"
+  integrity sha512-+k0vdJKNdW+Vu+dYe8tZA/VvQb6XKNWexC6URwBFXxNnjLJz9nQJCemGyNgRAWD+B7+nGNc9qMPGwcD7s4nzUw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -16750,24 +16750,24 @@ typeorm-seeding@^1.6.1:
     reflect-metadata "0.1.13"
     yargs "15.3.1"
 
-typeorm@^0.3.20:
-  version "0.3.27"
-  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.27.tgz#f1e8f3cdc820225f168e901e7e1eaca3a3ec6f3c"
-  integrity sha512-pNV1bn+1n8qEe8tUNsNdD8ejuPcMAg47u2lUGnbsajiNUr3p2Js1XLKQjBMH0yMRMDfdX8T+fIRejFmIwy9x4A==
+typeorm@^0.3.20, typeorm@^0.3.29:
+  version "0.3.29"
+  resolved "https://registry.yarnpkg.com/typeorm/-/typeorm-0.3.29.tgz#ecf913d7dc031c0bf34ec7f191e59eafabc16543"
+  integrity sha512-wwPEX/df4l72gCmOsrs0otJZYLGA9lLQkUZCkukbsymEycV4zXv2KM7wU7v2r8L01TaCgY9ApSSqHQWBOUhEoQ==
   dependencies:
     "@sqltools/formatter" "^1.2.5"
-    ansis "^3.17.0"
+    ansis "^4.2.0"
     app-root-path "^3.1.0"
     buffer "^6.0.3"
-    dayjs "^1.11.13"
-    debug "^4.4.0"
-    dedent "^1.6.0"
-    dotenv "^16.4.7"
-    glob "^10.4.5"
+    dayjs "^1.11.20"
+    debug "^4.4.3"
+    dedent "^1.7.2"
+    dotenv "^16.6.1"
+    glob "^10.5.0"
     sha.js "^2.4.12"
-    sql-highlight "^6.0.0"
+    sql-highlight "^6.1.0"
     tslib "^2.8.1"
-    uuid "^11.1.0"
+    uuid "^11.1.1"
     yargs "^17.7.2"
 
 typescript@5.9.3, typescript@^5.7.3:


### PR DESCRIPTION
Replaces wave data source with Open-Meteo Marine API. Wind stays on Sofar/GFS (Phase 2).

Sofar's wave model was snapping ~937 sites to land cells and hitting rate limits across ~6,000 sites/hour, leaving ~2,193 sites with no wave data. Open-Meteo's cell_selection=sea + batched multi-coordinate requests (100 sites/call) fixes both.
Changes:

- New SourceType.OPEN_METEO enum + migration (enum-add only, no data rewrite — avoids a transient mislabeling bug found in testing)
- hindcast-wind-wave.ts: wave now fetched via batched Open-Meteo calls; wind untouched; original getForecastData preserved for generate-stormglass-csv.ts compat
- Dashboard card: fixed hardcoded SOFAR MODEL badge → separate WIND/WAVE badges linking to correct sources (was silently mislabeling wave-sourced data as wind data in the non-Spotter case)

Follow-up (not in this PR): ~40% of sites (2,523/6,368) have wind data older than 3 days (29 completely missing). This can be added in a second PR.

Note: the Security Audit CI check is currently failing on master too (confirmed independently). Seems to be a pre-existing vulnerability in firebase-admin/multer/hono/typeorm/axios transitive deps, unrelated to this PR's changes. Not something I've touched or can safely fix here.

UPDATE:
One thing I couldn't finish myself due to permissions: I purchased the Open-Meteo $29/mo paid tier, and added OPEN_METEO_API_KEY to .env + functionsConfig.ts. But pushing it to Firebase's remote config for aqualink-programize needs yarn config:cloud-functions:programize run from packages/api, and I'm hitting a 403 (missing serviceusage.serviceUsageConsumer on that project, even as Owner). Could you run that command, or grant whatever role's missing? The key is sent via Slack.