### PR TITLE
New Grok model added

### DIFF
--- a/packages/api/src/utils/aiGrokService.ts
+++ b/packages/api/src/utils/aiGrokService.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { buildPromptWithContext, PromptMap } from './prompts';
 
 const GROK_API_URL = 'https://api.x.ai/v1/chat/completions';
-const GROK_MODEL = 'grok-4.6'; // Fast and cost-effective
+const GROK_MODEL = 'grok-4.6';
 
 interface GrokMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';
@@ -209,7 +209,7 @@ async function callGrokRaw(
         temperature: 0.1,
         max_tokens: 2500, // Accommodate reasoning + output
         stream: false,
-        reasoning_effort: 'low',
+        reasoning_effort: 'low', // Low effort for faster responses
         ...toolParams,
       },
       {

--- a/packages/api/src/utils/aiGrokService.ts
+++ b/packages/api/src/utils/aiGrokService.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 import { buildPromptWithContext, PromptMap } from './prompts';
 
 const GROK_API_URL = 'https://api.x.ai/v1/chat/completions';
-const GROK_MODEL = 'grok-4-fast-reasoning'; // Fast and cost-effective
+const GROK_MODEL = 'grok-4.6'; // Fast and cost-effective
 
 interface GrokMessage {
   role: 'system' | 'user' | 'assistant' | 'tool';

--- a/packages/api/src/utils/aiGrokService.ts
+++ b/packages/api/src/utils/aiGrokService.ts
@@ -209,6 +209,7 @@ async function callGrokRaw(
         temperature: 0.1,
         max_tokens: 2500, // Accommodate reasoning + output
         stream: false,
+        reasoning_effort: 'low',
         ...toolParams,
       },
       {


### PR DESCRIPTION
Updated the Grok model to a new model. Added `reasoning_effort: 'low',` for faster response time. Now we're matching production with a 5-7 second response time for greetings and short questions. Grok 4.6 has a default effort level of High, but responses took between 20 and 25 seconds, which I think is way too long, especially for the greeting message. 