### PR TITLE
feat: browse historical map data by date

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -5,6 +5,7 @@ import {
   IsInt,
   IsEnum,
   IsBooleanString,
+  IsISO8601,
 } from 'class-validator';
 import { Type } from 'class-transformer';
 import { ApiProperty } from '@nestjs/swagger';
@@ -37,4 +38,14 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({
+    example: '2025-08-15',
+    required: false,
+    description:
+      'Return the latest available daily map data on or before this date',
+  })
+  @IsOptional()
+  @IsISO8601({ strict: true })
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getHistoricalCollectionData,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -198,10 +201,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mappedSiteData = filter.date
+      ? await getHistoricalCollectionData(
+          res,
+          this.dailyDataRepository,
+          new Date(`${filter.date}T23:59:59.999Z`),
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/sites/sites.spec.ts
+++ b/packages/api/src/sites/sites.spec.ts
@@ -99,6 +99,30 @@ export const siteTests = () => {
     siteId = sortedSites[sortedSites.length - 1].id;
   });
 
+  it('GET / returns the latest daily snapshot at a historical date', async () => {
+    const historicalDate = DateTime.fromISO(
+      String(californiaDailyData[2].date),
+    ).toISODate();
+
+    const rsp = await request(app.getHttpServer())
+      .get('/sites')
+      .query({ date: historicalDate });
+
+    expect(rsp.status).toBe(200);
+    const california = rsp.body.find(
+      (site: { name: string }) => site.name === californiaSite.name,
+    );
+
+    expect(california.collectionData).toMatchObject({
+      dhw: expect.closeTo(
+        Number(californiaDailyData[2].degreeHeatingDays) / 7,
+        5,
+      ),
+      satelliteTemperature: californiaDailyData[2].satelliteTemperature,
+      tempAlert: californiaDailyData[2].dailyAlertLevel,
+    });
+  });
+
   it('GET /:id retrieve one site', async () => {
     const rsp = await request(app.getHttpServer()).get(`/sites/${siteId}`);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -87,26 +87,24 @@ export const getHistoricalCollectionData = async (
     }
   });
 
-  return Array.from(snapshots.entries()).reduce<Record<number, CollectionDataDto>>(
-    (result, [siteId, row]) => {
-      result[siteId] = {
-        ...(row.degreeHeatingDays == null
-          ? {}
-          : { dhw: row.degreeHeatingDays / 7 }),
-        ...(row.satelliteTemperature == null
-          ? {}
-          : { satelliteTemperature: row.satelliteTemperature }),
-        ...(row.dailyAlertLevel == null
-          ? {}
-          : { tempAlert: row.dailyAlertLevel }),
-        ...(row.weeklyAlertLevel == null
-          ? {}
-          : { tempWeeklyAlert: row.weeklyAlertLevel }),
-      };
-      return result;
-    },
-    {},
-  );
+  const collectionData: Record<number, CollectionDataDto> = {};
+  for (const [siteId, row] of snapshots) {
+    collectionData[siteId] = {
+      ...(row.degreeHeatingDays == null
+        ? {}
+        : { dhw: row.degreeHeatingDays / 7 }),
+      ...(row.satelliteTemperature == null
+        ? {}
+        : { satelliteTemperature: row.satelliteTemperature }),
+      ...(row.dailyAlertLevel == null
+        ? {}
+        : { tempAlert: row.dailyAlertLevel }),
+      ...(row.weeklyAlertLevel == null
+        ? {}
+        : { tempWeeklyAlert: row.weeklyAlertLevel }),
+    };
+  }
+  return collectionData;
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -87,24 +87,25 @@ export const getHistoricalCollectionData = async (
     }
   });
 
