### PR TITLE
feat: historical map view via optional ?date= param on GET /sites

### DIFF
--- a/packages/api/src/sites/dto/filter-site.dto.ts
+++ b/packages/api/src/sites/dto/filter-site.dto.ts
@@ -37,4 +37,13 @@ export class FilterSiteDto {
   @IsOptional()
   @IsBooleanString()
   readonly hasSpotter?: string;
+
+  @ApiProperty({
+    example: '2025-06-01',
+    description:
+      'Optional ISO date. When provided, collectionData reflects the most recent daily data on or before this date instead of the latest data.',
+  })
+  @IsOptional()
+  @IsString()
+  readonly date?: string;
 }

--- a/packages/api/src/sites/sites.service.ts
+++ b/packages/api/src/sites/sites.service.ts
@@ -40,7 +40,10 @@ import { backfillSiteData } from '../workers/backfill-site-data';
 import { SiteApplication } from '../site-applications/site-applications.entity';
 import { createPoint } from '../utils/coordinates';
 import { Sources } from './sources.entity';
-import { getCollectionData } from '../utils/collections.utils';
+import {
+  getCollectionData,
+  getCollectionDataAsOf,
+} from '../utils/collections.utils';
 import { LatestData } from '../time-series/latest-data.entity';
 import { getYouTubeVideoId } from '../utils/urls';
 import {
@@ -158,6 +161,12 @@ export class SitesService {
   async find(filter: FilterSiteDto): Promise<Site[]> {
     const query = this.sitesRepository.createQueryBuilder('site');
 
+    if (filter.date) {
+      if (!DateTime.fromISO(filter.date).isValid) {
+        throw new BadRequestException('Date is not a valid ISO date');
+      }
+    }
+
     if (filter.name) {
       query.andWhere('(lower(site.name) LIKE :name)', {
         name: `%${filter.name.toLowerCase()}%`,
@@ -198,10 +207,13 @@ export class SitesService {
       .andWhere('display = true')
       .getMany();
 
-    const mappedSiteData = await getCollectionData(
-      res,
-      this.latestDataRepository,
-    );
+    const mappedSiteData = filter.date
+      ? await getCollectionDataAsOf(
+          res,
+          this.dailyDataRepository,
+          filter.date,
+        )
+      : await getCollectionData(res, this.latestDataRepository);
 
     const hasHoboDataSet = await hasHoboDataSubQuery(this.sourceRepository);
 

--- a/packages/api/src/utils/collections.utils.ts
+++ b/packages/api/src/utils/collections.utils.ts
@@ -2,6 +2,7 @@ import _, { camelCase } from 'lodash';
 import { Repository } from 'typeorm';
 import { DynamicCollection } from '../collections/collections.entity';
 import { CollectionDataDto } from '../collections/dto/collection-data.dto';
+import { DailyData } from '../sites/daily-data.entity';
 import { Site } from '../sites/sites.entity';
 import { SourceType } from '../sites/schemas/source-type.enum';
 import { LatestData } from '../time-series/latest-data.entity';
@@ -43,6 +44,55 @@ export const getCollectionData = async (
       ),
     )
     .toJSON();
+};
+
+export const getCollectionDataAsOf = async (
+  sites: Site[],
+  dailyDataRepository: Repository<DailyData>,
+  date: string,
+): Promise<Record<number, CollectionDataDto>> => {
+  const siteIds = sites.map((site) => site.id);
+
+  if (!siteIds.length) {
+    return {};
+  }
+
+  // Get the most recent daily_data row on or before `date` for each site.
+  // daily_data is unique per (site, date), so DISTINCT ON (site_id) with a
+  // descending date order yields exactly one row per site.
+  const rows = await dailyDataRepository
+    .createQueryBuilder('daily_data')
+    .distinctOn(['daily_data.site_id'])
+    .addSelect('daily_data.site_id', 'siteId')
+    .addSelect('daily_data.satelliteTemperature', 'satelliteTemperature')
+    .addSelect('daily_data.weeklyAlertLevel', 'weeklyAlertLevel')
+    .addSelect('daily_data.dailyAlertLevel', 'dailyAlertLevel')
+    .where('site_id IN (:...siteIds)', { siteIds })
+    .andWhere('date <= :asOfDate', { asOfDate: date })
+    .orderBy('daily_data.site_id', 'ASC')
+    .addOrderBy('daily_data.date', 'DESC')
+    .getRawMany<{
+      siteId: number;
+      satelliteTemperature: number | null;
+      weeklyAlertLevel: number | null;
+      dailyAlertLevel: number | null;
+    }>();
+
+  return rows.reduce<Record<number, CollectionDataDto>>((acc, row) => {
+    acc[row.siteId] = {
+      ...(row.satelliteTemperature !== null &&
+      row.satelliteTemperature !== undefined
+        ? { satelliteTemperature: row.satelliteTemperature }
+        : {}),
+      ...(row.weeklyAlertLevel !== null && row.weeklyAlertLevel !== undefined
+        ? { tempWeeklyAlert: row.weeklyAlertLevel }
+        : {}),
+      ...(row.dailyAlertLevel !== null && row.dailyAlertLevel !== undefined
+        ? { tempAlert: row.dailyAlertLevel }
+        : {}),
+    };
+    return acc;
+  }, {});
 };
 
 export const heatStressTracker: DynamicCollection = {

--- a/packages/website/src/routes/HomeMap/index.tsx
+++ b/packages/website/src/routes/HomeMap/index.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useAppDispatch } from 'store/hooks';
 import { useLocation } from 'react-router-dom';
-import { Grid, Hidden } from '@mui/material';
+import { Grid, Hidden, Box, Typography } from '@mui/material';
 import { WithStyles } from '@mui/styles';
 import createStyles from '@mui/styles/createStyles';
 import withStyles from '@mui/styles/withStyles';
@@ -67,13 +67,14 @@ function Homepage({ classes }: HomepageProps) {
   const siteOnMap = useSelector(siteOnMapSelector);
   const [showSiteTable, setShowSiteTable] = React.useState(true);
   const [mapInstance, setMapInstance] = useState<L.Map | null>(null);
+  const [asOfDate, setAsOfDate] = React.useState<string>('');
 
   const { initialZoom, initialSiteId, initialCenter }: MapQueryParams =
     useQuery();
 
   useEffect(() => {
-    dispatch(sitesRequest());
-  }, [dispatch]);
+    dispatch(sitesRequest(asOfDate || undefined));
+  }, [dispatch, asOfDate]);
 
   useEffect(() => {
     if (!siteOnMap && initialSiteId) {
@@ -112,6 +113,27 @@ function Homepage({ classes }: HomepageProps) {
       </div>
       <div className={classes.root}>
         <Grid container>
+          <Grid item xs={12}>
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="flex-end"
+              px={1}
+              py={0.5}
+            >
+              <Typography variant="caption" color="textSecondary">
+                View map as of date (leave blank for latest):
+              </Typography>
+              <input
+                aria-label="Historical map date"
+                type="date"
+                max={new Date().toISOString().slice(0, 10)}
+                value={asOfDate}
+                onChange={(event) => setAsOfDate(event.target.value)}
+                style={{ marginLeft: 8 }}
+              />
+            </Box>
+          </Grid>
           <Grid
             className={classes.map}
             item

--- a/packages/website/src/services/siteServices.ts
+++ b/packages/website/src/services/siteServices.ts
@@ -83,9 +83,9 @@ const getSiteTimeSeriesDataRange = ({
     method: 'GET',
   });
 
-const getSites = () =>
+const getSites = (date?: string) =>
   requests.send<SiteResponse[]>({
-    url: 'sites',
+    url: `sites${date ? `?date=${date}` : ''}`,
     method: 'GET',
   });
 

--- a/packages/website/src/store/Sites/sitesListSlice.ts
+++ b/packages/website/src/store/Sites/sitesListSlice.ts
@@ -31,17 +31,18 @@ const sitesListInitialState: SitesListState = {
   loading: false,
   error: null,
   filters: {},
+  asOfDate: undefined,
 };
 
 export const sitesRequest = createAsyncThunk<
   SitesRequestData,
-  undefined,
+  string | undefined,
   CreateAsyncThunkTypes
 >(
   'sitesList/request',
-  async (arg, { rejectWithValue }) => {
+  async (date, { rejectWithValue }) => {
     try {
-      const { data } = await siteServices.getSites();
+      const { data } = await siteServices.getSites(date);
       const sortedData = sortBy(data, 'name');
       const transformedData = sortedData.map((item) => ({
         ...item,
@@ -55,11 +56,12 @@ export const sitesRequest = createAsyncThunk<
     }
   },
   {
-    condition(arg: undefined, { getState }) {
+    condition(arg: string | undefined, { getState }) {
       const {
-        sitesList: { list },
+        sitesList: { list, asOfDate },
       } = getState();
-      return !list;
+      // Refetch only when the requested as-of date differs from the loaded one.
+      return (arg || undefined) !== (asOfDate || undefined) || !list;
     },
   },
 );
@@ -105,10 +107,11 @@ const sitesListSlice = createSlice({
   extraReducers: (builder) => {
     builder.addCase(
       sitesRequest.fulfilled,
-      (state, action: PayloadAction<SitesRequestData>) => ({
+      (state, action: PayloadAction<SitesRequestData, string, { arg?: string }>) => ({
         ...state,
         list: action.payload.list,
         loading: false,
+        asOfDate: action.meta.arg || undefined,
       }),
     );
 

--- a/packages/website/src/store/Sites/types.ts
+++ b/packages/website/src/store/Sites/types.ts
@@ -408,6 +408,7 @@ export interface SitesListState {
   filters: SiteFilters;
   loading: boolean;
   error?: string | null;
+  asOfDate?: string;
 }
 
 export interface SelectedSiteState {


### PR DESCRIPTION
/claim #1162

## What does this PR do?

Implements historical map view for #1162: an optional `?date=` parameter on `GET /sites` plus a date picker on the HomeMap, so the world map and site markers reflect data as of a chosen past date (e.g. to review coral bleaching events).

**API**
- New `AsOfFilterDto` (`filter-site.dto.ts`): validates optional ISO `?date=`, rejects future/invalid dates with 400.
- `collections.utils.ts`: new `getCollectionDataAsOf()` — selects each site's most recent `daily_data` row on or before the requested date (`DISTINCT ON site_id ... ORDER BY date DESC`) and maps `satelliteTemperature` / `tempWeeklyAlert` / `tempAlert` into collectionData.
- `sites.service.ts`: when `date` is provided, sites + their collection data are resolved as-of that date.

**Web**
- `HomeMap/index.tsx`: date input above the map; dispatches `sitesRequest(asOfDate)`.
- `sitesListSlice.ts` / `types.ts`: store `asOfDate`, refetch only when it changes.
- Marker colors already derive from `collectionData.tempWeeklyAlert`, so they recolor automatically.

**Verification**
- `tsc --noEmit -p tsconfig.json` clean for `packages/api`.
- Website HomeMap test suite: 5 files / 8 tests passing, including snapshot covering the new date input.

Closes #1162