-  const collectionData: Record<number, CollectionDataDto> = {};
-  for (const [siteId, row] of snapshots) {
-    collectionData[siteId] = {
-      ...(row.degreeHeatingDays == null
-        ? {}
-        : { dhw: row.degreeHeatingDays / 7 }),
-      ...(row.satelliteTemperature == null
-        ? {}
-        : { satelliteTemperature: row.satelliteTemperature }),
-      ...(row.dailyAlertLevel == null
-        ? {}
-        : { tempAlert: row.dailyAlertLevel }),
-      ...(row.weeklyAlertLevel == null
-        ? {}
-        : { tempWeeklyAlert: row.weeklyAlertLevel }),
-    };
-  }
-  return collectionData;
+  return Object.fromEntries(
+    Array.from(snapshots.entries()).map(([siteId, row]) => [
+      siteId,
+      {
+        ...(row.degreeHeatingDays == null
+          ? {}
+          : { dhw: row.degreeHeatingDays / 7 }),
+        ...(row.satelliteTemperature == null
+          ? {}
+          : { satelliteTemperature: row.satelliteTemperature }),
+        ...(row.dailyAlertLevel == null
+          ? {}
+          : { tempAlert: row.dailyAlertLevel }),
+        ...(row.weeklyAlertLevel == null
+          ? {}
+          : { tempWeeklyAlert: row.weeklyAlertLevel }),
+      },
+    ]),
+  ) as Record<number, CollectionDataDto>;
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -5,6 +5,7 @@ import { CollectionDataDto } from '../collections/dto/collection-data.dto';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
+import { DailyData } from '../sites/daily-data.entity';
 
 export const getCollectionData = async (
   sites: Site[],
@@ -43,6 +44,69 @@ export const getCollectionData = async (
       ),
     )
     .toJSON();
+};
+
+/**
+ * Build the map summary from the latest daily snapshot at or before a date.
+ * Daily data is the historical source of truth for the map's heat-stress
+ * indicators; latest_data only represents the current snapshot.
+ */
+export const getHistoricalCollectionData = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: Date,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  const dailyData = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .select('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.degree_heating_days', 'degreeHeatingDays')
+    .addSelect('daily_data.satellite_temperature', 'satelliteTemperature')
+    .addSelect('daily_data.daily_alert_level', 'dailyAlertLevel')
+    .addSelect('daily_data.weekly_alert_level', 'weeklyAlertLevel')
+    .where('daily_data.site_id IN (:...siteIds)', { siteIds })
+    .andWhere('daily_data.date <= :date', { date })
+    .orderBy('daily_data.date', 'DESC')
+    .getRawMany<{
+      siteId: number;
+      degreeHeatingDays: number | null;
+      satelliteTemperature: number | null;
+      dailyAlertLevel: number | null;
+      weeklyAlertLevel: number | null;
+    }>();
+
+  const snapshots = new Map<number, (typeof dailyData)[number]>();
+  dailyData.forEach((row) => {
+    if (!snapshots.has(Number(row.siteId))) {
+      snapshots.set(Number(row.siteId), row);
+    }
+  });
+
+  return Array.from(snapshots.entries()).reduce<Record<number, CollectionDataDto>>(
+    (result, [siteId, row]) => {
+      result[siteId] = {
+        ...(row.degreeHeatingDays == null
+          ? {}
+          : { dhw: row.degreeHeatingDays / 7 }),
+        ...(row.satelliteTemperature == null
+          ? {}
+          : { satelliteTemperature: row.satelliteTemperature }),
+        ...(row.dailyAlertLevel == null
+          ? {}
+          : { tempAlert: row.dailyAlertLevel }),
+        ...(row.weeklyAlertLevel == null
+          ? {}
+          : { tempWeeklyAlert: row.weeklyAlertLevel }),
+      };
+      return result;
+    },
+    {},
+  );
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/website/src/common/Datepicker/index.tsx
+++ b/packages/website/src/common/Datepicker/index.tsx
@@ -34,7 +34,7 @@ function DatePicker({
                 .toJSDate()}
               minDate={DateTime.fromMillis(0).toJSDate()}
               closeOnSelect={autoOk}
-              value={parseISO(value ?? '')}
+              value={value ? parseISO(value) : null}
               onChange={(v) => onChange(v)}
               slotProps={{
                 textField: {

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -31,6 +31,7 @@ import {
 import { CollectionDetails } from 'store/Collection/types';
 import { MapLayerName } from 'store/Homepage/types';
 import { mapConstants } from 'constants/maps';
+import DatePicker from 'common/Datepicker';
 import FullscreenIcon from '@mui/icons-material/Fullscreen';
 import FullscreenExitIcon from '@mui/icons-material/FullscreenExit';
 import InfoIcon from '@mui/icons-material/Info';
@@ -40,7 +41,6 @@ import { SofarLayers } from './sofarLayers';
 import { InfoDialog } from './InfoDialog';
 import Legend from './Legend';
 import AlertLevelLegend from './alertLevelLegend';
-import DatePicker from 'common/Datepicker';
 
 const accessToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 

--- a/packages/website/src/routes/HomeMap/Map/index.tsx
+++ b/packages/website/src/routes/HomeMap/Map/index.tsx
@@ -40,6 +40,7 @@ import { SofarLayers } from './sofarLayers';
 import { InfoDialog } from './InfoDialog';
 import Legend from './Legend';
 import AlertLevelLegend from './alertLevelLegend';
+import DatePicker from 'common/Datepicker';
 
 const accessToken = process.env.REACT_APP_MAPBOX_ACCESS_TOKEN;
 
@@ -91,6 +92,8 @@ function HomepageMap({
   legendLeft,
   classes,
   onMapLoad,
+  historicalDate,
+  onHistoricalDateChange,
 }: HomepageMapProps) {
   const [infoDialogOpen, setInfoDialogOpen] = useState(false);
   const [legendName, setLegendName] = useState<string>(defaultLayerName || '');
@@ -280,6 +283,21 @@ function HomepageMap({
         handleInfoClose={handleInfoClose}
       />
       {tileLayer}
+      {onHistoricalDateChange && (
+        <div
+          className={classes.historicalDatePicker}
+          onClick={(event) => event.stopPropagation()}
+          role="presentation"
+        >
+          <DatePicker
+            value={historicalDate || null}
+            dateName="Map date"
+            dateNameTextVariant="caption"
+            timeZone="UTC"
+            onChange={onHistoricalDateChange}
+          />
+        </div>
+      )}
       {sofarLayers}
       {siteMarkers}
       {currentLocation && (
@@ -358,6 +376,16 @@ const styles = (theme: Theme) =>
         top: 50,
       },
     },
+    historicalDatePicker: {
+      position: 'absolute',
+      left: 10,
+      top: 10,
+      zIndex: 1000,
+      padding: '8px 12px',
+      borderRadius: 4,
+      backgroundColor: 'white',
+      boxShadow: '0 1px 5px rgba(0, 0, 0, 0.35)',
+    },
     expandIcon: {
       fontSize: '34px',
     },
@@ -385,6 +413,8 @@ interface HomepageMapIncomingProps {
   legendBottom?: number;
   legendLeft?: number;
   onMapLoad?: (map: L.Map) => void;
+  historicalDate?: string | null;
+  onHistoricalDateChange?: (date: Date | null) => void;
 }
 
 type HomepageMapProps = WithStyles<typeof styles> & HomepageMapIncomingProps;

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -21,12 +21,14 @@ import HomepageMap from './Map';
 enum QueryParamKeys {
   SITE_ID = 'site_id',
   ZOOM_LEVEL = 'zoom',
+  DATE = 'date',
 }
 
 interface MapQueryParams {
   initialCenter: LatLng;
   initialZoom: number;
   initialSiteId: string | undefined;
+  initialDate: string | null;
 }
 
 const INITIAL_CENTER = new LatLng(0, 121.3);
@@ -44,6 +46,7 @@ function useQuery() {
       findSiteById(sitesList, featuredSiteId)?.id.toString() ||
       ''
     : featuredSiteId;
+  const initialDate = urlParams.get(QueryParamKeys.DATE);
 
   // Focus on the site provided in the queryParamSiteId or the site with highest alert level.
   // const initialCenter =
@@ -59,6 +62,7 @@ function useQuery() {
     initialCenter,
     initialSiteId,
     initialZoom,
+    initialDate,
   };
 }
 
@@ -68,12 +72,38 @@ function Homepage({ classes }: HomepageProps) {
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
-  const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
+  const { initialZoom, initialSiteId, initialCenter, initialDate }: MapQueryParams =
     useQuery();
+  const [historicalDate, setHistoricalDate] = useState<string | null>(
+    initialDate,
+  );
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(initialDate ? { date: initialDate } : undefined));
+  }, [dispatch, initialDate]);
+
+  const handleHistoricalDateChange = (date: Date | null) => {
+    const nextDate = date
+      ? `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(
+          2,
+          '0',
+        )}-${String(date.getDate()).padStart(2, '0')}`
+      : null;
+
+    setHistoricalDate(nextDate);
+    const params = new URLSearchParams(window.location.search);
+    if (nextDate) {
+      params.set(QueryParamKeys.DATE, nextDate);
+    } else {
+      params.delete(QueryParamKeys.DATE);
+    }
+    window.history.replaceState(
+      null,
+      '',
+      `${window.location.pathname}${params.toString() ? `?${params}` : ''}`,
+    );
+    dispatch(sitesRequest(nextDate ? { date: nextDate } : undefined));
+  };
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -124,6 +154,8 @@ function Homepage({ classes }: HomepageProps) {
               showSiteTable={showSiteTable}
               initialZoom={initialZoom}
               initialCenter={initialCenter}
+              historicalDate={historicalDate}
+              onHistoricalDateChange={handleHistoricalDateChange}
             />
           </Grid>
           {showSiteTable && (

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -72,8 +72,12 @@ function Homepage({ classes }: HomepageProps) {
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
 
-  const { initialZoom, initialSiteId, initialCenter, initialDate }: MapQueryParams =
-    useQuery();
+  const {
+    initialZoom,
+    initialSiteId,
+    initialCenter,
+    initialDate,
+  }: MapQueryParams = useQuery();
   const [historicalDate, setHistoricalDate] = useState<string | null>(
     initialDate,
   );

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${encodeURIComponent(date)}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -30,18 +30,24 @@ import { readFiltersFromUrl, writeFiltersToUrl } from './helpers';
 const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
+  date: null,
   filters: {},
 };
 
+export interface SitesRequestParams {
+  date?: string | null;
+}
+
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  SitesRequestParams | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
   async (arg, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const date = arg?.date || undefined;
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -49,17 +55,18 @@ export const sitesRequest = createAsyncThunk<
       }));
       return {
         list: transformedData,
+        date: date || null,
       };
     } catch (err) {
       return rejectWithValue(getAxiosErrorMessage(err));
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: SitesRequestParams | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, date },
       } = getState();
-      return !list;
+      return !list || (arg?.date || null) !== (date || null);
     },
   },
 );
@@ -108,6 +115,7 @@ const sitesListSlice = createSlice({
       (state, action: PayloadAction<SitesRequestData>) => ({
         ...state,
         list: action.payload.list,
+        date: action.payload.date,
         loading: false,
       }),
     );

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -397,10 +397,12 @@ export type SiteUploadHistory = DataUploadsSites[];
 
 export interface SitesRequestData {
   list: Site[];
+  date: string | null;
 }
 
 export interface SitesListState {
   list?: Site[];
+  date: string | null;
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;


### PR DESCRIPTION
## Summary
- add a date query to retrieve the latest available daily map snapshot on or before that date
- add a URL-persisted map date picker for historical browsing
- add API coverage for historical daily data and keep the latest-data path unchanged

## Validation
- git diff --check
- TypeScript transpile validation for all 10 changed TS/TSX files
- Full Yarn tests/build could not run locally because the workspace has no installed dependencies or package manager

Resolves #1162